### PR TITLE
[WIP] Fix E2E DataFrameTests for Spark 3.0.

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -487,7 +487,11 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             Assert.IsType<Row[]>(_df.Collect().ToArray());
 
-            Assert.IsType<Row[]>(_df.ToLocalIterator().ToArray());
+            if (SparkSettings.Version < new Version(Versions.V3_0_0))
+            {
+                // The following APIs are removed in Spark 3.0.
+                Assert.IsType<Row[]>(_df.ToLocalIterator().ToArray());
+             }
 
             Assert.IsType<long>(_df.Count());
 

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -714,7 +714,11 @@ namespace Microsoft.Spark.Sql
         /// Returns an iterator that contains all of the rows in this `DataFrame`.
         /// The iterator will consume as much memory as the largest partition in this `DataFrame`.
         /// </summary>
+        /// <remarks>
+        /// This API is removed in Spark 3.0.
+        /// </remarks>
         /// <returns>Row objects</returns>
+        [Removed(Versions.V3_0_0)]
         public IEnumerable<Row> ToLocalIterator()
         {
             return GetRows("toPythonIterator");


### PR DESCRIPTION
This fixes E2E DataFrameTests that are failing for Spark 3.0. because the APIs are either removed or deprecated.

This is a part of the effort to bring in CI for Spark 3.0: #348.

