### PR TITLE
Support for SparkSession.conf

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Sql;
 using Xunit;
 
@@ -37,7 +38,17 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             conf.Unset("stringKey");
             Assert.Equal("defaultValue", conf.Get("stringKey", "defaultValue"));
+        }
 
+        /// <summary>
+        /// Test signatures for APIs introduced in Spark 2.4.*.
+        /// </summary>
+        [SkipIfSparkVersionIsLessThan(Versions.V2_4_0)]
+        public void TestSignaturesV2_4_X()
+        {
+            RuntimeConfig conf = _spark.Conf();
+
+            Assert.True(conf.IsModifiable("spark.sql.streaming.checkpointLocation"));
             Assert.False(conf.IsModifiable("missingKey"));
         }
     }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
@@ -32,12 +32,13 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             conf.Set("boolKey", false);
             conf.Set("longKey", 1234L);
 
-            Assert.Equal("stringValue", conf.Get("stringKey", "defaultValue"));
-            Assert.Equal("false", conf.Get("boolKey", "true"));
-            Assert.Equal("1234", conf.Get("longKey", "0"));
+            Assert.Equal("stringValue", conf.Get("stringKey"));
+            Assert.Equal("false", conf.Get("boolKey"));
+            Assert.Equal("1234", conf.Get("longKey"));
 
             conf.Unset("stringKey");
             Assert.Equal("defaultValue", conf.Get("stringKey", "defaultValue"));
+            Assert.Equal("false", conf.Get("boolKey", "true"));
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             conf.Unset("stringKey");
             Assert.Equal("defaultValue", conf.Get("stringKey", "defaultValue"));
 
-            Assert.True(conf.IsModifiable("spark.sql.shuffle.partitions"));
             Assert.False(conf.IsModifiable("missingKey"));
         }
     }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/RuntimeConfigTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Spark.Sql;
