### PR TITLE
Update dotnet tool version to 3.1.100

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100"
+    "dotnet": "3.1.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19257.7"


### PR DESCRIPTION
Internal signing build was failing because the dotnet tool version is updated to support .NET Core 3.1.