### PR TITLE
DataFrameReader.Load() calls different Scala overload depending on path count

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameReaderTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameReaderTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                     }));
 
             string jsonFile = $"{TestEnvironment.ResourceDirectory}people.json";
+            Assert.IsType<DataFrame>(dfr.Load());
             Assert.IsType<DataFrame>(dfr.Load(jsonFile));
             Assert.IsType<DataFrame>(dfr.Load(jsonFile, jsonFile));
 

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
@@ -114,8 +114,19 @@ namespace Microsoft.Spark.Sql
         /// </remarks>
         /// <param name="paths">Input paths</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Load(params string[] paths) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", (object)paths));
+        public DataFrame Load(params string[] paths)
+        {
+            if (paths == null || paths.Length == 0)
+            {
+                return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
+            }
+            else if (paths.Length == 1)
+            {
+                return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", paths[0]));
+            }
+
+            return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", (object)paths));
+        }
 
         /// <summary>
         /// Loads a JSON file (one object per line) and returns the result as a DataFrame.

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         public DataFrame Load(params string[] paths)
         {
+            // Some Scala libraries only support particular overloads of load().
             if (paths == null || paths.Length == 0)
             {
                 return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
@@ -106,6 +106,22 @@ namespace Microsoft.Spark.Sql
         }
 
         /// <summary>
+        /// Loads input in as a DataFrame, for data sources that don't require a path
+        /// (e.g. external key-value stores).
+        /// </summary>
+        /// <returns>DataFrame object</returns>
+        public DataFrame Load() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
+
+        /// <summary>
+        /// Loads input in as a DataFrame, for data sources that require a path 
+        /// (e.g. data backed by a local or distributed file system).
+        /// </summary>
+        /// <param name="path">Input path</param>
+        /// <returns>DataFrame object</returns>
+        public DataFrame Load(string path) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", path));
+
+        /// <summary>
         /// Loads input in as a DataFrame from the given paths.
         /// </summary>
         /// <remarks>
@@ -114,20 +130,8 @@ namespace Microsoft.Spark.Sql
         /// </remarks>
         /// <param name="paths">Input paths</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Load(params string[] paths)
-        {
-            // Some Scala libraries only support particular overloads of load().
-            if (paths == null || paths.Length == 0)
-            {
-                return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
-            }
-            else if (paths.Length == 1)
-            {
-                return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", paths[0]));
-            }
-
-            return new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", (object)paths));
-        }
+        public DataFrame Load(params string[] paths) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", (object)paths));
 
         /// <summary>
         /// Loads a JSON file (one object per line) and returns the result as a DataFrame.


### PR DESCRIPTION
In Scala, `DataFrameReader.load()` has 3 overloads:
 
* `load()`
* `load(path: String)`
* `load(paths: String*)`

Some popular Scala libraries only support particular overloads of this function.

Until now, .Net for Spark always calls `load(path: String*)`, even if no paths or a single path are provided.

This PR changes the C# implementation of `DataFrameReader.Load(params string[] paths)` to call the appropriate Scala overload of `load()` depending on the number of paths provided to the `paths` parameter.

This is related to Issue #229 .