+using Xunit;
+
+namespace Microsoft.Spark.E2ETest.IpcTests
+{
+    [Collection("Spark E2E Tests")]
+    public class RuntimeConfigTests
+    {
+        private readonly SparkSession _spark;
+
+        public RuntimeConfigTests(SparkFixture fixture)
+        {
+            _spark = fixture.Spark;
+        }
+
+        /// <summary>
+        /// Test signatures for APIs up to Spark 2.3.*.
+        /// The purpose of this test is to ensure that JVM calls can be successfully made.
+        /// Note that this is not testing functionality of each function.
+        /// </summary>
+        [Fact]
+        public void TestSignaturesV2_3_X()
+        {
+            RuntimeConfig conf = _spark.Conf();
+
+            conf.Set("stringKey", "stringValue");
+            conf.Set("boolKey", false);
+            conf.Set("longKey", 1234L);
+
+            Assert.Equal("stringValue", conf.Get("stringKey", "defaultValue"));
+            Assert.Equal("false", conf.Get("boolKey", "true"));
+            Assert.Equal("1234", conf.Get("longKey", "0"));
+
+            conf.Unset("stringKey");
+            Assert.Equal("defaultValue", conf.Get("stringKey", "defaultValue"));
+
+            Assert.True(conf.IsModifiable("spark.sql.shuffle.partitions"));
+            Assert.False(conf.IsModifiable("missingKey"));
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Spark.Interop.Ipc;
 
 namespace Microsoft.Spark.Sql
@@ -39,6 +37,12 @@ namespace Microsoft.Spark.Sql
         /// <param name="key">Config name</param>
         /// <param name="value">Config value</param>
         public void Set(string key, long value) => _jvmObject.Invoke("set", key, value);
+
+        /// <summary>
+        /// Returns the value of Spark runtime configuration property for the given key.
+        /// </summary>
+        /// <param name="key">Key to use</param>
+        public string Get(string key) => (string)_jvmObject.Invoke("get", key);
 
         /// <summary>
         /// Returns the value of Spark runtime configuration property for the given key.

--- a/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
@@ -59,9 +59,11 @@ namespace Microsoft.Spark.Sql
         /// is modifiable in the current session.
         /// </summary>
         /// <param name="key">Key to check</param>
-        /// <returns>true if the configuration property is modifiable. For static SQL, Spark
+        /// <returns>
+        /// true if the configuration property is modifiable. For static SQL, Spark
         /// Core, invalid(not existing) and other non-modifiable configuration properties,
-        /// the returned value is false.</returns>
+        /// the returned value is false.
+        /// </returns>
         public bool IsModifiable(string key) => (bool)_jvmObject.Invoke("isModifiable", key);
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Spark.Interop.Ipc;
+
+namespace Microsoft.Spark.Sql
+{
+    /// <summary>
+    /// Runtime configuration interface for Spark.
+    /// </summary>
+    public sealed class RuntimeConfig : IJvmObjectReferenceProvider
+    {
+        private readonly JvmObjectReference _jvmObject;
+
+        internal RuntimeConfig(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
+
+        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+
+        /// <summary>
+        /// Sets the given Spark runtime configuration property.
+        /// </summary>
+        /// <param name="key">Config name</param>
+        /// <param name="value">Config value</param>
+        public void Set(string key, string value) => _jvmObject.Invoke("set", key, value);
+
+        /// <summary>
+        /// Sets the given Spark runtime configuration property.
+        /// </summary>
+        /// <param name="key">Config name</param>
+        /// <param name="value">Config value</param>
+        public void Set(string key, bool value) => _jvmObject.Invoke("set", key, value);
+
+        /// <summary>
+        /// Sets the given Spark runtime configuration property.
+        /// </summary>
+        /// <param name="key">Config name</param>
+        /// <param name="value">Config value</param>
+        public void Set(string key, long value) => _jvmObject.Invoke("set", key, value);
+
+        /// <summary>
+        /// Returns the value of Spark runtime configuration property for the given key.
+        /// </summary>
+        /// <param name="key">Key to use</param>
+        /// <param name="defaultValue">Default value to use</param>
+        public string Get(string key, string defaultValue) =>
+            (string)_jvmObject.Invoke("get", key, defaultValue);
+
+        /// <summary>
+        /// Resets the configuration property for the given key.
+        /// </summary>
+        /// <param name="key">Key to unset</param>
+        public void Unset(string key) => _jvmObject.Invoke("unset", key);
+
+        /// <summary>
+        /// Indicates whether the configuration property with the given key
+        /// is modifiable in the current session.
+        /// </summary>
+        /// <param name="key">Key to check</param>
+        /// <returns>true if the configuration property is modifiable. For static SQL, Spark
+        /// Core, invalid(not existing) and other non-modifiable configuration properties,
+        /// the returned value is false.</returns>
+        public bool IsModifiable(string key) => (bool)_jvmObject.Invoke("isModifiable", key);
+    }
+}

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Spark.Sql
         /// this defaults to the value set in the underlying SparkContext, if any.
         /// </remarks>
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The RuntimeConfig object</returns>
         public RuntimeConfig Conf() =>
             new RuntimeConfig((JvmObjectReference)_jvmObject.Invoke("conf"));
 

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -52,6 +52,18 @@ namespace Microsoft.Spark.Sql
         }
 
         /// <summary>
+        /// Runtime configuration interface for Spark.
+        /// <remarks>
+        /// This is the interface through which the user can get and set all Spark and Hadoop
+        /// configurations that are relevant to Spark SQL. When getting the value of a config,
+        /// this defaults to the value set in the underlying SparkContext, if any.
+        /// </remarks>
+        /// </summary>
+        /// <returns></returns>
+        public RuntimeConfig Conf() =>
+            new RuntimeConfig((JvmObjectReference)_jvmObject.Invoke("conf"));
+
+        /// <summary>
         /// Start a new session with isolated SQL configurations, temporary tables, registered
         /// functions are isolated, but sharing the underlying SparkContext and cached data.
         /// </summary>
@@ -70,16 +82,16 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="tableName">Name of a table or view</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Table(string tableName)
-            => new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
+        public DataFrame Table(string tableName) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
 
         /// <summary>
         /// Executes a SQL query using Spark, returning the result as a DataFrame.
         /// </summary>
         /// <param name="sqlText">SQL query text</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Sql(string sqlText)
-            => new DataFrame((JvmObjectReference)_jvmObject.Invoke("sql", sqlText));
+        public DataFrame Sql(string sqlText) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("sql", sqlText));
 
         /// <summary>
         /// Returns a DataFrameReader that can be used to read non-streaming data in


### PR DESCRIPTION
This PR will allow retrieving and modifying a SparkSessions configuration without requiring a `stop` and recreation of the SparkSession.