### PR TITLE
Add zip files in working directory to assembly search path

### DIFF
--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -55,6 +56,19 @@ namespace Microsoft.Spark.Utils
 
             searchPaths.Add(Directory.GetCurrentDirectory());
             searchPaths.Add(AppDomain.CurrentDomain.BaseDirectory);
+
+            FileInfo[] archives = new DirectoryInfo(Directory.GetCurrentDirectory())
+                .GetFiles("*.zip");
+            foreach (var archive in archives)
+            {
+                string extractedPath = Path.Combine(archive.DirectoryName,
+                    Path.GetFileNameWithoutExtension(archive.FullName));
+                if (!File.Exists(extractedPath))
+                {
+                    ZipFile.ExtractToDirectory(archive.FullName, extractedPath);
+                    searchPaths.Add(extractedPath);
+                }
+            }
 
             return searchPaths.ToArray();
         }


### PR DESCRIPTION
This change extracts any zip files within the working directory and adds the extracted folders to the assembly search path.  When combined with the `--files` parameter allows you to copy the application dependencies to all workers and adds them to the assembly search path.

Fixes #192 