### PR TITLE
Expose SparkContext.setLogLevel API

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Spark.E2ETest.Utils;
 using Xunit;
 
@@ -26,14 +27,9 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             sc.SetJobDescription("job description");
 
-            sc.SetLogLevel(SparkContext.LogLevel.ALL);
-            sc.SetLogLevel(SparkContext.LogLevel.DEBUG);
-            sc.SetLogLevel(SparkContext.LogLevel.ERROR);
-            sc.SetLogLevel(SparkContext.LogLevel.FATAL);
-            sc.SetLogLevel(SparkContext.LogLevel.INFO);
-            sc.SetLogLevel(SparkContext.LogLevel.OFF);
-            sc.SetLogLevel(SparkContext.LogLevel.TRACE);
-            sc.SetLogLevel(SparkContext.LogLevel.WARN);
+            sc.SetLogLevel("ALL");
+            sc.SetLogLevel("debug");
+            Assert.Throws<Exception>(() => sc.SetLogLevel("INVALID"));
 
             sc.SetJobGroup("group id", "description");
             sc.SetJobGroup("group id", "description", true);

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
@@ -21,10 +21,19 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         {
             SparkContext sc = SparkContext.GetOrCreate(new SparkConf());
 
-            _ = sc.GetConf();
-            _ = sc.DefaultParallelism;
+            Assert.IsType<SparkConf>(sc.GetConf());
+            Assert.IsType<int>(sc.DefaultParallelism);
 
             sc.SetJobDescription("job description");
+
+            sc.SetLogLevel(SparkContext.LogLevel.ALL);
+            sc.SetLogLevel(SparkContext.LogLevel.DEBUG);
+            sc.SetLogLevel(SparkContext.LogLevel.ERROR);
+            sc.SetLogLevel(SparkContext.LogLevel.FATAL);
+            sc.SetLogLevel(SparkContext.LogLevel.INFO);
+            sc.SetLogLevel(SparkContext.LogLevel.OFF);
+            sc.SetLogLevel(SparkContext.LogLevel.TRACE);
+            sc.SetLogLevel(SparkContext.LogLevel.WARN);
 
             sc.SetJobGroup("group id", "description");
             sc.SetJobGroup("group id", "description", true);
@@ -35,10 +44,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             sc.AddFile(filePath);
             sc.AddFile(filePath, true);
 
-            using (var tempDir = new TemporaryDirectory())
-            {
-                sc.SetCheckpointDir(TestEnvironment.ResourceDirectory);
-            }
+            using var tempDir = new TemporaryDirectory();
+            sc.SetCheckpointDir(TestEnvironment.ResourceDirectory);
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -94,6 +94,18 @@ namespace Microsoft.Spark
 
         JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
 
+        public enum LogLevel
+        {
+            ALL,
+            DEBUG,
+            ERROR,
+            FATAL,
+            INFO,
+            OFF,
+            TRACE,
+            WARN
+        }
+
         /// <summary>
         /// Returns SparkConf object associated with this SparkContext object.
         /// Note that modifying the SparkConf object will not have any impact.
@@ -119,6 +131,15 @@ namespace Microsoft.Spark
                     "org.apache.spark.SparkContext",
                     "getOrCreate",
                     conf));
+        }
+
+        /// <summary>
+        /// Control our logLevel. This overrides any user-defined log settings.
+        /// </summary>
+        /// <param name="logLevel">The desired log level.</param>
+        public void SetLogLevel(LogLevel logLevel)
+        {
+            _jvmObject.Invoke("setLogLevel", logLevel.ToString());
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -94,18 +94,6 @@ namespace Microsoft.Spark
 
         JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
 
-        public enum LogLevel
-        {
-            ALL,
-            DEBUG,
-            ERROR,
-            FATAL,
-            INFO,
-            OFF,
-            TRACE,
-            WARN
-        }
-
         /// <summary>
         /// Returns SparkConf object associated with this SparkContext object.
         /// Note that modifying the SparkConf object will not have any impact.
@@ -136,10 +124,13 @@ namespace Microsoft.Spark
         /// <summary>
         /// Control our logLevel. This overrides any user-defined log settings.
         /// </summary>
-        /// <param name="logLevel">The desired log level.</param>
-        public void SetLogLevel(LogLevel logLevel)
+        /// <remarks>
+        /// Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
+        /// </remarks>
+        /// <param name="logLevel">The desired log level as a string.</param>
+        public void SetLogLevel(string logLevel)
         {
-            _jvmObject.Invoke("setLogLevel", logLevel.ToString());
+            _jvmObject.Invoke("setLogLevel", logLevel);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR addresses #351 , exposing `SparkContext.setLogLevel` API, which helps change log levels programmatically.