### PR TITLE
Support for Apache Spark 2.4.5

### DIFF
--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val supportedSparkVersions = Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4")
+  private val supportedSparkVersions = Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 


### PR DESCRIPTION
This is preparation for supporting Apache Spark 2.4.5 which should be available this week. The E2E testing was run against RC1 (https://dist.apache.org/repos/dist/dev/spark/v2.4.5-rc1-bin/), so this should be good to go. I will update azure pipeline to run against 2.4.5 once the official version is out.