### PR TITLE
Support for new Delta v0.4.0 APIs

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Extensions.Delta.Tables;
 using Microsoft.Spark.Sql;

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -321,9 +321,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         /// </summary>
         /// <param name="expectedValues"></param>
         /// <param name="dataFrame"></param>
-        private void ValidateRangeDataFrame(
-            IEnumerable<int> expectedValues,
-            DataFrame dataFrame)
+        private void ValidateRangeDataFrame(IEnumerable<int> expectedValues, DataFrame dataFrame)
         {
             Assert.Equal(expectedValues.Count(), dataFrame.Count());
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -179,7 +179,10 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 Functions.Expr($"(`id` + 1) AS `{partitionColumnName}`"));
 
             // Run the same test on the different overloads of DeltaTable.ConvertToDelta().
-            void testWrapper(DataFrame dataFrame, Func<string, DeltaTable> convertToDelta, string partitionColumn = null)
+            void testWrapper(
+                DataFrame dataFrame,
+                Func<string, DeltaTable> convertToDelta,
+                string partitionColumn = null)
             {
                 using (var tempDirectory = new TemporaryDirectory())
                 {
@@ -206,7 +209,10 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             testWrapper(data, identifier => DeltaTable.ConvertToDelta(_spark, identifier));
             testWrapper(
                 data.Repartition(Functions.Col(partitionColumnName)),
-                identifier => DeltaTable.ConvertToDelta(_spark, identifier, $"{partitionColumnName} bigint"),
+                identifier => DeltaTable.ConvertToDelta(
+                    _spark,
+                    identifier,
+                    $"{partitionColumnName} bigint"),
                 partitionColumnName);
             // TODO: Test with StructType partition schema once StructType is supported.
         }
@@ -302,7 +308,10 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                     .PartitionBy("id")
                     .Mode(SaveMode.Overwrite)
                     .Parquet(path);
-                Assert.IsType<DeltaTable>(DeltaTable.ConvertToDelta(_spark, parquetIdentifier, "id bigint"));
+                Assert.IsType<DeltaTable>(DeltaTable.ConvertToDelta(
+                    _spark,
+                    parquetIdentifier,
+                    "id bigint"));
                 // TODO: Test with StructType partition schema once StructType is supported.
             }
         }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 table = Assert.IsType<DeltaTable>(DeltaTable.ForPath(_spark, path));
 
                 Assert.IsType<DeltaTable>(table.As("oldTable"));
+                Assert.IsType<DeltaTable>(table.Alias("oldTable"));
                 Assert.IsType<DataFrame>(table.History());
                 Assert.IsType<DataFrame>(table.History(200));
                 Assert.IsType<DataFrame>(table.ToDF());

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -137,12 +137,12 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 Functions.Expr($"(`id` + 1) AS `{partitionColumnName}`"));
 
             // Run the same test on the different overloads of DeltaTable.ConvertToDelta().
-            void testWrapper(DataFrame data, Func<string, DeltaTable> convertToDelta, string partitionColumn = null)
+            void testWrapper(DataFrame dataFrame, Func<string, DeltaTable> convertToDelta, string partitionColumn = null)
             {
                 using (var tempDirectory = new TemporaryDirectory())
                 {
                     string path = Path.Combine(tempDirectory.Path, "parquet-data");
-                    DataFrameWriter dataWriter = data.Write();
+                    DataFrameWriter dataWriter = dataFrame.Write();
 
                     if (!string.IsNullOrEmpty(partitionColumn))
                     {
@@ -253,6 +253,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                     .Mode(SaveMode.Overwrite)
                     .Parquet(path);
                 Assert.IsType<DeltaTable>(DeltaTable.ConvertToDelta(_spark, parquetIdentifier, "id bigint"));
+                // TODO: Test with StructType partition schema once StructType is supported.
             }
         }
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -103,6 +103,29 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         }
 
         /// <summary>
