### PR TITLE
[Scala] microsoft-spark-3.0.x project to build against spark-3.0.0-SNAPSHOT

### DIFF
--- a/src/scala/microsoft-spark-3.0.x/pom.xml
+++ b/src/scala/microsoft-spark-3.0.x/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.microsoft.scala</groupId>
     <artifactId>microsoft-spark</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
   </parent>
   <artifactId>microsoft-spark-3.0.x</artifactId>
   <inceptionYear>2019</inceptionYear>

--- a/src/scala/microsoft-spark-3.0.x/pom.xml
+++ b/src/scala/microsoft-spark-3.0.x/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.scala</groupId>
+    <artifactId>microsoft-spark</artifactId>
+    <version>0.5.0</version>
+  </parent>
+  <artifactId>microsoft-spark-3.0.x</artifactId>
+  <inceptionYear>2019</inceptionYear>
+  <properties>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.12.8</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>3.0.0-SNAPSHOT</spark.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.specs</groupId>
+      <artifactId>specs</artifactId>
+      <version>1.2.5</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <version>2.15.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+          <args>
+            <arg>-target:jvm-1.8</arg>
+            <arg>-deprecation</arg>
+            <arg>-feature</arg>
+          </args>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>Apache Spark snapshot repository</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+</project>

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.api.dotnet
+
+import java.io.DataOutputStream
+import java.net.{InetSocketAddress, Socket}
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import io.netty.bootstrap.ServerBootstrap
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder
+import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
+import org.apache.spark.internal.Logging
+
+/**
+ * Netty server that invokes JVM calls based upon receiving messages from .NET.
+ * The implementation mirrors the RBackend.
+ *
+ */
+class DotnetBackend extends Logging {
+  self => // for accessing the this reference in inner class(ChannelInitializer)
+  private[this] var channelFuture: ChannelFuture = _
+  private[this] var bootstrap: ServerBootstrap = _
+  private[this] var bossGroup: EventLoopGroup = _
+
+  def init(portNumber: Int): Int = {
+    // need at least 3 threads, use 10 here for safety
+    bossGroup = new NioEventLoopGroup(10)
+    val workerGroup = bossGroup
+
+    bootstrap = new ServerBootstrap()
+      .group(bossGroup, workerGroup)
+      .channel(classOf[NioServerSocketChannel])
+
+    bootstrap.childHandler(new ChannelInitializer[SocketChannel]() {
+      def initChannel(ch: SocketChannel): Unit = {
+        ch.pipeline()
+          .addLast("encoder", new ByteArrayEncoder())
+          .addLast(
+            "frameDecoder",
+            // maxFrameLength = 2G
+            // lengthFieldOffset = 0
+            // lengthFieldLength = 4
+            // lengthAdjustment = 0
+            // initialBytesToStrip = 4, i.e.  strip out the length field itself
+            // new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+            new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+          .addLast("decoder", new ByteArrayDecoder())
+          .addLast("handler", new DotnetBackendHandler(self))
+      }
+    })
+
+    channelFuture = bootstrap.bind(new InetSocketAddress("localhost", portNumber))
+    channelFuture.syncUninterruptibly()
+    channelFuture.channel().localAddress().asInstanceOf[InetSocketAddress].getPort
+  }
+
+  def run(): Unit = {
+    channelFuture.channel.closeFuture().syncUninterruptibly()
+  }
+
+  def close(): Unit = {
+    if (channelFuture != null) {
+      // close is a local operation and should finish within milliseconds; timeout just to be safe
+      channelFuture.channel().close().awaitUninterruptibly(10, TimeUnit.SECONDS)
+      channelFuture = null
+    }
+    if (bootstrap != null && bootstrap.config().group() != null) {
+      bootstrap.config().group().shutdownGracefully()
+    }
+    if (bootstrap != null && bootstrap.config().childGroup() != null) {
+      bootstrap.config().childGroup().shutdownGracefully()
+    }
+    bootstrap = null
+
+    // Send close to .NET callback server.
+    logInfo("Requesting to close all call back sockets")
+    var socket: Socket = null
+    do {
+      socket = DotnetBackend.callbackSockets.poll()
+      if (socket != null) {
+        try {
+          val dos = new DataOutputStream(socket.getOutputStream)
+          SerDe.writeString(dos, "close")
+          socket.close()
+          socket = null
+        } catch {
+          case e: Exception => logError("Exception when closing socket: ", e)
+        }
+      }
+    } while (socket != null)
+    DotnetBackend.callbackSocketShutdown = true
+  }
+}
+
+object DotnetBackend {
+  // Channels to callback server.
+  private[spark] val callbackSockets: BlockingQueue[Socket] = new LinkedBlockingQueue[Socket]()
+  @volatile private[spark] var callbackPort: Int = 0
+
+  // flag to denote whether the callback socket is shutdown explicitly
+  @volatile private[spark] var callbackSocketShutdown: Boolean = false
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.api.dotnet
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+import java.net.Socket
+
+import io.netty.channel.{ChannelHandlerContext, SimpleChannelInboundHandler}
+import org.apache.spark.api.dotnet.SerDe._
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
+
+import scala.collection.mutable.HashMap
+import scala.language.existentials
+
+/**
+ * Handler for DotnetBackend.
+ * This implementation is similar to RBackendHandler.
+ */
+class DotnetBackendHandler(server: DotnetBackend)
+    extends SimpleChannelInboundHandler[Array[Byte]]
+    with Logging {
+
+  override def channelRead0(ctx: ChannelHandlerContext, msg: Array[Byte]): Unit = {
+    val reply = handleBackendRequest(msg)
+    ctx.write(reply)
+  }
+
+  override def channelReadComplete(ctx: ChannelHandlerContext): Unit = {
+    ctx.flush()
+  }
+
+  def handleBackendRequest(msg: Array[Byte]): Array[Byte] = {
+    val bis = new ByteArrayInputStream(msg)
+    val dis = new DataInputStream(bis)
+
+    val bos = new ByteArrayOutputStream()
+    val dos = new DataOutputStream(bos)
+
+    // First bit is isStatic
+    val isStatic = readBoolean(dis)
+    val objId = readString(dis)
+    val methodName = readString(dis)
+    val numArgs = readInt(dis)
+
+    if (objId == "DotnetHandler") {
+      methodName match {
+        case "stopBackend" =>
+          writeInt(dos, 0)
+          writeType(dos, "void")
+          server.close()
+        case "rm" =>
+          try {
+            val t = readObjectType(dis)
+            assert(t == 'c')
+            val objToRemove = readString(dis)
+            JVMObjectTracker.remove(objToRemove)
+            writeInt(dos, 0)
+            writeObject(dos, null)
+          } catch {
+            case e: Exception =>
+              logError(s"Removing $objId failed", e)
+              writeInt(dos, -1)
+          }
+        case "connectCallback" =>
+          val t = readObjectType(dis)
+          assert(t == 'i')
+          val port = readInt(dis)
+          logInfo(s"Connecting to a callback server at port $port")
+          DotnetBackend.callbackPort = port
+          writeInt(dos, 0)
+          writeType(dos, "void")
+        case "closeCallback" =>
+          // Send close to .NET callback server.
+          logInfo("Requesting to close all call back sockets.")
+          var socket: Socket = null
+          do {
+            socket = DotnetBackend.callbackSockets.poll()
+            if (socket != null) {
+              val dataOutputStream = new DataOutputStream(socket.getOutputStream)
+              SerDe.writeString(dataOutputStream, "close")
+              try {
+                socket.close()
+                socket = null
+              } catch {
+                case e: Exception => logError("Exception when closing socket: ", e)
+              }
+            }
+          } while (socket != null)
+          DotnetBackend.callbackSocketShutdown = true
+
+          writeInt(dos, 0)
+          writeType(dos, "void")
+
+        case _ => dos.writeInt(-1)
+      }
+    } else {
+      handleMethodCall(isStatic, objId, methodName, numArgs, dis, dos)
+    }
+
+    bos.toByteArray
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    // Skip logging the exception message if the connection was disconnected from
+    // the .NET side so that .NET side doesn't have to explicitly close the connection via
+    // "stopBackend." Note that an exception is still thrown if the exit status is non-zero,
+    // so skipping this kind of exception message does not affect the debugging.
+    if (!cause.getMessage.contains(
+          "An existing connection was forcibly closed by the remote host")) {
+      logError("Exception caught: ", cause)
+    }
+
+    // Close the connection when an exception is raised.
+    ctx.close()
+  }
+
+  def handleMethodCall(
+      isStatic: Boolean,
+      objId: String,
+      methodName: String,
+      numArgs: Int,
+      dis: DataInputStream,
+      dos: DataOutputStream): Unit = {
+    var obj: Object = null
+    var args: Array[java.lang.Object] = null
+    var methods: Array[java.lang.reflect.Method] = null
+
+    try {
+      val cls = if (isStatic) {
+        Utils.classForName(objId)
+      } else {
+        JVMObjectTracker.get(objId) match {
+          case None => throw new IllegalArgumentException("Object not found " + objId)
+          case Some(o) =>
+            obj = o
+            o.getClass
+        }
+      }
+
+      args = readArgs(numArgs, dis)
+      methods = cls.getMethods
+
+      val selectedMethods = methods.filter(m => m.getName == methodName)
+      if (selectedMethods.length > 0) {
+        val index = findMatchedSignature(selectedMethods.map(_.getParameterTypes), args)
+
+        if (index.isEmpty) {
+          logWarning(
+            s"cannot find matching method ${cls}.$methodName. "
+              + s"Candidates are:")
+          selectedMethods.foreach { method =>
+            logWarning(s"$methodName(${method.getParameterTypes.mkString(",")})")
+          }
+          throw new Exception(s"No matched method found for $cls.$methodName")
+        }
+
+        val ret = selectedMethods(index.get).invoke(obj, args: _*)
+
+        // Write status bit
+        writeInt(dos, 0)
+        writeObject(dos, ret.asInstanceOf[AnyRef])
+      } else if (methodName == "<init>") {
+        // methodName should be "<init>" for constructor
+        val ctor = cls.getConstructors.filter { x =>
+          matchMethod(numArgs, args, x.getParameterTypes)
+        }.head
+
+        val obj = ctor.newInstance(args: _*)
+
+        writeInt(dos, 0)
+        writeObject(dos, obj.asInstanceOf[AnyRef])
+      } else {
+        throw new IllegalArgumentException(
+          "invalid method " + methodName + " for object " + objId)
+      }
+    } catch {
+      case e: Exception =>
+        val jvmObj = JVMObjectTracker.get(objId)
+        val jvmObjName = jvmObj match {
+          case Some(jObj) => jObj.getClass.getName
+          case None => "NullObject"
+        }
+        logError(s"On object of type $jvmObjName failed", e)
+        if (methods != null) {
+          logError("methods:")
+          methods.foreach(m => logError(m.toString))
+        }
+        if (args != null) {
+          logError("args:")
+          args.foreach(arg => {
+            if (arg != null) {
+              logError(s"argType: ${arg.getClass.getCanonicalName}, argValue: $arg")
+            } else {
+              logError("arg: NULL")
+            }
+          })
+        }
+        writeInt(dos, -1)
+        writeString(dos, Utils.exceptionString(e.getCause))
+    }
+  }
+
+  // Read a number of arguments from the data input stream
+  def readArgs(numArgs: Int, dis: DataInputStream): Array[java.lang.Object] = {
+    (0 until numArgs).map { arg =>
+      readObject(dis)
+    }.toArray
+  }
+
+  // Checks if the arguments passed in args matches the parameter types.
+  // NOTE: Currently we do exact match. We may add type conversions later.
+  def matchMethod(
+      numArgs: Int,
+      args: Array[java.lang.Object],
+      parameterTypes: Array[Class[_]]): Boolean = {
+    if (parameterTypes.length != numArgs) {
+      return false
+    }
+
+    for (i <- 0 to numArgs - 1) {
+      val parameterType = parameterTypes(i)
+      var parameterWrapperType = parameterType
+
+      // Convert native parameters to Object types as args is Array[Object] here
+      if (parameterType.isPrimitive) {
+        parameterWrapperType = parameterType match {
+          case java.lang.Integer.TYPE => classOf[java.lang.Integer]
+          case java.lang.Long.TYPE => classOf[java.lang.Long]
+          case java.lang.Double.TYPE => classOf[java.lang.Double]
+          case java.lang.Boolean.TYPE => classOf[java.lang.Boolean]
+          case _ => parameterType
+        }
+      }
+
+      if (!parameterWrapperType.isInstance(args(i))) {
+        // non primitive types
+        if (!parameterType.isPrimitive && args(i) != null) {
+          return false
+        }
+
+        // primitive types
+        if (parameterType.isPrimitive && !parameterWrapperType.isInstance(args(i))) {
+          return false
+        }
+      }
+    }
+
+    true
+  }
+
+  // Find a matching method signature in an array of signatures of constructors
+  // or methods of the same name according to the passed arguments. Arguments
+  // may be converted in order to match a signature.
+  //
+  // Note that in Java reflection, constructors and normal methods are of different
+  // classes, and share no parent class that provides methods for reflection uses.
+  // There is no unified way to handle them in this function. So an array of signatures
+  // is passed in instead of an array of candidate constructors or methods.
+  //
+  // Returns an Option[Int] which is the index of the matched signature in the array.
+  def findMatchedSignature(
+      parameterTypesOfMethods: Array[Array[Class[_]]],
+      args: Array[Object]): Option[Int] = {
+    val numArgs = args.length
+
+    for (index <- parameterTypesOfMethods.indices) {
+      val parameterTypes = parameterTypesOfMethods(index)
+
+      if (parameterTypes.length == numArgs) {
+        var argMatched = true
+        var i = 0
+        while (i < numArgs && argMatched) {
+          val parameterType = parameterTypes(i)
+
+          if (parameterType == classOf[Seq[Any]] && args(i).getClass.isArray) {
+            // The case that the parameter type is a Scala Seq and the argument
+            // is a Java array is considered matching. The array will be converted
+            // to a Seq later if this method is matched.
+          } else {
+            var parameterWrapperType = parameterType
+
+            // Convert native parameters to Object types as args is Array[Object] here
+            if (parameterType.isPrimitive) {
+              parameterWrapperType = parameterType match {
+                case java.lang.Integer.TYPE => classOf[java.lang.Integer]
+                case java.lang.Long.TYPE => classOf[java.lang.Long]
+                case java.lang.Double.TYPE => classOf[java.lang.Double]
+                case java.lang.Boolean.TYPE => classOf[java.lang.Boolean]
+                case _ => parameterType
+              }
+            }
+            if ((parameterType.isPrimitive || args(i) != null) &&
+                !parameterWrapperType.isInstance(args(i))) {
+              argMatched = false
+            }
+          }
+
+          i = i + 1
+        }
+
+        if (argMatched) {
+          // For now, we return the first matching method.
+          // TODO: find best method in matching methods.
+
+          // Convert args if needed
+          val parameterTypes = parameterTypesOfMethods(index)
+
+          for (i <- 0 until numArgs) {
+            if (parameterTypes(i) == classOf[Seq[Any]] && args(i).getClass.isArray) {
+              // Convert a Java array to scala Seq
+              args(i) = args(i).asInstanceOf[Array[_]].toSeq
+            }
+          }
+
+          return Some(index)
+        }
+      }
+    }
+    None
+  }
+
+  def logError(id: String, e: Exception): Unit = {}
+}
+
+/**
+ * Tracks JVM objects returned to .NET which is useful for invoking calls from .NET on JVM objects.
+ */
+private object JVMObjectTracker {
+
+  // Multiple threads may access objMap and increase objCounter. Because get method return Option,
+  // it is convenient to use a Scala map instead of java.util.concurrent.ConcurrentHashMap.
+  private[this] val objMap = new HashMap[String, Object]
+  private[this] var objCounter: Int = 1
+
+  def getObject(id: String): Object = {
+    synchronized {
+      objMap(id)
+    }
+  }
+
+  def get(id: String): Option[Object] = {
+    synchronized {
+      objMap.get(id)
+    }
+  }
+
+  def put(obj: Object): String = {
+    synchronized {
+      val objId = objCounter.toString
+      objCounter = objCounter + 1
+      objMap.put(objId, obj)
+      objId
+    }
+  }
+
+  def remove(id: String): Option[Object] = {
+    synchronized {
+      objMap.remove(id)
+    }
+  }
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetRDD.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetRDD.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.api.dotnet
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.api.python._
+import org.apache.spark.rdd.RDD
+
+object DotnetRDD {
+  def createPythonRDD(
+      parent: RDD[_],
+      func: PythonFunction,
+      preservePartitoning: Boolean): PythonRDD = {
+    new PythonRDD(parent, func, preservePartitoning)
+  }
+
+  def createJavaRDDFromArray(
+      sc: SparkContext,
+      arr: Array[Array[Byte]],
+      numSlices: Int): JavaRDD[Array[Byte]] = {
+    JavaRDD.fromRDD(sc.parallelize(arr, numSlices))
+  }
+
+  def toJavaRDD(rdd: RDD[_]): JavaRDD[_] = JavaRDD.fromRDD(rdd)
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/JvmBridgeUtils.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/JvmBridgeUtils.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.sql.api.dotnet
+
+import org.apache.spark.SparkConf
+
+/*
+ * Utils for JvmBridge.
+ */
+object JvmBridgeUtils {
+  def getKeyValuePairAsString(kvp: (String, String)): String = {
+    return kvp._1 + "=" + kvp._2
+  }
+
+  def getKeyValuePairArrayAsString(kvpArray: Array[(String, String)]): String = {
+    val sb = new StringBuilder
+
+    for (kvp <- kvpArray) {
+      sb.append(getKeyValuePairAsString(kvp))
+      sb.append(";")
+    }
+
+    sb.toString
+  }
+
+  def getSparkConfAsString(sparkConf: SparkConf): String = {
+    getKeyValuePairArrayAsString(sparkConf.getAll)
+  }
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.api.dotnet
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.sql.{Date, Time, Timestamp}
+
+import scala.collection.JavaConverters._
+
+/**
+ * Functions to serialize and deserialize between CLR & JVM.
+ * This implementation of methods is mostly identical to the SerDe implementation in R.
+ */
+object SerDe {
+  def readObjectType(dis: DataInputStream): Char = {
+    dis.readByte().toChar
+  }
+
+  def readObject(dis: DataInputStream): Object = {
+    val dataType = readObjectType(dis)
+    readTypedObject(dis, dataType)
+  }
+
+  def readTypedObject(dis: DataInputStream, dataType: Char): Object = {
+    dataType match {
+      case 'n' => null
+      case 'i' => new java.lang.Integer(readInt(dis))
+      case 'g' => new java.lang.Long(readLong(dis))
+      case 'd' => new java.lang.Double(readDouble(dis))
+      case 'b' => new java.lang.Boolean(readBoolean(dis))
+      case 'c' => readString(dis)
+      case 'e' => readMap(dis)
+      case 'r' => readBytes(dis)
+      case 'l' => readList(dis)
+      case 'D' => readDate(dis)
+      case 't' => readTime(dis)
+      case 'j' => JVMObjectTracker.getObject(readString(dis))
+      case _ => throw new IllegalArgumentException(s"Invalid type $dataType")
+    }
+  }
+
+  def readBytes(in: DataInputStream): Array[Byte] = {
+    val len = readInt(in)
+    val out = new Array[Byte](len)
+    in.readFully(out)
+    out
+  }
+
+  def readInt(in: DataInputStream): Int = {
+    in.readInt()
+  }
+
+  def readLong(in: DataInputStream): Long = {
+    in.readLong()
+  }
+
+  def readDouble(in: DataInputStream): Double = {
+    in.readDouble()
+  }
+
+  def readStringBytes(in: DataInputStream, len: Int): String = {
+    val bytes = new Array[Byte](len)
+    in.readFully(bytes)
+    val str = new String(bytes, "UTF-8")
+    str
+  }
+
+  def readString(in: DataInputStream): String = {
+    val len = in.readInt()
+    readStringBytes(in, len)
+  }
+
+  def readBoolean(in: DataInputStream): Boolean = {
+    in.readBoolean()
+  }
+
+  def readDate(in: DataInputStream): Date = {
+    Date.valueOf(readString(in))
+  }
+
+  def readTime(in: DataInputStream): Timestamp = {
+    val seconds = in.readDouble()
+    val sec = Math.floor(seconds).toLong
+    val t = new Timestamp(sec * 1000L)
+    t.setNanos(((seconds - sec) * 1e9).toInt)
+    t
+  }
+
+  def readBytesArr(in: DataInputStream): Array[Array[Byte]] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readBytes(in)).toArray
+  }
+
+  def readIntArr(in: DataInputStream): Array[Int] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readInt(in)).toArray
+  }
+
+  def readLongArr(in: DataInputStream): Array[Long] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readLong(in)).toArray
+  }
+
+  def readDoubleArr(in: DataInputStream): Array[Double] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readDouble(in)).toArray
+  }
+
+  def readBooleanArr(in: DataInputStream): Array[Boolean] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readBoolean(in)).toArray
+  }
+
+  def readStringArr(in: DataInputStream): Array[String] = {
+    val len = readInt(in)
+    (0 until len).map(_ => readString(in)).toArray
+  }
+
+  def readList(dis: DataInputStream): Array[_] = {
+    val arrType = readObjectType(dis)
+    arrType match {
+      case 'i' => readIntArr(dis)
+      case 'g' => readLongArr(dis)
+      case 'c' => readStringArr(dis)
+      case 'd' => readDoubleArr(dis)
+      case 'b' => readBooleanArr(dis)
+      case 'j' => readStringArr(dis).map(x => JVMObjectTracker.getObject(x))
+      case 'r' => readBytesArr(dis)
+      case _ => throw new IllegalArgumentException(s"Invalid array type $arrType")
+    }
+  }
+
+  def readMap(in: DataInputStream): java.util.Map[Object, Object] = {
+    val len = readInt(in)
+    if (len > 0) {
+      val keysType = readObjectType(in)
+      val keysLen = readInt(in)
+      val keys = (0 until keysLen).map(_ => readTypedObject(in, keysType))
+
+      val valuesLen = readInt(in)
+      val values = (0 until valuesLen).map(_ => {
+        val valueType = readObjectType(in)
+        readTypedObject(in, valueType)
+      })
+      keys.zip(values).toMap.asJava
+    } else {
+      new java.util.HashMap[Object, Object]()
+    }
+  }
+
+  // Using the same mapping as SparkR implementation for now
+  // Methods to write out data from Java to .NET.
+  //
+  // Type mapping from Java to .NET:
+  //
+  // void -> NULL
+  // Int -> integer
+  // String -> character
+  // Boolean -> logical
+  // Float -> double
+  // Double -> double
+  // Long -> long
+  // Array[Byte] -> raw
+  // Date -> Date
+  // Time -> POSIXct
+  //
+  // Array[T] -> list()
+  // Object -> jobj
+
+  def writeType(dos: DataOutputStream, typeStr: String): Unit = {
+    typeStr match {
+      case "void" => dos.writeByte('n')
+      case "character" => dos.writeByte('c')
+      case "double" => dos.writeByte('d')
+      case "long" => dos.writeByte('g')
+      case "integer" => dos.writeByte('i')
+      case "logical" => dos.writeByte('b')
+      case "date" => dos.writeByte('D')
+      case "time" => dos.writeByte('t')
+      case "raw" => dos.writeByte('r')
+      case "list" => dos.writeByte('l')
+      case "jobj" => dos.writeByte('j')
+      case _ => throw new IllegalArgumentException(s"Invalid type $typeStr")
+    }
+  }
+
+  def writeObject(dos: DataOutputStream, value: Object): Unit = {
+    if (value == null || value == Unit) {
+      writeType(dos, "void")
+    } else {
+      value.getClass.getName match {
+        case "java.lang.String" =>
+          writeType(dos, "character")
+          writeString(dos, value.asInstanceOf[String])
+        case "float" | "java.lang.Float" =>
+          writeType(dos, "double")
+          writeDouble(dos, value.asInstanceOf[Float].toDouble)
+        case "double" | "java.lang.Double" =>
+          writeType(dos, "double")
+          writeDouble(dos, value.asInstanceOf[Double])
+        case "long" | "java.lang.Long" =>
+          writeType(dos, "long")
+          writeLong(dos, value.asInstanceOf[Long])
+        case "int" | "java.lang.Integer" =>
+          writeType(dos, "integer")
+          writeInt(dos, value.asInstanceOf[Int])
+        case "boolean" | "java.lang.Boolean" =>
+          writeType(dos, "logical")
+          writeBoolean(dos, value.asInstanceOf[Boolean])
+        case "java.sql.Date" =>
+          writeType(dos, "date")
+          writeDate(dos, value.asInstanceOf[Date])
+        case "java.sql.Time" =>
+          writeType(dos, "time")
+          writeTime(dos, value.asInstanceOf[Time])
+        case "java.sql.Timestamp" =>
+          writeType(dos, "time")
+          writeTime(dos, value.asInstanceOf[Timestamp])
+        case "[B" =>
+          writeType(dos, "raw")
+          writeBytes(dos, value.asInstanceOf[Array[Byte]])
+        // TODO: Types not handled right now include
+        // byte, char, short, float
+
+        // Handle arrays
+        case "[Ljava.lang.String;" =>
+          writeType(dos, "list")
+          writeStringArr(dos, value.asInstanceOf[Array[String]])
+        case "[I" =>
+          writeType(dos, "list")
+          writeIntArr(dos, value.asInstanceOf[Array[Int]])
+        case "[J" =>
+          writeType(dos, "list")
+          writeLongArr(dos, value.asInstanceOf[Array[Long]])
+        case "[D" =>
+          writeType(dos, "list")
+          writeDoubleArr(dos, value.asInstanceOf[Array[Double]])
+        case "[Z" =>
+          writeType(dos, "list")
+          writeBooleanArr(dos, value.asInstanceOf[Array[Boolean]])
+        case "[[B" =>
+          writeType(dos, "list")
+          writeBytesArr(dos, value.asInstanceOf[Array[Array[Byte]]])
+        case otherName =>
+          // Handle array of objects
+          if (otherName.startsWith("[L")) {
+            val objArr = value.asInstanceOf[Array[Object]]
+            writeType(dos, "list")
+            writeType(dos, "jobj")
+            dos.writeInt(objArr.length)
+            objArr.foreach(o => writeJObj(dos, o))
+          } else {
+            writeType(dos, "jobj")
+            writeJObj(dos, value)
+          }
+      }
+    }
+  }
+
+  def writeInt(out: DataOutputStream, value: Int): Unit = {
+    out.writeInt(value)
+  }
+
+  def writeLong(out: DataOutputStream, value: Long): Unit = {
+    out.writeLong(value)
+  }
+
+  def writeDouble(out: DataOutputStream, value: Double): Unit = {
+    out.writeDouble(value)
+  }
+
+  def writeBoolean(out: DataOutputStream, value: Boolean): Unit = {
+    out.writeBoolean(value)
+  }
+
+  def writeDate(out: DataOutputStream, value: Date): Unit = {
+    writeString(out, value.toString)
+  }
+
+  def writeTime(out: DataOutputStream, value: Time): Unit = {
+    out.writeDouble(value.getTime.toDouble / 1000.0)
+  }
+
+  def writeTime(out: DataOutputStream, value: Timestamp): Unit = {
+    out.writeDouble((value.getTime / 1000).toDouble + value.getNanos.toDouble / 1e9)
+  }
+
+  // NOTE: Only works for ASCII right now
+  def writeString(out: DataOutputStream, value: String): Unit = {
+    val len = value.length
+    out.writeInt(len)
+    out.writeBytes(value)
+  }
+
+  def writeBytes(out: DataOutputStream, value: Array[Byte]): Unit = {
+    out.writeInt(value.length)
+    out.write(value)
+  }
+
+  def writeJObj(out: DataOutputStream, value: Object): Unit = {
+    val objId = JVMObjectTracker.put(value)
+    writeString(out, objId)
+  }
+
+  def writeIntArr(out: DataOutputStream, value: Array[Int]): Unit = {
+    writeType(out, "integer")
+    out.writeInt(value.length)
+    value.foreach(v => out.writeInt(v))
+  }
+
+  def writeLongArr(out: DataOutputStream, value: Array[Long]): Unit = {
+    writeType(out, "long")
+    out.writeInt(value.length)
+    value.foreach(v => out.writeLong(v))
+  }
+
+  def writeDoubleArr(out: DataOutputStream, value: Array[Double]): Unit = {
+    writeType(out, "double")
+    out.writeInt(value.length)
+    value.foreach(v => out.writeDouble(v))
+  }
+
+  def writeBooleanArr(out: DataOutputStream, value: Array[Boolean]): Unit = {
+    writeType(out, "logical")
+    out.writeInt(value.length)
+    value.foreach(v => writeBoolean(out, v))
+  }
+
+  def writeStringArr(out: DataOutputStream, value: Array[String]): Unit = {
+    writeType(out, "character")
+    out.writeInt(value.length)
+    value.foreach(v => writeString(out, v))
+  }
+
+  def writeBytesArr(out: DataOutputStream, value: Array[Array[Byte]]): Unit = {
+    writeType(out, "raw")
+    out.writeInt(value.length)
+    value.foreach(v => writeBytes(out, v))
+  }
+}
+
+private object SerializationFormats {
+  val BYTE = "byte"
+  val STRING = "string"
+  val ROW = "row"
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.deploy.dotnet
+
+import java.io.File
+import java.net.URI
+import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.{FileSystems, Files, Paths}
+import java.util.Locale
+import java.util.concurrent.{Semaphore, TimeUnit}
+
+import org.apache.commons.io.FilenameUtils
+import org.apache.hadoop.fs.Path
+import org.apache.spark
+import org.apache.spark.api.dotnet.DotnetBackend
+import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
+import org.apache.spark.util.{RedirectThread, Utils}
+import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
+
+import scala.collection.JavaConverters._
+import scala.io.StdIn
+import scala.util.Try
+
+/**
+ * DotnetRunner class used to launch Spark .NET applications using spark-submit.
+ * It executes .NET application as a subprocess and then has it connect back to
+ * the JVM to access system properties etc.
+ */
+object DotnetRunner extends Logging {
+  private val DEBUG_PORT = 5567
+  private val supportedSparkVersions = Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4")
+
+  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
+
+  def main(args: Array[String]): Unit = {
+    if (args.length == 0) {
+      throw new IllegalArgumentException("At least one argument is expected.")
+    }
+
+    validateSparkVersions
+
+    val settings = initializeSettings(args)
+
+    // Determines if this needs to be run in debug mode.
+    // In debug mode this runner will not launch a .NET process.
+    val runInDebugMode = settings._1
+    @volatile var dotnetBackendPortNumber = settings._2
+    var dotnetExecutable = ""
+    var otherArgs: Array[String] = null
+
+    if (!runInDebugMode) {
+      if (args(0).toLowerCase(Locale.ROOT).endsWith(".zip")) {
+        var zipFileName = args(0)
+        val zipFileUri = Try(new URI(zipFileName)).getOrElse(new File(zipFileName).toURI)
+        val workingDir = new File("").getAbsoluteFile
+        val driverDir = new File(workingDir, FilenameUtils.getBaseName(zipFileUri.getPath()))
+
+        // Standalone cluster mode where .NET application is remotely located.
+        if (zipFileUri.getScheme() != "file") {
+          zipFileName = downloadDriverFile(zipFileName, workingDir.getAbsolutePath).getName
+        }
+
+        logInfo(s"Unzipping .NET driver $zipFileName to $driverDir")
+        DotnetUtils.unzip(new File(zipFileName), driverDir)
+
+        // Reuse windows-specific formatting in PythonRunner.
+        dotnetExecutable = PythonRunner.formatPath(resolveDotnetExecutable(driverDir, args(1)))
+        otherArgs = args.slice(2, args.length)
+      } else {
+        // Reuse windows-specific formatting in PythonRunner.
+        dotnetExecutable = PythonRunner.formatPath(args(0))
+        otherArgs = args.slice(1, args.length)
+      }
+    } else {
+      otherArgs = args.slice(1, args.length)
+    }
+
+    val processParameters = new java.util.ArrayList[String]
+    processParameters.add(dotnetExecutable)
+    otherArgs.foreach(arg => processParameters.add(arg))
+
+    logInfo(s"Starting DotnetBackend with $dotnetExecutable.")
+
+    // Time to wait for DotnetBackend to initialize in seconds.
+    val backendTimeout = sys.env.getOrElse("DOTNETBACKEND_TIMEOUT", "120").toInt
+
+    // Launch a DotnetBackend server for the .NET process to connect to; this will let it see our
+    // Java system properties etc.
+    val dotnetBackend = new DotnetBackend()
+    val initialized = new Semaphore(0)
+    val dotnetBackendThread = new Thread("DotnetBackend") {
+      override def run() {
+        // need to get back dotnetBackendPortNumber because if the value passed to init is 0
+        // the port number is dynamically assigned in the backend
+        dotnetBackendPortNumber = dotnetBackend.init(dotnetBackendPortNumber)
+        logInfo(s"Port number used by DotnetBackend is $dotnetBackendPortNumber")
+        initialized.release()
+        dotnetBackend.run()
+      }
+    }
+
+    dotnetBackendThread.start()
+
+    if (initialized.tryAcquire(backendTimeout, TimeUnit.SECONDS)) {
+      if (!runInDebugMode) {
+        var returnCode = -1
+        try {
+          val builder = new ProcessBuilder(processParameters)
+          val env = builder.environment()
+          env.put("DOTNETBACKEND_PORT", dotnetBackendPortNumber.toString)
+
+          for ((key, value) <- Utils.getSystemProperties if key.startsWith("spark.")) {
+            env.put(key, value)
+            logInfo(s"Adding key=$key and value=$value to environment")
+          }
+          builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
+          val process = builder.start()
+
+          // Redirect stdin of JVM process to stdin of .NET process.
+          new RedirectThread(System.in, process.getOutputStream, "redirect JVM input").start()
+          // Redirect stdout and stderr of .NET process.
+          new RedirectThread(process.getInputStream, System.out, "redirect .NET stdout").start()
+          new RedirectThread(process.getErrorStream, System.out, "redirect .NET stderr").start()
+
+          returnCode = process.waitFor()
+          closeBackend(dotnetBackend)
+        } catch {
+          case t: Throwable =>
+            logError(s"${t.getMessage} \n ${t.getStackTrace}")
+        }
+
+        if (returnCode != 0) {
+          throw new SparkUserAppException(returnCode)
+        } else {
+          logInfo(s".NET application exited successfully")
+        }
+        // TODO: The following is causing the following error:
+        // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,
+        // (reason: Shutdown hook called before final status was reported.)
+        // DotnetUtils.exit(returnCode)
+      } else {
+        // scalastyle:off println
+        println("***********************************************************************")
+        println("* .NET Backend running debug mode. Press enter to exit *")
+        println("***********************************************************************")
+        // scalastyle:on println
+
+        StdIn.readLine()
+        closeBackend(dotnetBackend)
+        DotnetUtils.exit(0)
+      }
+    } else {
+      logError(s"DotnetBackend did not initialize in $backendTimeout seconds")
+      DotnetUtils.exit(-1)
+    }
+  }
+
+  private def validateSparkVersions: Unit = {
+    if (!supportedSparkVersions(SPARK_VERSION)) {
+      val supportedVersions = supportedSparkVersions.mkString(", ")
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: ${SPARK_VERSION}." +
+          s" Supported versions: ${supportedVersions}")
+    }
+  }
+
+  // When the executable is downloaded as part of zip file, check if the file exists
+  // after zip file is unzipped under the given dir. Once it is found, change the
+  // permission to executable (only for Unix systems, since the zip file may have been
+  // created under Windows. Finally, the absolute path for the executable is returned.
+  private def resolveDotnetExecutable(dir: File, dotnetExecutable: String): String = {
+    val resolvedExecutable = Files
+      .walk(FileSystems.getDefault.getPath(dir.getAbsolutePath))
+      .iterator()
+      .asScala
+      .find(path => Files.isRegularFile(path) && path.getFileName.toString == dotnetExecutable) match {
+      case Some(path) => path.toAbsolutePath.toString
+      case None =>
+        throw new IllegalArgumentException(
+          s"Failed to find $dotnetExecutable under" +
+            s" ${dir.getAbsolutePath}")
+    }
+
+    if (DotnetUtils.supportPosix) {
+      Files.setPosixFilePermissions(
+        Paths.get(resolvedExecutable),
+        PosixFilePermissions.fromString("rwxr-xr-x"))
+    }
+
+    resolvedExecutable
+  }
+
+  /**
+   * Download HDFS file into the supplied directory and return its local path.
+   * Will throw an exception if there are errors during downloading.
+   */
+  private def downloadDriverFile(hdfsFilePath: String, driverDir: String): File = {
+    val sparkConf = new SparkConf()
+    val filePath = new Path(hdfsFilePath)
+
+    val hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf)
+    val jarFileName = filePath.getName
+    val localFile = new File(driverDir, jarFileName)
+
+    if (!localFile.exists()) { // May already exist if running multiple workers on one node
+      logInfo(s"Copying user file $filePath to $driverDir")
+      Utils.fetchFile(
+        hdfsFilePath,
+        new File(driverDir),
+        sparkConf,
+        new SecurityManager(sparkConf),
+        hadoopConf,
+        System.currentTimeMillis(),
+        useCache = false)
+    }
+
+    if (!localFile.exists()) {
+      throw new Exception(s"Did not see expected $jarFileName in $driverDir")
+    }
+
+    localFile
+  }
+
+  private def closeBackend(dotnetBackend: DotnetBackend): Unit = {
+    logInfo("Closing DotnetBackend")
+    dotnetBackend.close()
+  }
+
+  private def initializeSettings(args: Array[String]): (Boolean, Int) = {
+    val runInDebugMode = (args.length == 1 || args.length == 2) && args(0).equalsIgnoreCase(
+      "debug")
+    var portNumber = 0
+    if (runInDebugMode) {
+      if (args.length == 1) {
+        portNumber = DEBUG_PORT
+      } else if (args.length == 2) {
+        portNumber = Integer.parseInt(args(1))
+      }
+    }
+
+    (runInDebugMode, portNumber)
+  }
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val supportedSparkVersions = Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4")
+  private val supportedSparkVersions = Set[String]("3.0.0")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.sql.api.dotnet
+
+import java.util.{List => JList, Map => JMap}
+
+import org.apache.spark.api.python.{PythonAccumulatorV2, PythonBroadcast, PythonFunction}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.deploy.dotnet.DotnetRunner
+
+object SQLUtils {
+
+  /**
+   * Exposes createPythonFunction to the .NET client to enable registering UDFs.
+   */
+  def createPythonFunction(
+      command: Array[Byte],
+      envVars: JMap[String, String],
+      pythonIncludes: JList[String],
+      pythonExec: String,
+      pythonVersion: String,
+      broadcastVars: JList[Broadcast[PythonBroadcast]],
+      accumulator: PythonAccumulatorV2): PythonFunction = {
+    // DOTNET_WORKER_SPARK_VERSION is used to handle different versions of Spark on the worker.
+    envVars.put("DOTNET_WORKER_SPARK_VERSION", DotnetRunner.SPARK_VERSION)
+
+    PythonFunction(
+      command,
+      envVars,
+      pythonIncludes,
+      pythonExec,
+      pythonVersion,
+      broadcastVars,
+      accumulator)
+  }
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.util.dotnet
+
+import java.io._
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermission._
+import java.nio.file.{FileSystems, Files}
+import java.util.{Timer, TimerTask}
+
+import org.apache.commons.compress.archivers.zip.{ZipArchiveEntry, ZipArchiveOutputStream, ZipFile}
+import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.internal.Logging
+
+import scala.collection.JavaConverters._
+import scala.collection.Set
+
+/**
+ * Utility methods.
+ */
+object Utils extends Logging {
+  private val posixFilePermissions = Array(
+    OWNER_READ,
+    OWNER_WRITE,
+    OWNER_EXECUTE,
+    GROUP_READ,
+    GROUP_WRITE,
+    GROUP_EXECUTE,
+    OTHERS_READ,
+    OTHERS_WRITE,
+    OTHERS_EXECUTE)
+
+  val supportPosix: Boolean =
+    FileSystems.getDefault.supportedFileAttributeViews().contains("posix")
+
+  /**
+   * Compress all files under given directory into one zip file and drop it to the target directory
+   *
+   * @param sourceDir source directory to zip
+   * @param targetZipFile target zip file
+   */
+  def zip(sourceDir: File, targetZipFile: File): Unit = {
+    var fos: FileOutputStream = null
+    var zos: ZipArchiveOutputStream = null
+    try {
+      fos = new FileOutputStream(targetZipFile)
+      zos = new ZipArchiveOutputStream(fos)
+
+      val sourcePath = sourceDir.toPath
+      FileUtils.listFiles(sourceDir, null, true).asScala.foreach { file =>
+        var in: FileInputStream = null
+        try {
+          val path = file.toPath
+          val entry = new ZipArchiveEntry(sourcePath.relativize(path).toString)
+          if (supportPosix) {
+            entry.setUnixMode(
+              permissionsToMode(Files.getPosixFilePermissions(path).asScala)
+                | (if (entry.getName.endsWith(".exe")) 0x1ED else 0x1A4))
+          } else if (entry.getName.endsWith(".exe")) {
+            entry.setUnixMode(0x1ED) // 755
+          } else {
+            entry.setUnixMode(0x1A4) // 644
+          }
+          zos.putArchiveEntry(entry)
+
+          in = new FileInputStream(file)
+          IOUtils.copy(in, zos)
+          zos.closeArchiveEntry()
+        } finally {
+          IOUtils.closeQuietly(in)
+        }
+      }
+    } finally {
+      IOUtils.closeQuietly(zos)
+      IOUtils.closeQuietly(fos)
+    }
+  }
+
+  /**
+   * Unzip a file to the given directory
+   *
+   * @param file file to be unzipped
+   * @param targetDir target directory
+   */
+  def unzip(file: File, targetDir: File): Unit = {
+    var zipFile: ZipFile = null
+    try {
+      targetDir.mkdirs()
+      zipFile = new ZipFile(file)
+      zipFile.getEntries.asScala.foreach { entry =>
+        val targetFile = new File(targetDir, entry.getName)
+
+        if (targetFile.exists()) {
+          logWarning(
+            s"Target file/directory $targetFile already exists. Skip it for now. " +
+              s"Make sure this is expected.")
+        } else {
+          if (entry.isDirectory) {
+            targetFile.mkdirs()
+          } else {
+            targetFile.getParentFile.mkdirs()
+            val input = zipFile.getInputStream(entry)
+            val output = new FileOutputStream(targetFile)
+            IOUtils.copy(input, output)
+            IOUtils.closeQuietly(input)
+            IOUtils.closeQuietly(output)
+            if (supportPosix) {
+              val permissions = modeToPermissions(entry.getUnixMode)
+              // When run in Unix system, permissions will be empty, thus skip
+              // setting the empty permissions (which will empty the previous permissions).
+              if (permissions.nonEmpty) {
+                Files.setPosixFilePermissions(targetFile.toPath, permissions.asJava)
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      case e: Exception => logError("exception caught during decompression:" + e)
+    } finally {
+      ZipFile.closeQuietly(zipFile)
+    }
+  }
+
+  /**
+   * Exits the JVM, trying to do it nicely, otherwise doing it nastily.
+   *
+   * @param status  the exit status, zero for OK, non-zero for error
+   * @param maxDelayMillis  the maximum delay in milliseconds
+   */
+  def exit(status: Int, maxDelayMillis: Long) {
+    try {
+      logInfo(s"Utils.exit() with status: $status, maxDelayMillis: $maxDelayMillis")
+
+      // setup a timer, so if nice exit fails, the nasty exit happens
+      val timer = new Timer()
+      timer.schedule(new TimerTask() {
+
+        override def run() {
+          Runtime.getRuntime.halt(status)
+        }
+      }, maxDelayMillis)
+      // try to exit nicely
+      System.exit(status);
+    } catch {
+      // exit nastily if we have a problem
+      case _: Throwable => Runtime.getRuntime.halt(status)
+    } finally {
+      // should never get here
+      Runtime.getRuntime.halt(status)
+    }
+  }
+
+  /**
+   * Exits the JVM, trying to do it nicely, wait 1 second
+   *
+   * @param status  the exit status, zero for OK, non-zero for error
+   */
+  def exit(status: Int): Unit = {
+    exit(status, 1000)
+  }
+
+  /**
+   * Normalize the Spark version by taking the first three numbers.
+   * For example:
+   * x.y.z => x.y.z
+   * x.y.z.xxx.yyy => x.y.z
+   * x.y => x.y
+   *
+   * @param version the Spark version to normalize
+   * @return Normalized Spark version.
+   */
+  def normalizeSparkVersion(version: String): String = {
+    version
+      .split('.')
+      .take(3)
+      .zipWithIndex
+      .map({
+        case (element, index) => {
+          index match {
+            case 2 => element.split("\\D+").lift(0).getOrElse("")
+            case _ => element
+          }
+        }
+      })
+      .mkString(".")
+  }
+
+  private[spark] def listZipFileEntries(file: File): Array[String] = {
+    var zipFile: ZipFile = null
+    try {
+      zipFile = new ZipFile(file)
+      zipFile.getEntries.asScala.map(_.getName).toArray
+    } finally {
+      ZipFile.closeQuietly(zipFile)
+    }
+  }
+
+  private[this] def permissionsToMode(permissions: Set[PosixFilePermission]): Int = {
+    posixFilePermissions.foldLeft(0) { (mode, perm) =>
+      (mode << 1) | (if (permissions.contains(perm)) 1 else 0)
+    }
+  }
+
+  private[this] def modeToPermissions(mode: Int): Set[PosixFilePermission] = {
+    posixFilePermissions.zipWithIndex
+      .filter { case (_, i) => (mode & (0x100 >>> i)) != 0 }
+      .map(_._1)
+      .toSet
+  }
+}

--- a/src/scala/microsoft-spark-3.0.x/src/test/scala/com/microsoft/scala/AppTest.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/test/scala/com/microsoft/scala/AppTest.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package com.microsoft.scala
+
+import org.junit._
+import Assert._
+
+@Test
+class AppTest {
+
+    @Test
+    def testOK() = assertTrue(true)
+
+//    @Test
+//    def testKO() = assertTrue(false)
+
+}
+
+

--- a/src/scala/pom.xml
+++ b/src/scala/pom.xml
@@ -12,6 +12,7 @@
   <modules>
     <module>microsoft-spark-2.3.x</module>
     <module>microsoft-spark-2.4.x</module>
+    <module>microsoft-spark-3.0.x</module>
   </modules>
 
   <pluginRepositories>


### PR DESCRIPTION
This PR creates a new microsoft-spark-3.0.x project for Scala to build against spark-3.0.0-SNAPSHOT.

Most of the files are copied from microsoft-spark-2.4.x project and `pom.xml` is updated to consume 3.0 SNAPSHOT jar files.

Now, when you build the scala project, `microsoft-spark-3.0.x.jar` will be produced. However, the UDF code path is not validated and most likely is broken since the contracts have been changed. These will be addressed in subsequent PRs.