### PR TITLE
Sign snupkg packages during build process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,7 @@ jobs:
         arguments: '--no-build --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)'
 
     - task: MSBuild@1
-      displayName: 'Sign nuget packages'
+      displayName: 'Sign nuget/snupkg packages'
       inputs:
         solution: eng/Sign.proj
         msbuildArguments: /t:SignBinaries 

--- a/eng/Sign.proj
+++ b/eng/Sign.proj
@@ -41,6 +41,12 @@
       </FilesToSign>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(SignNugetPackages)' == 'true'">
+      <FilesToSign Include="$(OutDir)*.snupkg">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+
     <ItemGroup Condition="'$(SignSparkBinaries)' == 'true'">
       <FilesToSign Include="$(OutDir)**/Microsoft.Spark.dll">
         <Authenticode>Microsoft</Authenticode>

--- a/eng/Sign.proj
+++ b/eng/Sign.proj
@@ -36,13 +36,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(SignNugetPackages)' == 'true'">
-      <FilesToSign Include="$(OutDir)*.nupkg">
-        <Authenticode>NuGet</Authenticode>
-      </FilesToSign>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(SignNugetPackages)' == 'true'">
-      <FilesToSign Include="$(OutDir)*.snupkg">
+      <FilesToSign Include="$(OutDir)*.nupkg;$(OutDir)*.snupkg">
         <Authenticode>NuGet</Authenticode>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
Currently, only the nuget packages are signed. Update build pipieline to sign snupkg packages as well.