+        /// Test <c>DeltaTable.IsDeltaTable()</c> API.
+        /// </summary>
+        [SkipIfSparkVersionIsLessThan(Versions.V2_4_2)]
+        public void TestIsDeltaTable()
+        {
+            using (var tempDirectory = new TemporaryDirectory())
+            {
+                // Save the same data to a DeltaTable and to Parquet.
+                DataFrame data = _spark.Range(0, 5);
+                string parquetPath = Path.Combine(tempDirectory.Path, "parquet-data");
+                data.Write().Parquet(parquetPath);
+                string deltaTablePath = Path.Combine(tempDirectory.Path, "delta-table");
+                data.Write().Format("delta").Save(deltaTablePath);
+
+                Assert.False(DeltaTable.IsDeltaTable(parquetPath));
+                Assert.False(DeltaTable.IsDeltaTable(_spark, parquetPath));
+
+                Assert.True(DeltaTable.IsDeltaTable(deltaTablePath));
+                Assert.True(DeltaTable.IsDeltaTable(_spark, deltaTablePath));
+            }
+        }
+
+        /// <summary>
         /// Test that methods return the expected signature.
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V2_4_2)]

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         }
 
         /// <summary>
-        /// 
+        /// Test <c>DeltaTable.ConvertToDelta()</c> API.
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V2_4_2)]
         public void TestConvertToDelta()

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 data.Write().Format("delta").Save(path);
 
                 // Validate that data contains the the sequence [0 ... 4].
-                ValidateDataFrame(Enumerable.Range(0, 5), data);
+                ValidateRangeDataFrame(Enumerable.Range(0, 5), data);
 
                 // Create a second iteration of the table.
                 data = _spark.Range(5, 10);
@@ -50,7 +50,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 var deltaTable = DeltaTable.ForPath(path);
 
                 // Validate that deltaTable contains the the sequence [5 ... 9].
-                ValidateDataFrame(Enumerable.Range(5, 5), deltaTable.ToDF());
+                ValidateRangeDataFrame(Enumerable.Range(5, 5), deltaTable.ToDF());
 
                 // Update every even value by adding 100 to it.
                 deltaTable.Update(
@@ -69,7 +69,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 // |106|
                 // |108|
                 // +---+
-                ValidateDataFrame(
+                ValidateRangeDataFrame(
                     new List<int>() { 5, 7, 9, 106, 108 },
                     deltaTable.ToDF());
 
@@ -84,7 +84,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 // |  7|
                 // |  9|
                 // +---+
-                ValidateDataFrame(new List<int>() { 5, 7, 9 }, deltaTable.ToDF());
+                ValidateRangeDataFrame(new List<int>() { 5, 7, 9 }, deltaTable.ToDF());
 
                 // Upsert (merge) new data.
                 DataFrame newData = _spark.Range(0, 20).As("newData").ToDF();
@@ -99,7 +99,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                     .Execute();
 
                 // Validate that the resulTable contains the the sequence [0 ... 19].
-                ValidateDataFrame(Enumerable.Range(0, 20), deltaTable.ToDF());
+                ValidateRangeDataFrame(Enumerable.Range(0, 20), deltaTable.ToDF());
             }
         }
 
@@ -133,14 +133,14 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
 
                 // Now read the sink DeltaTable and validate its content.
                 DeltaTable sink = DeltaTable.ForPath(sinkPath);
-                ValidateDataFrame(Enumerable.Range(0, 5), sink.ToDF());
+                ValidateRangeDataFrame(Enumerable.Range(0, 5), sink.ToDF());
 
                 // Write [5,6,7,8,9] to the source and trigger another stream batch.
                 _spark.Range(5, 10).Write().Format("delta").Mode("append").Save(sourcePath);
                 dataStreamWriter.Trigger(Trigger.Once()).Start(sinkPath).AwaitTermination();
 
                 // Finally, validate that the new data made its way to the sink.
-                ValidateDataFrame(Enumerable.Range(0, 10), sink.ToDF());
+                ValidateRangeDataFrame(Enumerable.Range(0, 10), sink.ToDF());
             }
         }
 
@@ -201,7 +201,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                     string identifier = $"parquet.`{path}`";
                     DeltaTable convertedDeltaTable = convertToDelta(identifier);
 
-                    ValidateDataFrame(Enumerable.Range(0, 5), convertedDeltaTable.ToDF());
+                    ValidateRangeDataFrame(Enumerable.Range(0, 5), convertedDeltaTable.ToDF());
                     Assert.True(DeltaTable.IsDeltaTable(path));
                 }
             }
@@ -317,11 +317,11 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         }
 
         /// <summary>
-        /// Validate that a tutorial DataFrame contains only the expected values.
+        /// Validate that a range DataFrame contains only the expected values.
         /// </summary>
         /// <param name="expectedValues"></param>
         /// <param name="dataFrame"></param>
