### PR TITLE
Set the microsoft-spark version only in the parent pom.xml

### DIFF
--- a/src/scala/microsoft-spark-2.3.x/pom.xml
+++ b/src/scala/microsoft-spark-2.3.x/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.microsoft.scala</groupId>
     <artifactId>microsoft-spark</artifactId>
-    <version>0.7.0</version>
+    <version>${microsoft-spark.version}</version>
   </parent>
   <artifactId>microsoft-spark-2.3.x</artifactId>
   <inceptionYear>2019</inceptionYear>

--- a/src/scala/microsoft-spark-2.4.x/pom.xml
+++ b/src/scala/microsoft-spark-2.4.x/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.microsoft.scala</groupId>
     <artifactId>microsoft-spark</artifactId>
-    <version>0.7.0</version>
+    <version>${microsoft-spark.version}</version>
   </parent>
   <artifactId>microsoft-spark-2.4.x</artifactId>
   <inceptionYear>2019</inceptionYear>

--- a/src/scala/microsoft-spark-3.0.x/pom.xml
+++ b/src/scala/microsoft-spark-3.0.x/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.microsoft.scala</groupId>
     <artifactId>microsoft-spark</artifactId>
-    <version>0.7.0</version>
+    <version>${microsoft-spark.version}</version>
   </parent>
   <artifactId>microsoft-spark-3.0.x</artifactId>
   <inceptionYear>2019</inceptionYear>

--- a/src/scala/pom.xml
+++ b/src/scala/pom.xml
@@ -4,9 +4,10 @@
   <groupId>com.microsoft.scala</groupId>
   <artifactId>microsoft-spark</artifactId>
   <packaging>pom</packaging>
-  <version>0.7.0</version>
+  <version>${microsoft-spark.version}</version>
   <properties>
     <encoding>UTF-8</encoding>
+    <microsoft-spark.version>0.7.0</microsoft-spark.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
To help reduce the number of touched files during version updates, the individual microsoft-spark-<version> pom.xmls will inherit the version defined in the parent pom.xml