### PR TITLE
[Scala] Use Spark 3.0.0-preview instead of 3.0.0-SNAPSHOT

### DIFF
--- a/src/scala/microsoft-spark-3.0.x/pom.xml
+++ b/src/scala/microsoft-spark-3.0.x/pom.xml
@@ -12,7 +12,7 @@
     <encoding>UTF-8</encoding>
     <scala.version>2.12.8</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.0.0-SNAPSHOT</spark.version>
+    <spark.version>3.0.0-preview</spark.version>
   </properties>
 
   <dependencies>
@@ -74,14 +74,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>Apache Spark snapshot repository</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION
Consume 3.0.0-preview jars from the Maven repository instead of the SNAPSHOT repository.