-        private void ValidateDataFrame(
+        private void ValidateRangeDataFrame(
             IEnumerable<int> expectedValues,
             DataFrame dataFrame)
         {

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -141,6 +141,9 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 DeltaTable table = Assert.IsType<DeltaTable>(DeltaTable.ForPath(path));
                 table = Assert.IsType<DeltaTable>(DeltaTable.ForPath(_spark, path));
 
+                Assert.IsType<bool>(DeltaTable.IsDeltaTable(_spark, path));
+                Assert.IsType<bool>(DeltaTable.IsDeltaTable(path));
+
                 Assert.IsType<DeltaTable>(table.As("oldTable"));
                 Assert.IsType<DeltaTable>(table.Alias("oldTable"));
                 Assert.IsType<DataFrame>(table.History());

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// </summary>
     public class DeltaTable : IJvmObjectReferenceProvider
     {
-        private const string JvmClassName = "io.delta.tables.DeltaTable";
         private readonly JvmObjectReference _jvmObject;
+
+        private static readonly string s_deltaTableClassName = "io.delta.tables.DeltaTable";
 
         internal DeltaTable(JvmObjectReference jvmObject)
         {
@@ -60,7 +61,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
             StructType partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "convertToDelta",
                 spark,
                 identifier,
@@ -90,7 +91,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
             string partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "convertToDelta",
                 spark,
                 identifier,
@@ -115,7 +116,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "convertToDelta",
                 spark,
                 identifier));
@@ -132,7 +133,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ForPath(string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "forPath",
                 path));
 
@@ -146,7 +147,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ForPath(SparkSession sparkSession, string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "forPath",
                 sparkSession,
                 path));
@@ -165,7 +166,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(SparkSession sparkSession, string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "isDeltaTable",
                 sparkSession,
                 identifier);
@@ -187,7 +188,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                JvmClassName,
+                s_deltaTableClassName,
                 "isDeltaTable",
                 identifier);
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Apache.Arrow.Types;
 using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.Extensions.Delta.Tables
 {
@@ -43,7 +43,10 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// DeltaTable.ConvertToDelta(
         ///     spark,
         ///     "parquet.`/path`",
-        ///     new StructType(new List&lt;StructField&gt;(){new StructField("key1", LongType), new StructField("key2", StringType)}))
+        ///     var partitionSchema = new StructType(new List&lt;StructField&gt;() {
+        ///         new StructField("key1", new LongType()),
+        ///         new StructField("key2", new StringType())
+        ///     });
         /// </code>
         /// </summary>
         /// <param name="spark">The relevant session.</param>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// for maintaining older versions up to the given retention threshold. This method will
         /// return an empty DataFrame on successful completion.
         /// 
-        /// Note: This will use the default retention period of 7 hours.
+        /// Note: This will use the default retention period of 7 days.
         /// </summary>
         /// <returns>Vacuumed DataFrame.</returns>
         public DataFrame Vacuum() =>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -35,21 +35,21 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// of that table.
         /// 
         /// Note: Any changes to the table during the conversion process may not result in a
-        /// consistent state at the end of the conversion.Users should stop any changes to the
+        /// consistent state at the end of the conversion. Users should stop any changes to the
         /// table before the conversion is started.
         /// 
         /// An example usage would be
         /// <code>
-        /// io.delta.tables.DeltaTable.convertToDelta(
+        /// DeltaTable.ConvertToDelta(
         ///     spark,
         ///     "parquet.`/path`",
-        ///     new StructType().add(StructField("key1", LongType)).add(StructField("key2", StringType)))
+        ///     new StructType(new List&lt;StructField&gt;(){new StructField("key1", LongType), new StructField("key2", StringType)}))
         /// </code>
         /// </summary>
-        /// <param name="spark"></param>
-        /// <param name="identifier"></param>
-        /// <param name="partitionSchema"></param>
-        /// <returns></returns>
+        /// <param name="spark">The relevant session.</param>
+        /// <param name="identifier">String used to identify the parquet table.</param>
+        /// <param name="partitionSchema">Struct representing the partition schema.</param>
+        /// <returns>The converted DeltaTable.</returns>
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, StructType partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -59,6 +59,24 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
                 identifier,
                 partitionSchema));
 
