### PR TITLE
Speed up Delta tests

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         public DeltaFixture()
         {
             Environment.SetEnvironmentVariable(
-                SparkFixture.EnvironmentVariableNames.Packages,
-                "io.delta:delta-core_2.11:0.3.0");
-
+                SparkFixture.EnvironmentVariableNames.ExtraSparkSubmitArgs,
+                "--packages io.delta:delta-core_2.11:0.3.0 " +
+                "--conf spark.databricks.delta.snapshotPartitions=2 " +
+                "--conf spark.sql.sources.parallelPartitionDiscovery.parallelism=5");
             SparkFixture = new SparkFixture();
         }
     }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             Column col = Column("col1");
             Assert.IsType<Column>(col);
-            
+
             Assert.IsType<Column>(Col("col2"));
             Assert.IsType<Column>(Lit(1));
             Assert.IsType<Column>(Lit("some column"));
@@ -201,8 +201,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Assert.IsType<Column>(Map(col, col));
 
             DataFrame df = _spark
-               .Read()
-               .Json($"{TestEnvironment.ResourceDirectory}people.json");
+                .Read()
+                .Json($"{TestEnvironment.ResourceDirectory}people.json");
 
             Assert.IsType<DataFrame>(Broadcast(df));
 
@@ -644,9 +644,9 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Udf<int, int>((arg) => arg);
             Udf<long, long>((arg) => arg);
             Udf<short, short>((arg) => arg);
-            
+
             // Test array type.
-            Udf<string, string[]>((arg) => new[] { arg } );
+            Udf<string, string[]>((arg) => new[] { arg });
             Udf<string, IEnumerable<string>>((arg) => new[] { arg });
             Udf<string, IEnumerable<IEnumerable<string>>>((arg) => new[] { new[] { arg } });
 

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.E2ETest
         public class EnvironmentVariableNames
         {
             /// <summary>
-            /// This environment variable specifies extra params passed to spark-submit.
+            /// This environment variable specifies extra args passed to spark-submit.
             /// </summary>
             public const string ExtraSparkSubmitArgs =
                 "DOTNET_SPARKFIXTURE_EXTRA_SPARK_SUBMIT_ARGS";


### PR DESCRIPTION
Currently, Delta tests take about 8.5 minutes per supported Spark versions. This change reduces them to about 40 seconds. The configuration to reduce the time is taken from https://github.com/delta-io/delta/pull/113.
