### PR TITLE
Fix E2E WindowSpecTests for Spark 3.0

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowSpecTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowSpecTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Sql.Expressions;
 using Xunit;
@@ -23,26 +24,36 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Column col2 = Column("name");
             WindowSpec windowSpec = PartitionBy("age");
 
-            windowSpec = windowSpec.PartitionBy("age");
-            windowSpec = windowSpec.PartitionBy("age", "name");
-            windowSpec = windowSpec.PartitionBy();
-            windowSpec = windowSpec.PartitionBy(col1);
-            windowSpec = windowSpec.PartitionBy(col1, col2);
+            Assert.IsType<WindowSpec>(windowSpec.PartitionBy("age"));
+            Assert.IsType<WindowSpec>(windowSpec.PartitionBy("age", "name"));
+            Assert.IsType<WindowSpec>(windowSpec.PartitionBy());
+            Assert.IsType<WindowSpec>(windowSpec.PartitionBy(col1));
+            Assert.IsType<WindowSpec>(windowSpec.PartitionBy(col1, col2));
 
-            windowSpec = windowSpec.OrderBy("age");
-            windowSpec = windowSpec.OrderBy("age", "name");
-            windowSpec = windowSpec.OrderBy();
-            windowSpec = windowSpec.OrderBy(col1);
-            windowSpec = windowSpec.OrderBy(col1, col2);
+            Assert.IsType<WindowSpec>(windowSpec.OrderBy("age"));
+            Assert.IsType<WindowSpec>(windowSpec.OrderBy("age", "name"));
+            Assert.IsType<WindowSpec>(windowSpec.OrderBy());
+            Assert.IsType<WindowSpec>(windowSpec.OrderBy(col1));
+            Assert.IsType<WindowSpec>(windowSpec.OrderBy(col1, col2));
 
-            windowSpec = windowSpec.RowsBetween(
-                Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing);
+            Assert.IsType<WindowSpec>(
+                windowSpec.RowsBetween(
+                    Sql.Expressions.Window.UnboundedPreceding,
+                    Sql.Expressions.Window.UnboundedFollowing));
 
-            windowSpec = windowSpec.RangeBetween(
-                Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing);
-            windowSpec = windowSpec.RangeBetween(UnboundedPreceding(), UnboundedFollowing());
+            Assert.IsType<WindowSpec>(
+                windowSpec.RangeBetween(
+                    Sql.Expressions.Window.UnboundedPreceding,
+                    Sql.Expressions.Window.UnboundedFollowing));
+
+            if (SparkSettings.Version < new Version(Versions.V3_0_0))
+            {
+                // The following APIs are removed in Spark 3.0.
+                Assert.IsType<WindowSpec>(
+                    windowSpec.RangeBetween(
+                        UnboundedPreceding(),
+                        UnboundedFollowing()));
+            }
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Expressions/WindowTests.cs
@@ -39,20 +39,23 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Assert.IsType<WindowSpec>(OrderBy(col1));
             Assert.IsType<WindowSpec>(OrderBy(col1, col2));
 
-            Assert.IsType<WindowSpec>(RowsBetween(
-                Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing));
+            Assert.IsType<WindowSpec>(
+                RowsBetween(
+                    Sql.Expressions.Window.UnboundedPreceding,
+                    Sql.Expressions.Window.UnboundedFollowing));
 
-            Assert.IsType<WindowSpec>(RangeBetween(
-                Sql.Expressions.Window.UnboundedPreceding,
-                Sql.Expressions.Window.UnboundedFollowing));
+            Assert.IsType<WindowSpec>(
+                RangeBetween(
+                    Sql.Expressions.Window.UnboundedPreceding,
+                    Sql.Expressions.Window.UnboundedFollowing));
 
             if (SparkSettings.Version < new Version(Versions.V3_0_0))
             {
                 // The following APIs are removed in Spark 3.0.
-                Assert.IsType<WindowSpec>(RangeBetween(
-                    UnboundedPreceding(),
-                    UnboundedFollowing()));
+                Assert.IsType<WindowSpec>(
+                    RangeBetween(
+                        UnboundedPreceding(),
+                        UnboundedFollowing()));
             }
         }
     }

--- a/src/csharp/Microsoft.Spark/Sql/Expressions/WindowSpec.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Expressions/WindowSpec.cs
@@ -87,6 +87,9 @@ namespace Microsoft.Spark.Sql.Expressions
         /// <summary>
         /// Defines the frame boundaries, from `start` (inclusive) to `end` (inclusive).
         /// </summary>
+        /// <remarks>
+        /// This API is deprecated in Spark 2.4 and removed in Spark 3.0.
+        /// </remarks>
         /// <param name="start">
         /// Boundary start, inclusive. The frame is unbounded if the expression is
         /// `Microsoft.Spark.Sql.Functions.UnboundedPreceding()`
@@ -96,6 +99,8 @@ namespace Microsoft.Spark.Sql.Expressions
         /// `Microsoft.Spark.Sql.Functions.UnboundedFollowing()`
         /// </param>
         /// <returns>WindowSpec object</returns>
+        [Deprecated(Versions.V2_4_0)]
+        [Removed(Versions.V3_0_0)]
         public WindowSpec RangeBetween(Column start, Column end) =>
             WrapAsWindowSpec(_jvmObject.Invoke("rangeBetween", start, end));
 


### PR DESCRIPTION
This fixes E2E WindowSpecTests that are failing for Spark 3.0. because the APIs are either removed or deprecated.

This is a part of the effort to bring in CI for Spark 3.0: #348.