### PR TITLE
Fix E2E WindowTests for Spark 3.0.

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Sql.Expressions;
 using Xunit;
@@ -22,30 +23,37 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Column col1 = Column("age");
             Column col2 = Column("name");
 
-            _ = Sql.Expressions.Window.UnboundedPreceding;
-            _ = Sql.Expressions.Window.UnboundedFollowing;
-            _ = Sql.Expressions.Window.CurrentRow;
+            Assert.IsType<long>(Sql.Expressions.Window.UnboundedPreceding);
+            Assert.IsType<long>(Sql.Expressions.Window.UnboundedFollowing);
+            Assert.IsType<long>(Sql.Expressions.Window.CurrentRow);
 
-            WindowSpec windowSpec = PartitionBy("age");
-            windowSpec = PartitionBy("age", "name");
-            windowSpec = PartitionBy();
-            windowSpec = PartitionBy(col1);
-            windowSpec = PartitionBy(col1, col2);
+            Assert.IsType<WindowSpec>(PartitionBy("age"));
+            Assert.IsType<WindowSpec>(PartitionBy("age", "name"));
+            Assert.IsType<WindowSpec>(PartitionBy());
+            Assert.IsType<WindowSpec>(PartitionBy(col1));
+            Assert.IsType<WindowSpec>(PartitionBy(col1, col2));
 
-            windowSpec = OrderBy("age");
-            windowSpec = OrderBy("age", "name");
-            windowSpec = OrderBy();
-            windowSpec = OrderBy(col1);
-            windowSpec = OrderBy(col1, col2);
+            Assert.IsType<WindowSpec>(OrderBy("age"));
+            Assert.IsType<WindowSpec>(OrderBy("age", "name"));
+            Assert.IsType<WindowSpec>(OrderBy());
+            Assert.IsType<WindowSpec>(OrderBy(col1));
+            Assert.IsType<WindowSpec>(OrderBy(col1, col2));
 
-            windowSpec = RowsBetween(
+            Assert.IsType<WindowSpec>(RowsBetween(
                 Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing);
+                Sql.Expressions.Window.UnboundedFollowing));
 
-            windowSpec = RangeBetween(
+            Assert.IsType<WindowSpec>(RangeBetween(
                 Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing);
-            windowSpec = RangeBetween(UnboundedPreceding(), UnboundedFollowing());
+                Sql.Expressions.Window.UnboundedFollowing));
+
+            if (SparkSettings.Version < new Version(Versions.V3_0_0))
+            {
+                // The following APIs are removed in Spark 3.0.
+                Assert.IsType<WindowSpec>(RangeBetween(
+                    UnboundedPreceding(),
+                    UnboundedFollowing()));
+            }
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Expressions/Window.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Expressions/Window.cs
@@ -106,6 +106,9 @@ namespace Microsoft.Spark.Sql.Expressions
         /// Creates a `WindowSpec` with the frame boundaries defined,
         /// from `start` (inclusive) to `end` (inclusive).
         /// </summary>
+        /// <remarks>
+        /// This API is deprecated in Spark 2.4 and removed in Spark 3.0.
+        /// </remarks>
         /// <param name="start">
         /// Boundary start, inclusive. The frame is unbounded if the expression is
         /// `Microsoft.Spark.Sql.Functions.UnboundedPreceding()`
@@ -115,6 +118,8 @@ namespace Microsoft.Spark.Sql.Expressions
         /// `Microsoft.Spark.Sql.Functions.UnboundedFollowing()`
         /// </param>
         /// <returns>WindowSpec object</returns>
+        [Deprecated(Versions.V2_4_0)]
+        [Removed(Versions.V3_0_0)]
         public static WindowSpec RangeBetween(Column start, Column end) =>
             Apply("rangeBetween", start, end);
 

--- a/src/csharp/Microsoft.Spark/Sql/Functions.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Functions.cs
@@ -719,9 +719,10 @@ namespace Microsoft.Spark.Sql
         /// row in the window partition.
         /// </summary>
         /// <remarks>
-        /// This API is removed in Spark 3.0.
+        /// This API is deprecated in Spark 2.4 and removed in Spark 3.0.
         /// </remarks>
         /// <returns>Column object</returns>
+        [Deprecated(Versions.V2_4_0)]
         [Removed(Versions.V3_0_0)]
         public static Column UnboundedPreceding()
         {
@@ -733,9 +734,10 @@ namespace Microsoft.Spark.Sql
         /// row in the window partition.
         /// </summary>
         /// <remarks>
-        /// This API is removed in Spark 3.0.
+        /// This API is deprecated in Spark 2.4 and removed in Spark 3.0.
         /// </remarks>
         /// <returns>Column object</returns>
+        [Deprecated(Versions.V2_4_0)]
         [Removed(Versions.V3_0_0)]
         public static Column UnboundedFollowing()
         {
@@ -747,9 +749,10 @@ namespace Microsoft.Spark.Sql
         /// row in the window partition.
         /// </summary>
         /// <remarks>
-        /// This API is removed in Spark 3.0.
+        /// This API is deprecated in Spark 2.4 and removed in Spark 3.0.
         /// </remarks>
         /// <returns>Column object</returns>
+        [Deprecated(Versions.V2_4_0)]
         [Removed(Versions.V3_0_0)]
         public static Column CurrentRow()
         {


### PR DESCRIPTION
This fixes E2E WindowTests that are failing for Spark 3.0. because the APIs are either removed or deprecated.

This is a part of the effort to bring in CI for Spark 3.0: #348.