+        /// <summary>
+        /// Create a DeltaTable from the given parquet table and partition schema.
+        /// Takes an existing parquet table and constructs a delta transaction log in the base path of
+        /// that table.
+        ///
+        /// Note: Any changes to the table during the conversion process may not result in a consistent
+        /// state at the end of the conversion. Users should stop any changes to the table before the
+        /// conversion is started.
+        ///
+        /// An example usage would be
+        /// <code>
+        /// DeltaTable.ConvertToDelta(spark, "parquet.`/path`", "key1 long, key2 string")
+        /// </code>
+        /// </summary>
+        /// <param name="spark">The relevant session.</param>
+        /// <param name="identifier">String used to identify the parquet table.</param>
+        /// <param name="partitionSchema">String representing the partition schema.</param>
+        /// <returns>The converted DeltaTable.</returns>
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, string partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -68,6 +86,22 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
                 identifier,
                 partitionSchema));
 
+        /// <summary>
+        /// Create a DeltaTable from the given parquet table. Takes an existing parquet table and
+        /// constructs a delta transaction log in the base path of the table.
+        ///
+        /// Note: Any changes to the table during the conversion process may not result in a consistent
+        /// state at the end of the conversion. Users should stop any changes to the table before the
+        /// conversion is started.
+        ///
+        /// An example would be
+        /// <code>
+        /// DeltaTable.ConvertToDelta(spark, "parquet.`/path`")
+        /// </code>
+        /// </summary>
+        /// <param name="spark">The relevant session.</param>
+        /// <param name="identifier">String used to identify the parquet table.</param>
+        /// <returns>The converted DeltaTable.</returns>
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -108,11 +142,17 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
                 path));
 
         /// <summary>
-        /// 
+        /// Check if the provided <c>identifier</c> string, in this case a file path,
+        /// is the root of a Delta table using the given SparkSession.
+        ///
+        /// An example would be
+        /// <code>
+        ///   DeltaTable.IsDeltaTable(spark, "path/to/table")
+        /// </code>
         /// </summary>
-        /// <param name="sparkSession"></param>
-        /// <param name="identifier"></param>
-        /// <returns></returns>
+        /// <param name="sparkSession">The relevant session.</param>
+        /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
+        /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(SparkSession sparkSession, string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 "io.delta.tables.DeltaTable",
@@ -121,10 +161,20 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
                 identifier);
 
         /// <summary>
-        /// 
+        /// Check if the provided <c>identifier</c> string, in this case a file path,
+        /// is the root of a Delta table.
+        ///
+        /// Note: This uses the active SparkSession in the current thread to search for the table. Hence,
+        /// this throws error if active SparkSession has not been set, that is,
+        /// <c>SparkSession.GetActiveSession()</c> is empty.
+        ///
+        /// An example would be
+        /// <code>
+        ///   DeltaTable.IsDeltaTable(spark, "/path/to/table")
+        /// </code>
         /// </summary>
-        /// <param name="identifier"></param>
-        /// <returns></returns>
+        /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
+        /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 "io.delta.tables.DeltaTable",

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -69,6 +69,15 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
             new DeltaTable((JvmObjectReference)_jvmObject.Invoke("as", alias));
 
         /// <summary>
+        /// Apply an alias to the DeltaTable. This is similar to <c>Dataset.as(alias)</c>
+        /// or SQL <c>tableName AS alias</c>.
+        /// </summary>
+        /// <param name="alias">The table alias.</param>
+        /// <returns>Aliased DeltaTable.</returns>
+        public DeltaTable Alias(string alias) =>
+            new DeltaTable((JvmObjectReference)_jvmObject.Invoke("alias", alias));
+
+        /// <summary>
         /// Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
         /// </summary>
         /// <returns>DataFrame representation of Delta table.</returns>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">Struct representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
