### PR TITLE
Compatibility check for Microsoft.Spark.dll in the worker.

### DIFF
--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Spark.Worker.UnitTest
             return new Payload()
             {
                 SplitIndex = 10,
-                Version = "1.0",
+                Version = Versions.CurrentVersion,
                 TaskContext = taskContext,
                 SparkFilesDir = "directory",
                 IncludeItems = new[] { "file1", "file2" },

--- a/src/csharp/Microsoft.Spark.Worker/Processor/PayloadProcessor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Processor/PayloadProcessor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Spark.Worker.Processor
         {
             var payload = new Payload();
 
-            byte[] splitIndexBytes = null;
+            byte[] splitIndexBytes;
             try
             {
                 splitIndexBytes = SerDe.ReadBytes(stream, sizeof(int));

--- a/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
+++ b/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
@@ -146,8 +146,7 @@ namespace Microsoft.Spark.Worker
                     return null;
                 }
 
-                // Check the version here.
-                payload.Version.
+                ValidateVersion(payload.Version);
 
                 DateTime initTime = DateTime.UtcNow;
 
@@ -187,7 +186,7 @@ namespace Microsoft.Spark.Worker
                     SerDe.Write(outputStream, (int)SpecialLengths.END_OF_DATA_SECTION);
                 }
 
-                LogStat(payload, commandExecutorStat, readComplete);
+                LogStat(commandExecutorStat, readComplete);
 
                 return payload;
             }
@@ -214,7 +213,22 @@ namespace Microsoft.Spark.Worker
             }
         }
 
-        private void LogStat(Payload payloa, CommandExecutorStat stat, bool readComplete)
+        private void ValidateVersion(string versionStr)
+        {
+            // Initial version was shipped with version "1.0", so this needs to be adjusted
+            // to be compatible going forward.
+            if (versionStr == "1.0")
+            {
+                versionStr = "0.1.0";
+            }
+
+            if (new Version(versionStr) < new Version(Versions.CurrentVersion))
+            {
+                throw new Exception($"Upgrade Microsoft.Spark to '{Versions.CurrentVersion}+' from '{versionStr}+'.");
+            }
+        }
+
+        private void LogStat(CommandExecutorStat stat, bool readComplete)
         {
             s_logger.LogInfo($"[{TaskId}] Processed a task: readComplete:{readComplete}, entries:{stat.NumEntriesProcessed}");
         }

--- a/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
+++ b/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
@@ -146,6 +146,9 @@ namespace Microsoft.Spark.Worker
                     return null;
                 }
 
+                // Check the version here.
+                payload.Version.
+
                 DateTime initTime = DateTime.UtcNow;
 
                 CommandExecutorStat commandExecutorStat = new CommandExecutor().Execute(

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Spark.Utils
                 hashTableReference, // Environment variables
                 arrayListReference, // Python includes
                 SparkEnvironment.ConfigurationService.GetWorkerExePath(),
-                "1.0",
+                Versions.CurrentVersion,
                 arrayListReference, // Broadcast variables
                 null); // Accumulator
         }

--- a/src/csharp/Microsoft.Spark/Versions.cs
+++ b/src/csharp/Microsoft.Spark/Versions.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Spark
         // The following is used to check the compatibility of UDFs between
         // the driver and worker side. This needs to be updated only when there
         // is a breaking change on the UDF contract.
-        internal const string  CurrentVersion = "0.4.0";
+        internal const string CurrentVersion = "0.4.0";
     }
 }

--- a/src/csharp/Microsoft.Spark/Versions.cs
+++ b/src/csharp/Microsoft.Spark/Versions.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Spark
         internal const string V2_3_2 = "2.3.2";
         internal const string V2_3_3 = "2.3.3";
         internal const string V2_4_0 = "2.4.0";
+
+        // The following is used to check the compatibility of UDFs between
+        // the driver and worker side. This needs to be updated only when there
+        // is a breaking change on the UDF contract.
+        internal const string  CurrentVersion = "0.4.0";
     }
 }


### PR DESCRIPTION
There will be a breaking change for UDF contract due to #135. Now, the worker needs to enforce some kind of versioning check to ensure that Microsoft.Spark.dll is compatible b/w the driver and worker.