### PR TITLE
Expose a way to override assembly search paths used by AssemblyLoader.

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Spark.Utils;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    public class AssemblyLoaderTests
+    {
+        [Fact]
+        public void TestAssemblySearchPathResolver()
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            string appDir = AppDomain.CurrentDomain.BaseDirectory;
+
+            // Test the default scenario.
+            string[] searchPaths = AssemblySearchPathResolver.GetAssemblySearchPaths();
+            Assert.Equal(new[] { curDir, appDir }, searchPaths);
+
+            // Test the case where DOTNET_ASSEMBLY_SEARCH_PATHS is defined.
+            char sep = Path.PathSeparator;
+            Environment.SetEnvironmentVariable(
+                AssemblySearchPathResolver.AssemblySearchPathsEnvVarName,
+                $"mydir1, mydir2, .{sep}mydir3,.{sep}mydir4");
+
+            searchPaths = AssemblySearchPathResolver.GetAssemblySearchPaths();
+            Assert.Equal(
+                new[] {
+                    "mydir1",
+                    "mydir2",
+                    Path.Combine(curDir, $".{sep}mydir3"),
+                    Path.Combine(curDir, $".{sep}mydir4"),
+                    curDir,
+                    appDir },
+                searchPaths);
+
+            Environment.SetEnvironmentVariable(
+                AssemblySearchPathResolver.AssemblySearchPathsEnvVarName,
+                null);
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Spark.UnitTest
         [Serializable]
         private class TestClass
         {
-            private string _str;
+            private readonly string _str;
 
             public TestClass(string s)
             {

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -6,12 +6,18 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Spark.Utils
 {
     internal static class AssemblyLoader
     {
+        // If this environment variable is set, the paths specified in this variable will have
+        // higher precedence over default search paths. Note that if a search path starts with
+        // ".", it will be replaced with the current directory.
+        internal const string AssemblySearchPathsEnvVarName = "DOTNET_ASSEMBLY_SEARCH_PATHS";
+
         internal static Func<string, Assembly> LoadFromFile { get; set; } = Assembly.LoadFrom;
 
         internal static Func<string, Assembly> LoadFromName { get; set; } = Assembly.Load;
@@ -19,8 +25,7 @@ namespace Microsoft.Spark.Utils
         private static readonly Dictionary<string, Assembly> s_assemblyCache =
             new Dictionary<string, Assembly>();
 
-        private static readonly string[] s_searchPaths =
-            new[] { Directory.GetCurrentDirectory(), AppDomain.CurrentDomain.BaseDirectory };
+        private static readonly string[] s_searchPaths = ResolveSearchPaths();
 
         private static readonly string[] s_extensions =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
@@ -127,6 +132,32 @@ namespace Microsoft.Spark.Utils
             }
 
             return false;
+        }
+
+        private static string[] ResolveSearchPaths()
+        {
+            var searchPaths = new List<string>();
+            string searchPathsStr =
+                Environment.GetEnvironmentVariable(AssemblySearchPathsEnvVarName);
+
+            if (!string.IsNullOrEmpty(searchPathsStr))
+            {
+                foreach (string searchPath in searchPathsStr.Split(','))
+                {
+                    if (searchPath.StartsWith($".{Path.DirectorySeparatorChar}"))
+                    {
+                        searchPaths.Add(Path.Combine(Directory.GetCurrentDirectory(), searchPath));
+                    }
+                    else
+                    {
+                        searchPaths.Add(searchPath);
+                    }
+                }
+            }
+            searchPaths.Add(Directory.GetCurrentDirectory());
+            searchPaths.Add(AppDomain.CurrentDomain.BaseDirectory);
+
+            return searchPaths.ToArray();
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -14,12 +14,22 @@ namespace Microsoft.Spark.Utils
     {
         internal const string AssemblySearchPathsEnvVarName = "DOTNET_ASSEMBLY_SEARCH_PATHS";
 
-        // Returns the paths to search when loading assemblies in the following order of
-        // precedence:
-        // 1) Comma-separated paths specified in DOTNET_ASSEMBLY_SEARCH_PATHS environment variable.
-        //    - Note that if a path starts with ".", the working directory will be prepended.
-        // 2) The working directory.
-        // 3) The directory of the application.
+        /// <summary>
+        /// Returns the paths to search when loading assemblies in the following order of
+        /// precedence:
+        /// 1) Comma-separated paths specified in DOTNET_ASSEMBLY_SEARCH_PATHS environment
+        /// variable. Note that if a path starts with ".", the working directory will be prepended.
+        /// 2) The working directory.
+        /// 3) The directory of the application.
+        /// </summary>
+        /// <remarks>
+        /// The reason that the working directory has higher precedence than the directory
+        /// of the application is for cases when spark is launched on YARN. The executors are run
+        /// inside 'containers' and files that are passed via 'spark-submit --files' will be pushed
+        /// to these 'containers'. This path is the working directory and the 1st probing path that
+        /// will be checked.
+        /// </remarks>
+        /// <returns>Assembly search paths</returns>
         internal static string[] GetAssemblySearchPaths()
         {
             var searchPaths = new List<string>();
@@ -131,16 +141,8 @@ namespace Microsoft.Spark.Utils
         }
 
         /// <summary>
-        /// Returns the loaded assembly by probing the following locations in order:
-        /// 1) The working directory
-        /// 2) The directory of the application
+        /// Returns the loaded assembly by probing paths returned by AssemblySearchPathResolver.
         /// </summary>
-        /// <remarks>
-        /// The probing order is important in cases when spark is launched on
-        /// YARN. The executors are run inside 'containers' and files that are passed
-        /// via 'spark-submit --files' will be pushed to these 'containers'. This path
-        /// is the working directory and the 1st probing path that will be checked.
-        /// </remarks>
         /// <param name="assemblyFileName">Name of the file that contains the assembly</param>
         /// <param name="assembly">The loaded assembly.</param>
         /// <returns>True if assembly is loaded, false otherwise.</returns>

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Spark.Utils
                 Type valueType = typeArguments[1];
                 return @"{""type"":""map"", " +
                     $@"""keyType"":{GetReturnType(keyType)}, " +
-                    $@"""valueType"":{GetReturnType(valueType)}, " + 
+                    $@"""valueType"":{GetReturnType(valueType)}, " +
                     $@"""valueContainsNull"":{valueType.CanBeNull()}}}";
             }
 
@@ -134,7 +134,7 @@ namespace Microsoft.Spark.Utils
             {
                 Type elementType = enumerableType.GenericTypeArguments[0];
                 return @"{""type"":""array"", " +
-                    $@"""elementType"":{GetReturnType(elementType)}, " + 
+                    $@"""elementType"":{GetReturnType(elementType)}, " +
                     $@"""containsNull"":{elementType.CanBeNull()}}}";
             }
 
@@ -149,14 +149,24 @@ namespace Microsoft.Spark.Utils
         /// <returns>JvmObjectReference object to the PythonFunction object</returns>
         internal static JvmObjectReference CreatePythonFunction(IJvmBridge jvm, byte[] command)
         {
-            JvmObjectReference hashTableReference = jvm.CallConstructor("java.util.Hashtable");
             JvmObjectReference arrayListReference = jvm.CallConstructor("java.util.ArrayList");
+
+            JvmObjectReference environmentVars = jvm.CallConstructor("java.util.Hashtable");
+            string assemblySearchPath = Environment.GetEnvironmentVariable("DOTNET_ASSEMBLY_SEARCH_PATHS");
+            if (!string.IsNullOrEmpty(assemblySearchPath))
+            {
+                jvm.CallNonStaticJavaMethod(
+                    environmentVars,
+                    "put",
+                    "DOTNET_ASSEMBLY_SEARCH_PATHS",
+                    assemblySearchPath);
+            }
 
             return (JvmObjectReference)jvm.CallStaticJavaMethod(
                 "org.apache.spark.sql.api.dotnet.SQLUtils",
                 "createPythonFunction",
                 command,
-                hashTableReference, // Environment variables
+                environmentVars, // Environment variables
                 arrayListReference, // Python includes
                 SparkEnvironment.ConfigurationService.GetWorkerExePath(),
                 Versions.CurrentVersion,


### PR DESCRIPTION
This will enable using --archives udf.zip so that you can put all the udf dlls in one zip file.
You can do this by setting AssemblySearchPathsEnvVarName:
```
export AssemblySearchPathsEnvVarName=./udf.zip
```
