### PR TITLE
Update PackageReleaseNotes for Nuget package

### DIFF
--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
 
     <Description>.NET for Apache Spark</Description>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/dotnet/spark/tree/master/docs/release-notes</PackageReleaseNotes>
     <PackageTags>spark;dotnet;csharp</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
<PackageReleaseNotes> will now point to the release notes in GitHub.