### PR TITLE
Fix UDF returning StructType when it is the only column.

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
@@ -189,8 +189,8 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                 Func<Column, Column> udf = Udf<string>(
                     str => new GenericRow(new object[] { 111 }), schema);
 
-                // umn nameCol = _df["name"];
-                Row[] rows = _df.Select(udf(_df["name"]).As("col"), _df["name"]).Collect().ToArray();
+                Column nameCol = _df["name"];
+                Row[] rows = _df.Select(udf(nameCol).As("col"), nameCol).Collect().ToArray();
                 Assert.Equal(3, rows.Length);
 
                 foreach (Row row in rows)

--- a/src/csharp/Microsoft.Spark/Sql/RowCollector.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RowCollector.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Spark.Interop.Ipc;
@@ -34,24 +33,7 @@ namespace Microsoft.Spark.Sql
 
                 foreach (object unpickled in unpickledObjects)
                 {
-                    // Unpickled object can be either a RowConstructor object (not materialized),
-                    // or a Row object (materialized). Refer to RowConstruct.construct() to see how
-                    // Row objects are unpickled.
-                    switch (unpickled)
-                    {
-                        case RowConstructor rc:
-                            yield return rc.GetRow();
-                            break;
-
-                        case object[] objs when objs.Length == 1 && (objs[0] is Row row):
-                            yield return row;
-                            break;
-
-                        default:
-                            throw new NotSupportedException(
-                                string.Format("Unpickle type {0} is not supported",
-                                    unpickled.GetType()));
-                    }
+                    yield return (unpickled as RowConstructor).GetRow();
                 }
             }
         }

--- a/src/csharp/Microsoft.Spark/Sql/RowConstructor.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RowConstructor.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Spark.Sql
 
             // When a row is ready to be materialized, then construct() is called
             // on the RowConstructor which represents the row.
-            if ((args.Length == 1) && (args[0] is RowConstructor rowConstructor))
+            if ((args.Length == 1) &&
+                (args[0] is RowConstructor rowConstructor) &&
+                (rowConstructor._parent == null))
             {
                 // Construct the Row and return args containing the Row.
                 args[0] = rowConstructor.GetRow();


### PR DESCRIPTION
This is a follow up to #376 to address the following issue:
```C#
var schema = new StructType(new[] {
    new StructField("col1", new IntegerType()),
    new StructField("col2", new StringType()) });
    
var udf = Udf<string>(str => new GenericRow(new object[] { 1, "abc" }), schema);

Row[] rows = _df.Select(udf(_df["name"]).As("col")).Collect().ToArray();
Assert.Equal(3, rows.Length);
rows[0].GetAs<Row>("col"); // This would fail!
```
