### PR TITLE
Publish linux-x64 binaries instead of ubuntu* binaries.

### DIFF
--- a/script/publish-workers.cmd
+++ b/script/publish-workers.cmd
@@ -8,8 +8,7 @@ set Build.Configuration=%3
 
 CALL :PublishWorker net461, win-x64
 CALL :PublishWorker netcoreapp2.1, win-x64 
-CALL :PublishWorker netcoreapp2.1, ubuntu.16.04-x64
-CALL :PublishWorker netcoreapp2.1, ubuntu.18.04-x64
+CALL :PublishWorker netcoreapp2.1, linux-x64
 EXIT /B %ERRORLEVEL%
 
 :PublishWorker


### PR DESCRIPTION
Currently, the build outputs workers for netcoreapp2.1\ubuntu16.04-x64 and netcoreapp2.1\ubuntu18.04-x64. Instead of this, just publish worker for netcoreapp2.1\linux-x64.
