### PR TITLE
Remove formatPath() that adds ".\" or "./" to the executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In this section, we will show how to run a .NET for Apache Spark app using .NET 
            --class org.apache.spark.deploy.DotnetRunner `
            --master local `
            microsoft-spark-2.4.x-<version>.jar `
-           <full-path-to-dotnet.exe> .\HelloSpark.dll
+           dotnet HelloSpark.dll
        ```
        **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `c:\bin\apache-spark\bin\spark-submit`). For detailed instructions, you can see [Building .NET for Apache Spark from Source on Windows](docs/building/windows-instructions.md).
 

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/deploy/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/deploy/DotnetRunner.scala
@@ -71,11 +71,6 @@ object DotnetRunner extends Logging {
         // Reuse windows-specific formatting in PythonRunner.
         dotnetExecutable = PythonRunner.formatPath(resolveDotnetExecutable(driverDir, args(1)))
         otherArgs = args.slice(2, args.length)
-      } else if (new File(args(0)).isDirectory) {
-        // Local mode where .NET application is located in the given directory.
-        // Reuse windows-specific formatting in PythonRunner.
-        dotnetExecutable = PythonRunner.formatPath(args(1))
-        otherArgs = args.slice(2, args.length)
       } else {
         // Reuse windows-specific formatting in PythonRunner.
         dotnetExecutable = PythonRunner.formatPath(args(0))
@@ -86,7 +81,7 @@ object DotnetRunner extends Logging {
     }
 
     val processParameters = new java.util.ArrayList[String]
-    processParameters.add(formatPath(dotnetExecutable))
+    processParameters.add(dotnetExecutable)
     otherArgs.foreach(arg => processParameters.add(arg))
 
     logInfo(s"Starting DotnetBackend with $dotnetExecutable.")
@@ -198,17 +193,6 @@ object DotnetRunner extends Logging {
     }
 
     resolvedExecutable
-  }
-
-  // When executing in YARN cluster mode, the name of the
-  // executable is single-part (just the exe name). This method will add "." to it
-  private def formatPath(dotnetExecutable: String): String = {
-    var formattedDotnetExecutable = dotnetExecutable
-    val path = Paths.get(dotnetExecutable)
-    if (!path.isAbsolute && path.getNameCount == 1) {
-      formattedDotnetExecutable = Paths.get(".", path.toString).toString
-    }
-    formattedDotnetExecutable
   }
 
   /**

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/DotnetRunner.scala
@@ -71,11 +71,6 @@ object DotnetRunner extends Logging {
         // Reuse windows-specific formatting in PythonRunner.
         dotnetExecutable = PythonRunner.formatPath(resolveDotnetExecutable(driverDir, args(1)))
         otherArgs = args.slice(2, args.length)
-      } else if (new File(args(0)).isDirectory) {
-        // Local mode where .NET application is located in the given directory.
-        // Reuse windows-specific formatting in PythonRunner.
-        dotnetExecutable = PythonRunner.formatPath(args(1))
-        otherArgs = args.slice(2, args.length)
       } else {
         // Reuse windows-specific formatting in PythonRunner.
         dotnetExecutable = PythonRunner.formatPath(args(0))
@@ -86,7 +81,7 @@ object DotnetRunner extends Logging {
     }
 
     val processParameters = new java.util.ArrayList[String]
-    processParameters.add(formatPath(dotnetExecutable))
+    processParameters.add(dotnetExecutable)
     otherArgs.foreach(arg => processParameters.add(arg))
 
     logInfo(s"Starting DotnetBackend with $dotnetExecutable.")
@@ -198,17 +193,6 @@ object DotnetRunner extends Logging {
     }
 
     resolvedExecutable
-  }
-
-  // When executing in YARN cluster mode, the name of the
-  // executable is single-part (just the exe name). This method will add "." to it
-  private def formatPath(dotnetExecutable: String): String = {
-    var formattedDotnetExecutable = dotnetExecutable
-    val path = Paths.get(dotnetExecutable)
-    if (!path.isAbsolute && path.getNameCount == 1) {
-      formattedDotnetExecutable = Paths.get(".", path.toString).toString
-    }
-    formattedDotnetExecutable
   }
 
   /**


### PR DESCRIPTION
`formatPath()` adds ".\" or "." to the .NET executable. This forces the user to specify a full path for the .NET executable passed to `spark-submit`. For example,
```
spark-submit --class org.apache.spark.deploy.DotnetRunner microsoft-spark-<version>.jar dotnet HelloSpark.dll
```
is not allowed, since `formatPath()` changes `dotnet` to `.\dotnet.exe` even if dotnet is in the PATH.