-        public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, StructType partitionSchema) =>
+        public static DeltaTable ConvertToDelta(
+            SparkSession spark,
+            string identifier,
+            StructType partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 JvmClassName,
@@ -65,12 +68,12 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
 
         /// <summary>
         /// Create a DeltaTable from the given parquet table and partition schema.
-        /// Takes an existing parquet table and constructs a delta transaction log in the base path of
-        /// that table.
+        /// Takes an existing parquet table and constructs a delta transaction log in the base path
+        /// of that table.
         ///
-        /// Note: Any changes to the table during the conversion process may not result in a consistent
-        /// state at the end of the conversion. Users should stop any changes to the table before the
-        /// conversion is started.
+        /// Note: Any changes to the table during the conversion process may not result in a
+        /// consistent state at the end of the conversion. Users should stop any changes to the
+        /// table before the conversion is started.
         ///
         /// An example usage would be
         /// <code>
@@ -81,7 +84,10 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">String representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
-        public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, string partitionSchema) =>
+        public static DeltaTable ConvertToDelta(
+            SparkSession spark,
+            string identifier,
+            string partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 JvmClassName,
@@ -94,9 +100,9 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Create a DeltaTable from the given parquet table. Takes an existing parquet table and
         /// constructs a delta transaction log in the base path of the table.
         ///
-        /// Note: Any changes to the table during the conversion process may not result in a consistent
-        /// state at the end of the conversion. Users should stop any changes to the table before the
-        /// conversion is started.
+        /// Note: Any changes to the table during the conversion process may not result in a
+        /// consistent state at the end of the conversion. Users should stop any changes to the
+        /// table before the conversion is started.
         ///
         /// An example would be
         /// <code>
@@ -168,8 +174,8 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Check if the provided <c>identifier</c> string, in this case a file path,
         /// is the root of a Delta table.
         ///
-        /// Note: This uses the active SparkSession in the current thread to search for the table. Hence,
-        /// this throws error if active SparkSession has not been set, that is,
+        /// Note: This uses the active SparkSession in the current thread to search for the table.
+        /// Hence, this throws error if active SparkSession has not been set, that is,
         /// <c>SparkSession.GetActiveSession()</c> is empty.
         ///
         /// An example would be

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// </summary>
     public class DeltaTable : IJvmObjectReferenceProvider
     {
+        private const string JvmClassName = "io.delta.tables.DeltaTable";
         private readonly JvmObjectReference _jvmObject;
 
         internal DeltaTable(JvmObjectReference jvmObject)
@@ -56,7 +57,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, StructType partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "convertToDelta",
                 spark,
                 identifier,
@@ -83,7 +84,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier, string partitionSchema) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "convertToDelta",
                 spark,
                 identifier,
@@ -108,7 +109,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "convertToDelta",
                 spark,
                 identifier));
@@ -125,7 +126,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ForPath(string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "forPath",
                 path));
 
@@ -139,7 +140,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         public static DeltaTable ForPath(SparkSession sparkSession, string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "forPath",
                 sparkSession,
                 path));
@@ -158,7 +159,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(SparkSession sparkSession, string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "isDeltaTable",
                 sparkSession,
                 identifier);
@@ -180,7 +181,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>True if the table is a DeltaTable.</returns>
         public static bool IsDeltaTable(string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                "io.delta.tables.DeltaTable",
+                JvmClassName,
                 "isDeltaTable",
                 identifier);
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -35,42 +35,6 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Create a DeltaTable from the given parquet table and partition schema.
         /// Takes an existing parquet table and constructs a delta transaction log in the base path
         /// of that table.
-        /// 
-        /// Note: Any changes to the table during the conversion process may not result in a
-        /// consistent state at the end of the conversion. Users should stop any changes to the
-        /// table before the conversion is started.
-        /// 
-        /// An example usage would be
-        /// <code>
-        /// DeltaTable.ConvertToDelta(
-        ///     spark,
-        ///     "parquet.`/path`",
-        ///     var partitionSchema = new StructType(new List&lt;StructField&gt;() {
-        ///         new StructField("key1", new LongType()),
-        ///         new StructField("key2", new StringType())
-        ///     });
-        /// </code>
-        /// </summary>
-        /// <param name="spark">The relevant session.</param>
-        /// <param name="identifier">String used to identify the parquet table.</param>
-        /// <param name="partitionSchema">Struct representing the partition schema.</param>
-        /// <returns>The converted DeltaTable.</returns>
-        public static DeltaTable ConvertToDelta(
-            SparkSession spark,
-            string identifier,
-            StructType partitionSchema) =>
-            new DeltaTable(
-                (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
-                s_deltaTableClassName,
-                "convertToDelta",
-                spark,
-                identifier,
-                partitionSchema));
-
-        /// <summary>
-        /// Create a DeltaTable from the given parquet table and partition schema.
-        /// Takes an existing parquet table and constructs a delta transaction log in the base path
-        /// of that table.
         ///
         /// Note: Any changes to the table during the conversion process may not result in a
         /// consistent state at the end of the conversion. Users should stop any changes to the


### PR DESCRIPTION
This PR adds full support for new Delta v0.4.0 APIs.

The new APIs are:

* `DeltaTable.ConvertToDelta()`, which does an in-place conversion from Parquet data to DeltaTable.
* `DeltaTable.IsDeltaTable()`, which checks whether or not some data in storage is a DeltaTable.
* `DeltaTable.Alias()`, which is similar to `DeltaTable.As()`.