### PR TITLE
DataStreamReader.Load(path) and E2E test for DeltaTable streaming

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -215,7 +215,11 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 table.Delete();
 
                 // Load the table as a streaming source.
-                Assert.IsType<DataFrame>(_spark.ReadStream().Format("delta").Option("path", path).Load());
+                Assert.IsType<DataFrame>(_spark
+                    .ReadStream()
+                    .Format("delta")
+                    .Option("path", path)
+                    .Load());
                 Assert.IsType<DataFrame>(_spark.ReadStream().Format("delta").Load(path));
             }
         }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -170,6 +170,9 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 table.Delete("id > 10");
                 table.Delete(Functions.Expr("id > 5"));
                 table.Delete();
+
+                // Load the table as a streaming source.
+                Assert.IsType<DataFrame>(_spark.ReadStream().Format("delta").Load(path));
             }
         }
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
 
                 // Write [5,6,7,8,9] to the source.
                 _spark.Range(5, 10).Write().Format("delta").Mode("append").Save(sourcePath);
-                Thread.Sleep(TimeSpan.FromSeconds(5));
 
                 // Finally, validate that the new data made its way to the sink.
+                stream.Stop();
                 ValidateDataFrame(Enumerable.Range(0, 10), sink.ToDF());
             }
         }

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
@@ -113,6 +113,15 @@ namespace Microsoft.Spark.Sql.Streaming
         public DataFrame Load() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
 
         /// <summary>
+        /// Loads input in as a <see cref="DataFrame"/>, for data streams that read
+        /// from some path. 
+        /// </summary>
+        /// <param name="path">File path for streaming</param>
+        /// <returns>DataFrame object</returns>
+        public DataFrame Load(string path) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", path));
+
+        /// <summary>
         /// Loads a JSON file stream and returns the results as a <see cref="DataFrame"/>.
         /// </summary>
         /// <param name="path">File path for streaming</param>


### PR DESCRIPTION
This PR does two things:

1. Adds an overload to `DataStreamReader.Load()` that accepts a `path` parameter.  This new overload matches the Spark API documented [here](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/streaming/DataStreamReader.html#load-java.lang.String-).  Without this overload, DeltaTables can only be read as a stream source by calling `.Option("path", path).Load()` which is verbose and does not match the Scala syntax found in the Delta documentation found [here](https://docs.delta.io/latest/delta-streaming.html#delta-table-as-a-stream-source).
2. Adds an E2E test for basic `DeltaTable` streaming functionality.
