### PR TITLE
Precompute the normalized type names of DataTypes and use string.Create on NS2.1 for faster normalization.

### DIFF
--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0; netstandard2.1</TargetFrameworks>
     <RootNamespace>Microsoft.Spark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0; netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netstandard2.1</TargetFrameworks>
     <RootNamespace>Microsoft.Spark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Spark.Interop.Ipc;

--- a/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Spark.Interop.Ipc;
@@ -39,10 +39,13 @@ namespace Microsoft.Spark.Sql.Types
             typeof(MapType),
             typeof(StructType) };
 
+        private static string[] s_simpleTypeNormalizedNames = null;
+        private static string[] s_complexTypeNormalizedNames = null;
+
         /// <summary>
         /// Normalized type name.
         /// </summary>
-        public string TypeName => NormalizeTypeName(GetType().Name);
+        public string TypeName => NormalizeTypeName(GetType());
 
         /// <summary>
         /// Simple string version of the current data type.
@@ -134,19 +137,20 @@ namespace Microsoft.Spark.Sql.Types
                 var typeJObject = (JObject)json;
                 if (typeJObject.TryGetValue("type", out JToken type))
                 {
-                    Type complexType = s_complexTypes.FirstOrDefault(
-                        (t) => NormalizeTypeName(t.Name) == type.ToString());
+                    string typeName = type.ToString();
 
-                    if (complexType != default)
+                    int typeIndex = ComplexTypeIndex(typeName);
+
+                    if (typeIndex != -1)
                     {
                         return (DataType)Activator.CreateInstance(
-                            complexType,
+                            s_simpleTypes[typeIndex],
                             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                             null,
                             new object[] { typeJObject },
                             null);
                     }
-                    else if (type.ToString() == "udt")
+                    else if (typeName == "udt")
                     {
                         throw new NotImplementedException();
                     }
@@ -169,12 +173,12 @@ namespace Microsoft.Spark.Sql.Types
         private static DataType ParseSimpleType(JToken json)
         {
             string typeName = json.ToString();
-            Type simpleType = s_simpleTypes.FirstOrDefault(
-                (t) => NormalizeTypeName(t.Name) == typeName);
 
-            if (simpleType != default)
+            int typeIndex = SimpleTypeIndex(typeName);
+
+            if (typeIndex != -1)
             {
-                return (DataType)Activator.CreateInstance(simpleType);
+                return (DataType)Activator.CreateInstance(s_simpleTypes[typeIndex]);
             }
 
             Match decimalMatch = DecimalType.s_fixedDecimal.Match(typeName);
@@ -191,9 +195,99 @@ namespace Microsoft.Spark.Sql.Types
         /// <summary>
         /// Remove "Type" from the end of type name and lower cases to align with Scala type name.
         /// </summary>
+        /// <param name="type">The type to normalize.</param>
+        /// <returns>Normalized type name.</returns>
+        private static string NormalizeTypeName(Type type)
+        {
+            if (s_simpleTypeNormalizedNames == null)
+            {
+                Debug.Assert(s_complexTypeNormalizedNames == null);
+                BuildNormalizedStringMapping();
+            }
+
+            for (int i = 0; i < s_simpleTypes.Length; i++)
+            {
+                if (s_simpleTypes[i] == type)
+                {
+                    return s_simpleTypeNormalizedNames[i];
+                }
+            }
+
+            for (int i = 0; i < s_complexTypes.Length; i++)
+            {
+                if (s_complexTypes[i] == type)
+                {
+                    return s_complexTypeNormalizedNames[i];
+                }
+            }
+
+            return NormalizeTypeName(type.Name);
+        }
+
+        /// <summary>
+        /// Remove "Type" from the end of type name and lower cases to align with Scala type name.
+        /// </summary>
         /// <param name="typeName">Type name to normalize</param>
         /// <returns>Normalized type name</returns>
-        private static string NormalizeTypeName(string typeName) =>
-            typeName.Substring(0, typeName.Length - 4).ToLower();
+        private static string NormalizeTypeName(string typeName)
+        {
+#if NETSTANDARD2_1
+            return string.Create(typeName.Length - 4, typeName, (span, typeName) =>
+            {
+                typeName.AsSpan(0, typeName.Length - 4).ToLower(span, CultureInfo.CurrentCulture);
+            });
+#else
+            return typeName.Substring(0, typeName.Length - 4).ToLower();
+#endif
+        }
+
+        /// <summary>
+        /// Uses the built up normalized type name cache to find the index of the simple type that matches the passed in <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="typeName">Normalized simple type name to compare against.</param>
+        /// <returns>The index of the simple type within the list that matches the type name, if found. Otherwise, -1.</returns>
+        private static int SimpleTypeIndex(string typeName)
+        {
+            if (s_simpleTypeNormalizedNames == null)
+            {
+                Debug.Assert(s_complexTypeNormalizedNames == null);
+                BuildNormalizedStringMapping();
+            }
+            return s_simpleTypeNormalizedNames.AsSpan().IndexOf(typeName);
+        }
+
+        /// <summary>
+        /// Uses the built up normalized type name cache to find the index of the complex type that matches the passed in <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="typeName">Normalized complex type name to compare against.</param>
+        /// <returns>The index of the complex type within the list that matches the type name, if found. Otherwise, -1.</returns>
+        private static int ComplexTypeIndex(string typeName)
+        {
+            if (s_simpleTypeNormalizedNames == null)
+            {
+                Debug.Assert(s_complexTypeNormalizedNames == null);
+                BuildNormalizedStringMapping();
+            }
+            return s_complexTypeNormalizedNames.AsSpan().IndexOf(typeName);
+        }
+
+        /// <summary>
+        /// Builds up the normalized type name cache for both simple and complex types which is used for faster type name look up.
+        /// </summary>
+        private static void BuildNormalizedStringMapping()
+        {
+            s_simpleTypeNormalizedNames = new string[s_simpleTypes.Length];
+            s_complexTypeNormalizedNames = new string[s_complexTypes.Length];
+
+            for (int i = 0; i < s_simpleTypes.Length; i++)
+            {
+                s_simpleTypeNormalizedNames[i] = NormalizeTypeName(s_simpleTypes[i].Name);
+            }
+
+            for (int i = 0; i < s_complexTypes.Length; i++)
+            {
+                s_complexTypeNormalizedNames[i] = NormalizeTypeName(s_complexTypes[i].Name);
+            }
+        }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;

--- a/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Spark.Sql.Types
                     if (typeIndex != -1)
                     {
                         return (DataType)Activator.CreateInstance(
-                            s_simpleTypes[typeIndex],
+                            s_complexTypes[typeIndex],
                             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                             null,
                             new object[] { typeJObject },
@@ -232,10 +232,10 @@ namespace Microsoft.Spark.Sql.Types
         /// <returns>Normalized type name</returns>
         private static string NormalizeTypeName(string typeName)
         {
-#if NETSTANDARD2_1
-            return string.Create(typeName.Length - 4, typeName, (span, typeName) =>
+#if !NETSTANDARD2_0
+            return string.Create(typeName.Length - 4, typeName, (span, name) =>
             {
-                typeName.AsSpan(0, typeName.Length - 4).ToLower(span, CultureInfo.CurrentCulture);
+                name.AsSpan(0, name.Length - 4).ToLower(span, CultureInfo.CurrentCulture);
             });
 #else
             return typeName.Substring(0, typeName.Length - 4).ToLower();


### PR DESCRIPTION
I noticed some areas where the implementation could be made more performant by avoiding using Linq and caching the normalized type names for the simple and complex DataTypes. That way, they don't have to be computed every time. I am not sure if the code paths are perf critical, in which case, I would understand if this PR isn't useful. If that's the case, please let me know.

Also, added a call to use `string.Create` to make normalizing the type names a bit faster (and allocate less). If adding a netstandard2.1 TFM isn't feasible, please let me know and I can revert that part of the change.

The behavior isn't being changed at all, hence existing tests should be sufficient.

``` ini

BenchmarkDotNet=v0.11.5.1159-nightly, OS=Windows 10.0.18362
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.100-preview1-014459
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT
  Job-PDGMZC : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=10  
MinIterationCount=5  WarmupCount=1  

```
Accessing the `TypeName` property for the known simple/complex types got much faster:

|                Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
| TypeName_old | 41.71 ns | 0.684 ns | 0.304 ns | 41.61 ns | 41.31 ns | 42.22 ns |  1.00 | 0.0095 |     - |     - |      40 B |
|     TypeName_new | 14.52 ns | 0.360 ns | 0.188 ns | 14.53 ns | 14.25 ns | 14.72 ns |  0.35 |      - |     - |     - |         - |

Normalizing a new type name (using string.Create) reduces allocations:

|                Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
| NormalizeTypeName_old | 42.60 ns | 1.359 ns | 0.899 ns | 42.54 ns | 41.42 ns | 43.86 ns |  1.00 | 0.0190 |     - |     - |      80 B |
|     NormalizeTypeName_new | 38.42 ns | 0.762 ns | 0.453 ns | 38.22 ns | 38.02 ns | 39.35 ns |  0.90 |      - |     - |     - |    40 B |

cc @eerhardt 