### PR TITLE
Add an example of using .NET Core 3.0 hardware intrinsics in a VectorUdf.

### DIFF
--- a/benchmark/csharp/Tpch/Tpch.csproj
+++ b/benchmark/csharp/Tpch/Tpch.csproj
@@ -4,13 +4,38 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
+    <!--
+    Uncomment the following line to build for netcoreapp3.0.
+    Don't build for netcoreapp3.0, by default, because it requires VS 16.3.
+    -->
+    <!--<TargetFrameworks>$(TargetFrameworks);netcoreapp3.0</TargetFrameworks>-->
     <RootNamespace>Tpch</RootNamespace>
     <AssemblyName>Tpch</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
+    <None Include="**/*.cs" />
+    
     <ProjectReference Include="..\..\..\src\csharp\Microsoft.Spark.Experimental\Microsoft.Spark.Experimental.csproj" />
     <ProjectReference Include="..\..\..\src\csharp\Microsoft.Spark\Microsoft.Spark.csproj" />
   </ItemGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+      <PropertyGroup>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+      </PropertyGroup>
+      
+      <ItemGroup>
+        <Compile Remove="VectorFunctions.cs" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Compile Remove="VectorFunctions.intrinsics.cs" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   
 </Project>

--- a/benchmark/csharp/Tpch/VectorFunctions.intrinsics.cs
+++ b/benchmark/csharp/Tpch/VectorFunctions.intrinsics.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Apache.Arrow;
+
+namespace Tpch
+{
+    internal static class VectorFunctions
+    {
+        internal static unsafe DoubleArray ComputeTotal(DoubleArray price, DoubleArray discount, DoubleArray tax)
+        {
+            if ((price.Length != discount.Length) || (price.Length != tax.Length))
+            {
+                throw new ArgumentException("Arrays need to be the same length");
+            }
+
+            int length = price.Length;
+            int vectorizationLength = length - (length % 4);
+
+            DoubleArray.Builder builder = new DoubleArray.Builder().Reserve(length);
+            Span<double> buffer = stackalloc double[4];
+
+            fixed (double* pExtendedPrice = price.Values)
+            fixed (double* pDiscount = discount.Values)
+            fixed (double* pTaxes = discount.Values)
+            fixed (double* pBuffer = buffer)
+            {
+                Vector256<double> ones = Vector256.Create(1.0);
+
+                int i = 0;
+                for (; i < vectorizationLength; i += 4)
+                {
+                    Vector256<double> r = Avx.Multiply(
+                        Avx.Multiply(
+                            Avx.LoadVector256(pExtendedPrice + i),
+                            Avx.Subtract(ones, Avx.LoadVector256(pDiscount + i))),
+                        Avx.Add(ones, Avx.LoadVector256(pTaxes + i)));
+
+                    Avx.Store(pBuffer, r);
+                    builder.Append(buffer);
+                }
+
+                for (; i < length; i += 1)
+                {
+                    builder.Append(pExtendedPrice[i] * (1 - pDiscount[i]) * (1 + pTaxes[i]));
+                }
+            }
+
+            return builder.Build();
+        }
+
+        internal static unsafe DoubleArray ComputeDiscountPrice(DoubleArray price, DoubleArray discount)
+        {
+            if (price.Length != discount.Length)
+            {
+                throw new ArgumentException("Arrays need to be the same length");
+            }
+
+            int length = price.Length;
+            int vectorizationLength = length - (length % 4);
+
+            DoubleArray.Builder builder = new DoubleArray.Builder().Reserve(length);
+            Span<double> buffer = stackalloc double[4];
+
+            fixed (double* pExtendedPrice = price.Values)
+            fixed (double* pDiscount = discount.Values)
+            fixed (double* pBuffer = buffer)
+            {
+                Vector256<double> ones = Vector256.Create(1.0);
+                
+                int i = 0;
+                for (; i < vectorizationLength; i += 4)
+                {
+                    Vector256<double> r = Avx.Multiply(
+                        Avx.LoadVector256(pExtendedPrice + i),
+                        Avx.Subtract(ones, Avx.LoadVector256(pDiscount + i)));
+
+                    Avx.Store(pBuffer, r);
+                    builder.Append(buffer);
+                }
+
+                for (; i < length; i += 1)
+                {
+                    builder.Append(pExtendedPrice[i] * (1 - pDiscount[i]));
+                }
+            }
+
+            return builder.Build();
+        }
+    }
+}


### PR DESCRIPTION
When Tpch.csproj is built for netcoreapp3.0, it will use .NET Core 3.0's `Avx` APIs to do 4 double computations at once.

Doing a simple BenchmarkDotNet benchmark of the two implementations:

```C#
public class VectorFunctionsBench
{
    private readonly DoubleArray extendedPrice;
    private readonly DoubleArray discount;
    private readonly DoubleArray tax;

    public VectorFunctionsBench()
    {
        DoubleArray.Builder builder = new DoubleArray.Builder();
        for (int i = 0; i < 10_000; i++)
            builder.Append(i);

        extendedPrice = builder.Build();

        builder.Clear();
        for (int i = 0; i < 10_000; i++)
            builder.Append((i % 5) * .01);

        discount = builder.Build();

        builder.Clear();
        for (int i = 0; i < 10_000; i++)
            builder.Append((i % 4) * .01);

        tax = builder.Build();
    }

    [Benchmark]
    public DoubleArray ComputeTotal_OneAtATime() => VectorFunctions.ComputeTotal(extendedPrice, discount, tax);

    [Benchmark]
    public DoubleArray ComputeTotal_Vectorized() => VectorFunctions30.ComputeTotal(extendedPrice, discount, tax);

    [Benchmark]
    public DoubleArray ComputeDiscountPrice_OneAtATime() => VectorFunctions.ComputeDiscountPrice(extendedPrice, discount);

    [Benchmark]
    public DoubleArray ComputeDiscountPrice_Vectorized() => VectorFunctions30.ComputeDiscountPrice(extendedPrice, discount);
}
```
results in:

|                          Method |      Mean |    Error |    StdDev |    Median |
|-------------------------------- |----------:|---------:|----------:|----------:|
|         ComputeTotal_OneAtATime | 136.72 us | 2.253 us |  1.997 us | 136.77 us |
|         ComputeTotal_Vectorized |  74.57 us | 3.771 us | 11.061 us |  77.01 us |
| ComputeDiscountPrice_OneAtATime | 134.46 us | 3.752 us | 10.765 us | 132.59 us |
| ComputeDiscountPrice_Vectorized |  63.22 us | 2.445 us |  7.172 us |  60.52 us |

This benchmark only covers the computation part. In a real Spark cluster, the cost of serializing/deserializing the data would outweigh the small computation costs here. But when you are computing a lot of data, and every clock cycle counts, this approach can speed the computations up.

/cc @bamurtaugh