### PR TITLE
Updating Readme to reflect the use of dotnet.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
            --class org.apache.spark.deploy.DotnetRunner `
            --master local `
            microsoft-spark-2.4.x-<version>.jar `
-           c:\Program Files\dotnet.exe .\HelloSpark.dll
+           c:\Program Files\dotnet\dotnet.exe .\HelloSpark.dll
        ```
        **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `c:\bin\apache-spark\bin\spark-submit`). For detailed instructions, you can see [Building .NET for Apache Spark from Source on Windows](docs/building/windows-instructions.md).
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
 
 1. **Pre-requisites**: 
     - Download and install the following: **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** | **[Visual Studio 2019](https://www.visualstudio.com/downloads/)** | **[Java 1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** | **[Apache Spark 2.4.1](https://archive.apache.org/dist/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz)**
-      - **Optional** Add the location of Apache Spark to your [PATH environment variable](https://www.java.com/en/download/help/path.xml) (e.g., `c:\bin\apache-spark\`).
-      - **Optional** Add the location of .NET Core 2.1 to your [PATH environment variable](https://www.java.com/en/download/help/path.xml) (e.g., `c:\Program Files\dotnet\`).
     - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
       - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (e.g., `c:\bin\Microsoft.Spark.Worker\`).
       - **IMPORTANT** Create a [new environment variable](https://www.java.com/en/download/help/path.xml) `DotnetWorkerPath` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `c:\bin\Microsoft.Spark.Worker`).
@@ -63,7 +61,7 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
            --class org.apache.spark.deploy.DotnetRunner `
            --master local `
            microsoft-spark-2.4.x-<version>.jar `
-           c:\Program Files\dotnet\dotnet.exe .\HelloSpark.dll
+           <full-path-to-dotnet.exe> .\HelloSpark.dll
        ```
        **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `c:\bin\apache-spark\bin\spark-submit`). For detailed instructions, you can see [Building .NET for Apache Spark from Source on Windows](docs/building/windows-instructions.md).
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
 
 1. **Pre-requisites**: 
     - Download and install the following: **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** | **[Visual Studio 2019](https://www.visualstudio.com/downloads/)** | **[Java 1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** | **[Apache Spark 2.4.1](https://archive.apache.org/dist/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz)**
+      - **Optional** Add the location of Apache Spark to your [PATH environment variable](https://www.java.com/en/download/help/path.xml) (e.g., `c:\bin\apache-spark\`).
+      - **Optional** Add the location of .NET Core 2.1 to your [PATH environment variable](https://www.java.com/en/download/help/path.xml) (e.g., `c:\Program Files\dotnet\`).
     - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
       - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (e.g., `c:\bin\Microsoft.Spark.Worker\`).
       - **IMPORTANT** Create a [new environment variable](https://www.java.com/en/download/help/path.xml) `DotnetWorkerPath` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `c:\bin\Microsoft.Spark.Worker`).
@@ -61,9 +63,9 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
            --class org.apache.spark.deploy.DotnetRunner `
            --master local `
            microsoft-spark-2.4.x-<version>.jar `
-           HelloSpark
+           c:\Program Files\dotnet.exe .\HelloSpark.dll
        ```
-       Note that this command assumes you have downloaded Apache Spark and added it to your PATH environment variable. For detailed instructions, you can see [Building .NET for Apache Spark from Source on Windows](docs/building/windows-instructions.md).
+       **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `c:\bin\apache-spark\bin\spark-submit`). For detailed instructions, you can see [Building .NET for Apache Spark from Source on Windows](docs/building/windows-instructions.md).
 
 ## Build Status
 


### PR DESCRIPTION
On Windows, when you use .NET Core 2.1, building the solution will produce a DLL as opposed to an EXE. This means the user would have to pass in the path to dotnet.exe and not the DLL itself.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

