### PR TITLE
Update SparkFiles to be callable by the Worker.

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
@@ -14,12 +14,15 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestAssemblySearchPathResolver()
         {
+            string sparkFilesDir = "sparkFilesDir";
+            SparkFiles.SetRootDirectory(sparkFilesDir);
+
             string curDir = Directory.GetCurrentDirectory();
             string appDir = AppDomain.CurrentDomain.BaseDirectory;
 
             // Test the default scenario.
             string[] searchPaths = AssemblySearchPathResolver.GetAssemblySearchPaths();
-            Assert.Equal(new[] { curDir, appDir }, searchPaths);
+            Assert.Equal(new[] { sparkFilesDir, curDir, appDir }, searchPaths);
 
             // Test the case where DOTNET_ASSEMBLY_SEARCH_PATHS is defined.
             char sep = Path.PathSeparator;
@@ -34,6 +37,7 @@ namespace Microsoft.Spark.UnitTest
                     "mydir2",
                     Path.Combine(curDir, $".{sep}mydir3"),
                     Path.Combine(curDir, $".{sep}mydir4"),
+                    sparkFilesDir,
                     curDir,
                     appDir },
                 searchPaths);

--- a/src/csharp/Microsoft.Spark.UnitTest/CommandSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/CommandSerDeTests.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Spark.UnitTest
 {
     public class CommandSerDeTests
     {
+        public CommandSerDeTests()
+        {
+            SparkFiles.SetRootDirectory(string.Empty);
+        }
+
         [Fact]
         public void TestCommandSerDeForSqlPickling()
         {

--- a/src/csharp/Microsoft.Spark.UnitTest/CommandSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/CommandSerDeTests.cs
@@ -13,13 +13,9 @@ using static Microsoft.Spark.UnitTest.TestUtils.ArrowTestUtils;
 
 namespace Microsoft.Spark.UnitTest
 {
+    [Collection("Spark Unit Tests")]
     public class CommandSerDeTests
     {
-        public CommandSerDeTests()
-        {
-            SparkFiles.SetRootDirectory(string.Empty);
-        }
-
         [Fact]
         public void TestCommandSerDeForSqlPickling()
         {

--- a/src/csharp/Microsoft.Spark.UnitTest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/SparkFixture.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Spark.Interop.Ipc;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    public sealed class SparkFixture : IDisposable
+    {
+        internal Mock<IJvmBridge> MockJvm { get; private set; }
+
+        public SparkFixture()
+        {
+            SetupBasicMockJvm();
+            SetupSparkFiles();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private void SetupBasicMockJvm()
+        {
+            MockJvm = new Mock<IJvmBridge>();
+
+            MockJvm
+                .Setup(m => m.CallStaticJavaMethod(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+            MockJvm
+                .Setup(m => m.CallStaticJavaMethod(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<object>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+            MockJvm
+                .Setup(m => m.CallStaticJavaMethod(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+
+            MockJvm
+                .Setup(m => m.CallNonStaticJavaMethod(
+                    It.IsAny<JvmObjectReference>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+            MockJvm
+                .Setup(m => m.CallNonStaticJavaMethod(
+                    It.IsAny<JvmObjectReference>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<object>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+            MockJvm
+                .Setup(m => m.CallNonStaticJavaMethod(
+                    It.IsAny<JvmObjectReference>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+                .Returns(
+                    new JvmObjectReference("result", MockJvm.Object));
+        }
+
+        private void SetupSparkFiles()
+        {
+            MockJvm
+                .Setup(m => m.CallStaticJavaMethod(
+                    "org.apache.spark.SparkFiles",
+                    "getRootDirectory"))
+                .Returns(Path.Combine("Mock", "SparkFilesRootDirectory"));
+
+            SparkFiles.Init(MockJvm.Object);
+        }
+    }
+
+    [CollectionDefinition("Spark Unit Tests")]
+    public class SparkCollection : ICollectionFixture<SparkFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/Sql/ColumnTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Sql/ColumnTests.cs
@@ -12,71 +12,12 @@ using Xunit;
 
 namespace Microsoft.Spark.UnitTest
 {
-    public class ColumnTestsFixture : IDisposable
-    {
-        internal Mock<IJvmBridge> MockJvm { get; }
-
-        public ColumnTestsFixture()
-        {
-            MockJvm = new Mock<IJvmBridge>();
-
-            MockJvm
-                .Setup(m => m.CallStaticJavaMethod(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-            MockJvm
-                .Setup(m => m.CallStaticJavaMethod(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object>(),
-                    It.IsAny<object>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-            MockJvm
-                .Setup(m => m.CallStaticJavaMethod(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object[]>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-
-            MockJvm
-                .Setup(m => m.CallNonStaticJavaMethod(
-                    It.IsAny<JvmObjectReference>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-            MockJvm
-                .Setup(m => m.CallNonStaticJavaMethod(
-                    It.IsAny<JvmObjectReference>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object>(),
-                    It.IsAny<object>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-            MockJvm
-                .Setup(m => m.CallNonStaticJavaMethod(
-                    It.IsAny<JvmObjectReference>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object[]>()))
-                .Returns(
-                    new JvmObjectReference("result", MockJvm.Object));
-        }
-
-        public void Dispose()
-        {
-        }
-    }
-
-    public class ColumnTests : IClassFixture<ColumnTestsFixture>
+    [Collection("Spark Unit Tests")]
+    public class ColumnTests
     {
         private readonly Mock<IJvmBridge> _mockJvm;
 
-        public ColumnTests(ColumnTestsFixture fixture)
+        public ColumnTests(SparkFixture fixture)
         {
             _mockJvm = fixture.MockJvm;
         }

--- a/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Spark.UnitTest
 {
     public class UdfSerDeTests
     {
+        public UdfSerDeTests()
+        {
+            SparkFiles.SetRootDirectory(string.Empty);
+        }
+
         [Serializable]
         private class TestClass
         {

--- a/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
@@ -11,13 +11,9 @@ using Xunit;
 
 namespace Microsoft.Spark.UnitTest
 {
+    [Collection("Spark Unit Tests")]
     public class UdfSerDeTests
     {
-        public UdfSerDeTests()
-        {
-            SparkFiles.SetRootDirectory(string.Empty);
-        }
-
         [Serializable]
         private class TestClass
         {

--- a/src/csharp/Microsoft.Spark.Worker/Processor/PayloadProcessor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Processor/PayloadProcessor.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Spark.Worker.Processor
             payload.Version = SerDe.ReadString(stream);
             payload.TaskContext = new TaskContextProcessor(_version).Process(stream);
             payload.SparkFilesDir = SerDe.ReadString(stream);
+            SparkFiles.SetRootDirectory(payload.SparkFilesDir);
 
             if (Utils.SettingUtils.IsDatabricks)
             {

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -2,33 +2,62 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
 using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Ipc;
 
 namespace Microsoft.Spark
 {
     /// <summary>
-    /// Resolves paths to files added through `SparkContext.addFile()`.
+    /// Resolves paths to files added through
+    /// <c>SparkContext.addFile()</c>.
     /// </summary>
     public static class SparkFiles
     {
         private static IJvmBridge Jvm { get; } = SparkEnvironment.JvmBridge;
         private static readonly string s_sparkFilesClassName = "org.apache.spark.SparkFiles";
 
-        /// <summary>
-        /// Get the absolute path of a file added through `SparkContext.addFile()`.
-        /// </summary>
-        /// <param name="fileName">The name of the file added through `SparkContext.addFile()`
-        /// </param>
-        /// <returns>The absolute path of the file.</returns>
-        public static string Get(string fileName) =>
-            (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "get", fileName);
+        [ThreadStatic]
+        private static string s_rootDirectory;
+
+        [ThreadStatic]
+        private static bool s_isWorker;
 
         /// <summary>
-        /// Get the root directory that contains files added through `SparkContext.addFile()`.
+        /// Get the absolute path of a file added through
+        /// <c>SparkContext.addFile()</c>.
+        /// </summary>
+        /// <param name="fileName">The name of the file added
+        /// through <c>SparkContext.addFile()</c>
+        /// </param>
+        /// <returns>The absolute path of the file.</returns>
+        public static string Get(string fileName) => Path.Combine(GetRootDirectory(), fileName);
+
+        /// <summary>
+        /// Get the root directory that contains files added
+        /// through <c>SparkContext.addFile()</c>.
         /// </summary>
         /// <returns>The root directory that contains the files.</returns>
         public static string GetRootDirectory() =>
+            s_isWorker ?
+            s_rootDirectory :
             (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "getRootDirectory");
+
+        /// <summary>
+        /// Set the root directory that contains files added
+        /// through <c>SparkContext.addFile()</c>
+        /// <remarks>
+        /// This should only be called from the Microsoft.Spark.Worker.
+        /// </remarks>
+        /// </summary>
+        /// <param name="path">Root directory that contains files added
+        /// through <c>SparkContext.addFile()</c>.
+        /// </param>
+        internal static void SetRootDirectory(string path)
+        {
+            s_isWorker = true;
+            s_rootDirectory = path;
+        }
     }
 }

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Spark
     /// </summary>
     public static class SparkFiles
     {
-        private static IJvmBridge Jvm { get; } = SparkEnvironment.JvmBridge;
+        private static IJvmBridge s_jvm;
+        private static IJvmBridge Jvm => s_jvm ?? SparkEnvironment.JvmBridge;
+
         private static readonly string s_sparkFilesClassName = "org.apache.spark.SparkFiles";
 
         [ThreadStatic]
@@ -22,6 +24,11 @@ namespace Microsoft.Spark
 
         [ThreadStatic]
         private static bool s_isRunningOnWorker;
+
+        internal static void Init(IJvmBridge jvm)
+        {
+            s_jvm = jvm;
+        }
 
         /// <summary>
         /// Get the absolute path of a file added through <c>SparkContext.AddFile()</c>.

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -22,11 +22,10 @@ namespace Microsoft.Spark
         private static string s_rootDirectory;
 
         [ThreadStatic]
-        private static bool s_isWorker;
+        private static bool s_isRunningOnWorker;
 
         /// <summary>
-        /// Get the absolute path of a file added through
-        /// <c>SparkContext.addFile()</c>.
+        /// Get the absolute path of a file added through <c>SparkContext.addFile()</c>.
         /// </summary>
         /// <param name="fileName">The name of the file added
         /// through <c>SparkContext.addFile()</c>
@@ -35,18 +34,16 @@ namespace Microsoft.Spark
         public static string Get(string fileName) => Path.Combine(GetRootDirectory(), fileName);
 
         /// <summary>
-        /// Get the root directory that contains files added
-        /// through <c>SparkContext.addFile()</c>.
+        /// Get the root directory that contains files added through <c>SparkContext.addFile()</c>.
         /// </summary>
         /// <returns>The root directory that contains the files.</returns>
         public static string GetRootDirectory() =>
-            s_isWorker ?
+            s_isRunningOnWorker ?
             s_rootDirectory :
             (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "getRootDirectory");
 
         /// <summary>
-        /// Set the root directory that contains files added
-        /// through <c>SparkContext.addFile()</c>
+        /// Set the root directory that contains files added through <c>SparkContext.addFile()</c>.
         /// <remarks>
         /// This should only be called from the Microsoft.Spark.Worker.
         /// </remarks>
@@ -56,7 +53,7 @@ namespace Microsoft.Spark
         /// </param>
         internal static void SetRootDirectory(string path)
         {
-            s_isWorker = true;
+            s_isRunningOnWorker = true;
             s_rootDirectory = path;
         }
     }

--- a/src/csharp/Microsoft.Spark/SparkFiles.cs
+++ b/src/csharp/Microsoft.Spark/SparkFiles.cs
@@ -10,8 +10,7 @@ using Microsoft.Spark.Interop.Ipc;
 namespace Microsoft.Spark
 {
     /// <summary>
-    /// Resolves paths to files added through
-    /// <c>SparkContext.addFile()</c>.
+    /// Resolves paths to files added through <c>SparkContext.AddFile()</c>.
     /// </summary>
     public static class SparkFiles
     {
@@ -25,16 +24,16 @@ namespace Microsoft.Spark
         private static bool s_isRunningOnWorker;
 
         /// <summary>
-        /// Get the absolute path of a file added through <c>SparkContext.addFile()</c>.
+        /// Get the absolute path of a file added through <c>SparkContext.AddFile()</c>.
         /// </summary>
         /// <param name="fileName">The name of the file added
-        /// through <c>SparkContext.addFile()</c>
+        /// through <c>SparkContext.AddFile()</c>.
         /// </param>
         /// <returns>The absolute path of the file.</returns>
         public static string Get(string fileName) => Path.Combine(GetRootDirectory(), fileName);
 
         /// <summary>
-        /// Get the root directory that contains files added through <c>SparkContext.addFile()</c>.
+        /// Get the root directory that contains files added through <c>SparkContext.AddFile()</c>.
         /// </summary>
         /// <returns>The root directory that contains the files.</returns>
         public static string GetRootDirectory() =>
@@ -43,13 +42,13 @@ namespace Microsoft.Spark
             (string)Jvm.CallStaticJavaMethod(s_sparkFilesClassName, "getRootDirectory");
 
         /// <summary>
-        /// Set the root directory that contains files added through <c>SparkContext.addFile()</c>.
+        /// Set the root directory that contains files added through <c>SparkContext.AddFile()</c>.
         /// <remarks>
         /// This should only be called from the Microsoft.Spark.Worker.
         /// </remarks>
         /// </summary>
         /// <param name="path">Root directory that contains files added
-        /// through <c>SparkContext.addFile()</c>.
+        /// through <c>SparkContext.AddFile()</c>.
         /// </param>
         internal static void SetRootDirectory(string path)
         {

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Spark.Utils
         /// precedence:
         /// 1) Comma-separated paths specified in DOTNET_ASSEMBLY_SEARCH_PATHS environment
         /// variable. Note that if a path starts with ".", the working directory will be prepended.
-        /// 2) The working directory.
-        /// 3) The directory of the application.
+        /// 2) The path of the files added through SparkContext.AddFile().
+        /// 3) The working directory.
+        /// 4) The directory of the application.
         /// </summary>
         /// <remarks>
         /// The reason that the working directory has higher precedence than the directory
@@ -52,6 +53,12 @@ namespace Microsoft.Spark.Utils
                         searchPaths.Add(trimmedSearchPath);
                     }
                 }
+            }
+
+            string sparkFilesPath = SparkFiles.GetRootDirectory();
+            if (!string.IsNullOrWhiteSpace(sparkFilesPath))
+            {
+                searchPaths.Add(sparkFilesPath);
             }
 
             searchPaths.Add(Directory.GetCurrentDirectory());

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Spark.Utils
         /// precedence:
         /// 1) Comma-separated paths specified in DOTNET_ASSEMBLY_SEARCH_PATHS environment
         /// variable. Note that if a path starts with ".", the working directory will be prepended.
-        /// 2) The path of the files added through SparkContext.AddFile().
+        /// 2) The path of the files added through <c>SparkContext.AddFile()</c>.
         /// 3) The working directory.
         /// 4) The directory of the application.
         /// </summary>

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -167,14 +167,8 @@ namespace Microsoft.Spark.Utils
         private static IJvmObjectReferenceProvider CreateEnvVarsForPythonFunction(IJvmBridge jvm)
         {
             var environmentVars = new Hashtable(jvm);
-            string assemblySearchPath = string.Join(",",
-                new[]
-                {
-                    Environment.GetEnvironmentVariable(
-                        AssemblySearchPathResolver.AssemblySearchPathsEnvVarName),
-                    SparkFiles.GetRootDirectory()
-                }.Where(s => !string.IsNullOrWhiteSpace(s)));
-
+            string assemblySearchPath = Environment.GetEnvironmentVariable(
+                AssemblySearchPathResolver.AssemblySearchPathsEnvVarName);
             if (!string.IsNullOrEmpty(assemblySearchPath))
             {
                 environmentVars.Put(


### PR DESCRIPTION
The SparkFiles root path is sent to the Microsoft.Spark.Worker as part of its payload.  On the worker, use the payload to set and use this path as part of its assembly probing paths. 