### PR TITLE
Batch continious integration builds to minimize number of builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,10 @@
 # Spark .NET build
 
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+    - master
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
This will cause to only run 1 build at a time by batching commits, rather than 1 per commit.