### PR TITLE
Fix VS 2017 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,10 +139,10 @@ jobs:
         artifactName:  Microsoft.Spark.Binaries
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - job: Package
+  - job: SignPublish
     dependsOn:
       - Build
-    displayName: Build packages
+    displayName: Sign and Publish Artifacts
     pool:
       name: NetCoreInternal-Int-Pool
       queue: buildpool.windows.10.amd64.vs2017

--- a/examples/Microsoft.Spark.FSharp.Examples/Microsoft.Spark.FSharp.Examples.fsproj
+++ b/examples/Microsoft.Spark.FSharp.Examples/Microsoft.Spark.FSharp.Examples.fsproj
@@ -7,6 +7,8 @@
     <RootNamespace>Microsoft.Spark.Examples</RootNamespace>
     <AssemblyName>Microsoft.Spark.FSharp.Examples</AssemblyName>
     <PublicSign>false</PublicSign>
+    <!-- workaround https://github.com/dotnet/fsharp/issues/4822 to support VS 2017 -->
+    <NoWarn>2003;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The VS 2017 F# compiler doesn't like the new AssemblyInformationAttribute added by dotnet/arcade.

Also, rename the signing leg of the build.