### PR TITLE
Package Worker zip fix for Mac OSX

### DIFF
--- a/script/package-worker.ps1
+++ b/script/package-worker.ps1
@@ -1,3 +1,8 @@
+Remove-module -Name Microsoft.PowerShell.Archive
+Install-PackageProvider -Name NuGet -Force -Scope CurrentUser
+Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.3.0
+Import-module -Name Microsoft.PowerShell.Archive -Scope CurrentUser
+
 $version = $args[0]
 $worker_dir = $args[1]
 $output_dir = $args[2]

--- a/script/package-worker.ps1
+++ b/script/package-worker.ps1
@@ -1,7 +1,5 @@
-Remove-module -Name Microsoft.PowerShell.Archive
 Install-PackageProvider -Name NuGet -Force -Scope CurrentUser
 Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.3.0
-Import-module -Name Microsoft.PowerShell.Archive -Scope CurrentUser
 
 $version = $args[0]
 $worker_dir = $args[1]


### PR DESCRIPTION
`zip` files created using `Compress-Archive` in powershell causes incorrect behavior when using OSX's `Archiver` to extract.  There is a bug in Powershell module Microsoft.PowerShell.Archive.  This PR will update the module before creating the `zip`.