### PR TITLE
Support for SparkFiles

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkFilesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkFilesTests.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.Spark.E2ETest.IpcTests
+{
+    [Collection("Spark E2E Tests")]
+    public class SparkFilesTests
+    {
+        [Fact]
+        public void TestSparkFiles()
+        {
+            Assert.IsType<string>(SparkFiles.Get("people.json"));
+            Assert.IsType<string>(SparkFiles.GetRootDirectory());
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Spark.Interop;
+using Microsoft.Spark.Interop.Ipc;
+
+namespace Microsoft.Spark
+{
+    /// <summary>
+    /// Resolves paths to files added through `SparkContext.addFile()`.
+    /// </summary>
+    public static class SparkFiles
+    {
+        private static IJvmBridge Jvm { get; } = SparkEnvironment.JvmBridge;
+        private static readonly string s_sparkFilesClassName = "org.apache.spark.SparkFiles";
+
+        /// <summary>
+        /// Get the absolute path of a file added through `SparkContext.addFile()`.
+        /// </summary>
+        /// <param name="fileName">The name of the file added through `SparkContext.addFile()`
+        /// </param>
+        /// <returns>The absolute path of the file.</returns>
+        public static string Get(string fileName) =>
+            (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "get", fileName);
+
+
+        /// <summary>
+        /// Get the root directory that contains files added through `SparkContext.addFile()`.
+        /// </summary>
+        /// <returns>The root directory that contains the files.</returns>
+        public static string GetRootDirectory() =>
+            (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "getRootDirectory");
+    }
+}

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Spark
         public static string Get(string fileName) =>
             (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "get", fileName);
 
-
         /// <summary>
         /// Get the root directory that contains files added through `SparkContext.addFile()`.
         /// </summary>

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -166,8 +166,13 @@ namespace Microsoft.Spark.Utils
         private static JvmObjectReference CreateEnvVarsForPythonFunction(IJvmBridge jvm)
         {
             JvmObjectReference environmentVars = jvm.CallConstructor("java.util.Hashtable");
-            string assemblySearchPath = Environment.GetEnvironmentVariable(
-                AssemblySearchPathResolver.AssemblySearchPathsEnvVarName);
+            string assemblySearchPath = string.Join(",",
+                new[] {
+                    SparkFiles.GetRootDirectory(),
+                    Environment.GetEnvironmentVariable(
+                        AssemblySearchPathResolver.AssemblySearchPathsEnvVarName)
+                }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
             if (!string.IsNullOrEmpty(assemblySearchPath))
             {
                 jvm.CallNonStaticJavaMethod(

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -167,7 +167,8 @@ namespace Microsoft.Spark.Utils
         {
             JvmObjectReference environmentVars = jvm.CallConstructor("java.util.Hashtable");
             string assemblySearchPath = string.Join(",",
-                new[] {
+                new[]
+                {
                     SparkFiles.GetRootDirectory(),
                     Environment.GetEnvironmentVariable(
                         AssemblySearchPathResolver.AssemblySearchPathsEnvVarName)

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -169,9 +169,9 @@ namespace Microsoft.Spark.Utils
             string assemblySearchPath = string.Join(",",
                 new[]
                 {
-                    SparkFiles.GetRootDirectory(),
                     Environment.GetEnvironmentVariable(
-                        AssemblySearchPathResolver.AssemblySearchPathsEnvVarName)
+                        AssemblySearchPathResolver.AssemblySearchPathsEnvVarName),
+                    SparkFiles.GetRootDirectory()
                 }.Where(s => !string.IsNullOrWhiteSpace(s)));
 
             if (!string.IsNullOrEmpty(assemblySearchPath))


### PR DESCRIPTION
Support [SparkFiles.scala](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkFiles.scala) . This is useful in determining the path of the files added through `SparkContext.addFile()`