### PR TITLE
Support DateType

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Sql.Catalog;
+using Microsoft.Spark.Sql.Types;
 using Xunit;
 using static Microsoft.Spark.Sql.Functions;
 
@@ -650,6 +651,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Udf<int, int>((arg) => arg);
             Udf<long, long>((arg) => arg);
             Udf<short, short>((arg) => arg);
+            Udf<DateTime, Date>((arg) => new Date(arg));
 
             // Test array type.
             Udf<string, string[]>((arg) => new[] { arg });

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -651,7 +651,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Udf<int, int>((arg) => arg);
             Udf<long, long>((arg) => arg);
             Udf<short, short>((arg) => arg);
-            Udf<DateTime, Date>((arg) => new Date(arg));
+            Udf<Date, Date>((arg) => arg);
 
             // Test array type.
             Udf<string, string[]>((arg) => new[] { arg });

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -127,6 +127,19 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                 DataFrame df = _spark.CreateDataFrame(data);
                 ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
             }
+            
+            // Calling CreateDataFrame(IEnumerable<DateTime> _) without schema
+            {
+                var data = new List<DateTime>(new DateTime[]
+                {
+                    new DateTime(2020, 1, 1),
+                    new DateTime(2020, 1, 2)
+                });
+                StructType schema = SchemaWithSingleColumn(new DateType());
+
+                DataFrame df = _spark.CreateDataFrame(data);
+                ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
+            }
         }
 
         private void ValidateDataFrame(

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             // Calling CreateDataFrame with schema
             {
                 var data = new List<GenericRow>();
-                data.Add(new GenericRow(new object[] { "Alice", 20, new DateTime(2020, 1, 1) }));
-                data.Add(new GenericRow(new object[] { "Bob", 30, new DateTime(2020, 1, 2) }));
+                data.Add(new GenericRow(new object[] { "Alice", 20, new Date(2020, 1, 1) }));
+                data.Add(new GenericRow(new object[] { "Bob", 30, new Date(2020, 1, 2) }));
 
                 var schema = new StructType(new List<StructField>()
                 {
@@ -128,12 +128,12 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                 ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
             }
             
-            // Calling CreateDataFrame(IEnumerable<DateTime> _) without schema
+            // Calling CreateDataFrame(IEnumerable<Date> _) without schema
             {
-                var data = new List<DateTime>(new DateTime[]
+                var data = new List<Date>(new Date[]
                 {
-                    new DateTime(2020, 1, 1),
-                    new DateTime(2020, 1, 2)
+                    new Date(2020, 1, 1),
+                    new Date(2020, 1, 2)
                 });
                 StructType schema = SchemaWithSingleColumn(new DateType());
 

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -130,11 +130,11 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             
             // Calling CreateDataFrame(IEnumerable<Date> _) without schema
             {
-                var data = new List<Date>(new Date[]
+                var data = new Date[]
                 {
                     new Date(2020, 1, 1),
                     new Date(2020, 1, 2)
-                });
+                };
                 StructType schema = SchemaWithSingleColumn(new DateType());
 
                 DataFrame df = _spark.CreateDataFrame(data);

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Spark.E2ETest.Utils;
@@ -78,13 +79,14 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             // Calling CreateDataFrame with schema
             {
                 var data = new List<GenericRow>();
-                data.Add(new GenericRow(new object[] { "Alice", 20 }));
-                data.Add(new GenericRow(new object[] { "Bob", 30 }));
+                data.Add(new GenericRow(new object[] { "Alice", 20, new DateTime(2020, 1, 1) }));
+                data.Add(new GenericRow(new object[] { "Bob", 30, new DateTime(2020, 1, 2) }));
 
                 var schema = new StructType(new List<StructField>()
                 {
                     new StructField("Name", new StringType()),
-                    new StructField("Age", new IntegerType())
+                    new StructField("Age", new IntegerType()),
+                    new StructField("Date", new DateType())
                 });
                 DataFrame df = _spark.CreateDataFrame(data, schema);
                 ValidateDataFrame(df, data.Select(a => a.Values), schema);

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/TypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/TypesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql.Types;
 using Xunit;

--- a/src/csharp/Microsoft.Spark.E2ETest/Resources/people.json
+++ b/src/csharp/Microsoft.Spark.E2ETest/Resources/people.json
@@ -1,3 +1,3 @@
-{"name":"Michael", "ids":[1], "info1":{"city":"Burdwan"}, "info2":{"state":"Paschimbanga"}, "info3":{"company":{"job":"Developer"}}}"
-{"name":"Andy", "age":30, "ids":[3,5], "info1":{"city":"Los Angeles"}, "info2":{"state":"California"}, "info3":{"company":{"job":"Developer"}}}
-{"name":"Justin", "age":19, "ids":[2,4], "info1":{"city":"Seattle"}, "info2":{"state":"Washington"}, "info3":{"company":{"job":"Developer"}}}
+{"name":"Michael", "ids":[1], "date":"2020-1-1", "info1":{"city":"Burdwan"}, "info2":{"state":"Paschimbanga"}, "info3":{"company":{"job":"Developer"}}}"
+{"name":"Andy", "age":30, "ids":[3,5], "date":"2020-1-2", "info1":{"city":"Los Angeles"}, "info2":{"state":"California"}, "info3":{"company":{"job":"Developer"}}}
+{"name":"Justin", "age":19, "ids":[2,4], "date":"2020-1-3", "info1":{"city":"Seattle"}, "info2":{"state":"Washington"}, "info3":{"company":{"job":"Developer"}}}

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                 for (int i = 0; i < rows.Length; ++i)
                 {
                     Assert.Equal(1, rows[i].Size());
-                    Assert.Equal(expected.ElementAt(i), rows[i].GetAs<Date>("col"));
+                    Assert.Equal(expected[i], rows[i].GetAs<Date>("col"));
                 }
             }
 
@@ -77,8 +77,11 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                 Assert.Equal(3, rows.Length);
 
                 var expected = new string[] { "2020-01-04", "2050-01-04", "2039-01-04" };
-                string[] rowsToArray = rows.Select(x => x[0].ToString()).ToArray();
-                Assert.Equal(expected, rowsToArray);
+                for (int i = 0; i < rows.Length; ++i)
+                {
+                    Assert.Equal(1, rows[i].Size());
+                    Assert.Equal(expected[i], rows[i].GetAs<string>(0));
+                }
             }
         }       
     }

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
+using Xunit;
+using static Microsoft.Spark.Sql.Functions;
+
+namespace Microsoft.Spark.E2ETest.UdfTests
+{
+    [Collection("Spark E2E Tests")]
+    public class UdfSimpleTypesTests
+    {
+        private readonly SparkSession _spark;
+        private readonly DataFrame _df;
+
+        public UdfSimpleTypesTests(SparkFixture fixture)
+        {
+            _spark = fixture.Spark;
+            _df = _spark
+                .Read()
+                .Schema("name STRING, date DATE")
+                .Json(Path.Combine($"{TestEnvironment.ResourceDirectory}people.json"));
+        }
+
+        /// <summary>
+        /// UDF that takes in Date type.
+        /// </summary>
+        [Fact]
+        public void TestUdfWithDateType()
+        {
+            Func<Column, Column> udf = Udf<Date, string>(date => date.ToString());
+
+            Row[] rows = _df.Select(udf(_df["date"])).Collect().ToArray();
+            Assert.Equal(3, rows.Length);
+
+            var expected = new string[] { "1/1/2020", "1/2/2020", "1/3/2020" };
+            string[] rowsToArray = rows.Select(x => x[0].ToString()).ToArray();
+            Assert.Equal(expected, rowsToArray);
+        }
+
+        /// <summary>
+        /// UDF that returns Date type.
+        /// </summary>
+        [Fact]
+        public void TestUdfWithReturnAsDateType()
+        {
+            Func<Column, Column> udf1 = Udf<string, Date>(str => new Date(2020, 1, 4));
+            Func<Column, Column> udf2 = Udf<Date, string>(date => date.ToString());
+
+            // Test UDF that returns a Date object.
+            {
+                Row[] rows = _df.Select(udf1(_df["name"]).Alias("col")).Collect().ToArray();
+                Assert.Equal(3, rows.Length);
+
+                foreach (Row row in rows)
+                {
+                    Assert.Equal(1, row.Size());
+                    Assert.IsType<Date>(row.Get("col"));
+                    Assert.Equal(new Date(2020, 1, 4).ToString(), row.Get("col").ToString());
+                }
+            }
+
+            // Chained UDFs.
+            {
+                Row[] rows = _df.Select(udf2(udf1(_df["name"]))).Collect().ToArray();
+                Assert.Equal(3, rows.Length);
+
+                foreach (Row row in rows)
+                {
+                    Assert.Equal(1, row.Size());
+                    Assert.Equal("1/4/2020", row.GetAs<string>(0));
+                }
+            }
+        }       
+    }
+}

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
@@ -83,6 +83,6 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                     Assert.Equal(expected[i], rows[i].GetAs<string>(0));
                 }
             }
-        }       
+        }
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs
@@ -60,8 +60,7 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                 foreach (Row row in rows)
                 {
                     Assert.Equal(1, row.Size());
-                    Assert.IsType<Date>(row.Get("col"));
-                    Assert.Equal(new Date(2020, 1, 4).ToString(), row.Get("col").ToString());
+                    Assert.Equal(new Date(2020, 1, 4), row.GetAs<Date>("col"));
                 }
             }
 

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Spark.Interop.Ipc
         private static readonly byte[] s_stringTypeId = new[] { (byte)'c' };
         private static readonly byte[] s_boolTypeId = new[] { (byte)'b' };
         private static readonly byte[] s_doubleTypeId = new[] { (byte)'d' };
+        private static readonly byte[] s_dateTypeId = new[] { (byte)'D' };
         private static readonly byte[] s_jvmObjectTypeId = new[] { (byte)'j' };
         private static readonly byte[] s_byteArrayTypeId = new[] { (byte)'r' };
         private static readonly byte[] s_doubleArrayArrayTypeId = new[] { ( byte)'A' };
@@ -100,6 +101,10 @@ namespace Microsoft.Spark.Interop.Ipc
 
                     case TypeCode.Double:
                         SerDe.Write(destination, (double)arg);
+                        break;
+
+                    case TypeCode.DateTime:
+                        SerDe.Write(destination, ((DateTime)arg).ToString("yyyy-MM-dd"));
                         break;
 
                     case TypeCode.Object:
@@ -286,6 +291,8 @@ namespace Microsoft.Spark.Interop.Ipc
                     return s_boolTypeId;
                 case TypeCode.Double:
                     return s_doubleTypeId;
+                case TypeCode.DateTime:
+                    return s_dateTypeId;
                 case TypeCode.Object:
                     if (typeof(IJvmObjectReferenceProvider).IsAssignableFrom(type))
                     {

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Spark.Interop.Ipc
                                 break;
 
                             case Date argDate:
-                                SerDe.Write(destination, argDate.ToString("yyyy-MM-dd"));
+                                SerDe.Write(destination, argDate.ToString());
                                 break;
 
                             default:

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.Interop.Ipc
 {
@@ -101,10 +102,6 @@ namespace Microsoft.Spark.Interop.Ipc
 
                     case TypeCode.Double:
                         SerDe.Write(destination, (double)arg);
-                        break;
-
-                    case TypeCode.DateTime:
-                        SerDe.Write(destination, ((DateTime)arg).ToString("yyyy-MM-dd"));
                         break;
 
                     case TypeCode.Object:
@@ -268,6 +265,10 @@ namespace Microsoft.Spark.Interop.Ipc
                                 SerDe.Write(destination, argProvider.Reference.Id);
                                 break;
 
+                            case Date argDate:
+                                SerDe.Write(destination, argDate.ToString("yyyy-MM-dd"));
+                                break;
+
                             default:
                                 throw new NotSupportedException(
                                     string.Format($"Type {arg.GetType()} is not supported"));
@@ -291,8 +292,6 @@ namespace Microsoft.Spark.Interop.Ipc
                     return s_boolTypeId;
                 case TypeCode.Double:
                     return s_doubleTypeId;
-                case TypeCode.DateTime:
-                    return s_dateTypeId;
                 case TypeCode.Object:
                     if (typeof(IJvmObjectReferenceProvider).IsAssignableFrom(type))
                     {
@@ -327,6 +326,11 @@ namespace Microsoft.Spark.Interop.Ipc
                     if (typeof(IEnumerable<GenericRow>).IsAssignableFrom(type))
                     {
                         return s_rowArrTypeId;
+                    }
+
+                    if (typeof(Date).IsAssignableFrom(type))
+                    {
+                        return s_dateTypeId;
                     }
                     break;
             }

--- a/src/csharp/Microsoft.Spark/Sql/CustomPicklers.cs
+++ b/src/csharp/Microsoft.Spark/Sql/CustomPicklers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Microsoft.Spark.Sql.Types;
 using Razorvine.Pickle;
 
 namespace Microsoft.Spark.Sql
@@ -26,6 +27,17 @@ namespace Microsoft.Spark.Sql
         public void pickle(object o, Stream outs, Pickler currentPickler)
         {
             currentPickler.save(((GenericRow)o).Values);
+        }
+    }
+
+    /// <summary>
+    /// Custom pickler for Date objects.
+    /// </summary>
+    internal class DatePickler : IObjectPickler
+    {
+        public void pickle(object o, Stream outs, Pickler currentPickler)
+        {
+            currentPickler.save(((Date)o).GetInterval());
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Row.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Row.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.Sql
             _genericRow = new GenericRow(values);
             Schema = schema;
 
-            int schemaColumnCount = Schema.Fields.Count;
+            var schemaColumnCount = Schema.Fields.Count;
             if (Size() != schemaColumnCount)
             {
                 throw new Exception(
@@ -77,7 +77,7 @@ namespace Microsoft.Spark.Sql
         /// Returns the string version of this row.
         /// </summary>
         /// <returns>String version of this row</returns>
-        public override string ToString() => _genericRow.ToString();        
+        public override string ToString() => _genericRow.ToString();
 
         /// <summary>
         /// Returns the column value at the given index, as a type T.
@@ -123,23 +123,12 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         private void Convert()
         {
-            foreach (StructField field in Schema.Fields)
+            for (int i = 0; i < Size(); ++i)
             {
-                if (field.DataType is ArrayType)
+                DataType dataType = Schema.Fields[i].DataType;
+                if (dataType.NeedConversion())
                 {
-                    throw new NotImplementedException();
-                }
-                else if (field.DataType is MapType)
-                {
-                    throw new NotImplementedException();
-                }
-                else if (field.DataType is DecimalType)
-                {
-                    throw new NotImplementedException();
-                }
-                else if (field.DataType is DateType)
-                {
-                    throw new NotImplementedException();
+                    Values[i] = dataType.FromInternal(Values[i]);
                 }
             }
         }

--- a/src/csharp/Microsoft.Spark/Sql/Row.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Row.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.Sql
             _genericRow = new GenericRow(values);
             Schema = schema;
 
-            var schemaColumnCount = Schema.Fields.Count;
+            int schemaColumnCount = Schema.Fields.Count;
             if (Size() != schemaColumnCount)
             {
                 throw new Exception(

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -189,12 +189,11 @@ namespace Microsoft.Spark.Sql
             CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new BooleanType()));
 
         /// <summary>
-        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type
-        /// <see cref="DateTime"/>
+        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type Date
         /// </summary>
         /// <param name="data"></param>
         /// <returns>Dataframe object</returns>
-        public DataFrame CreateDataFrame(IEnumerable<DateTime> data) =>
+        public DataFrame CreateDataFrame(IEnumerable<Date> data) =>
             CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new DateType()));
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -189,7 +189,8 @@ namespace Microsoft.Spark.Sql
             CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new BooleanType()));
 
         /// <summary>
-        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type <see cref="DateTime"/>
+        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type
+        /// <see cref="DateTime"/>
         /// </summary>
         /// <param name="data"></param>
         /// <returns>Dataframe object</returns>

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -189,6 +189,14 @@ namespace Microsoft.Spark.Sql
             CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new BooleanType()));
 
         /// <summary>
+        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type <see cref="DateTime"/>
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns>Dataframe object</returns>
+        public DataFrame CreateDataFrame(IEnumerable<DateTime> data) =>
+            CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new DateType()));
+
+        /// <summary>
         /// Executes a SQL query using Spark, returning the result as a DataFrame.
         /// </summary>
         /// <param name="sqlText">SQL query text</param>

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Spark.Sql
             CreateDataFrame(ToGenericRows(data), SchemaWithSingleColumn(new BooleanType()));
 
         /// <summary>
-        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type Date
+        /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type <see cref="Date"/>
         /// </summary>
         /// <param name="data"></param>
         /// <returns>Dataframe object</returns>

--- a/src/csharp/Microsoft.Spark/Sql/Types/ComplexTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/ComplexTypes.cs
@@ -68,6 +68,10 @@ namespace Microsoft.Spark.Sql.Types
             ContainsNull = (bool)json["containsNull"];
             return this;
         }
+
+        internal override bool NeedConversion() => true;
+
+        internal override object FromInternal(object obj) => throw new NotImplementedException();
     }
 
     /// <summary>
@@ -137,6 +141,10 @@ namespace Microsoft.Spark.Sql.Types
             ValueContainsNull = (bool)json["valueContainsNull"];
             return this;
         }
+
+        internal override bool NeedConversion() => true;
+
+        internal override object FromInternal(object obj) => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/DataType.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Spark.Sql.Types
         /// JSON value of this data type.
         /// </summary>
         internal virtual object JsonValue => TypeName;
-        
+
         /// <summary>
         /// Parses a JSON string to create a <see cref="JvmObjectReference"/>.
         /// It references a <see cref="StructType"/> on the JVM side.
@@ -93,7 +93,7 @@ namespace Microsoft.Spark.Sql.Types
                 "fromJson",
                 json);
         }
-        
+
         /// <summary>
         /// Parses a JSON string to construct a DataType.
         /// </summary>
@@ -172,6 +172,16 @@ namespace Microsoft.Spark.Sql.Types
             }
 
         }
+
+        /// <summary>
+        /// Does this type need to conversion between C# object and internal SQL object.
+        /// </summary>
+        internal virtual bool NeedConversion() => false;
+
+        /// <summary>
+        /// Converts an internal SQL object into a native C# object.
+        /// </summary>
+        internal virtual object FromInternal(object obj) => obj;
 
         /// <summary>
         /// Parses a JToken object that represents a simple type.

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -56,6 +56,12 @@ namespace Microsoft.Spark.Sql.Types
         public override string ToString() => $"{Month}/{Day}/{Year}";
 
         /// <summary>
+        /// Readable string representation for this type using the specified format.
+        /// </summary>
+        /// <param name="format">A standard or custom date and time format string</param>
+        public string ToString(string format) => new DateTime(Year, Month, Day).ToString(format);
+
+        /// <summary>
         /// Returns DateTime object describing this type.
         /// </summary>
         public DateTime ToDateTime() => new DateTime(Year, Month, Day);

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -73,11 +73,13 @@ namespace Microsoft.Spark.Sql.Types
         /// <summary>
         /// Returns DateTime object describing this type.
         /// </summary>
+        /// <returns>DateTime object of the current object</returns>
         public DateTime ToDateTime() => _dateTime;
 
         /// <summary>
         /// Returns an integer object that represents a count of days from 1970-01-01.
         /// </summary>
+        /// <returns>Integer object that represents a count of days from 1970-01-01.</returns>
         internal int GetInterval() => (_dateTime - s_unixTimeEpoch).Days;
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Spark.Sql.Types
+{
+    /// <summary>
+    /// Represents Date containing year, month, and day.
+    /// </summary>
+    public class Date
+    {
+        /// <summary>
+        /// Constructor for Date class.
+        /// </summary>
+        /// <param name="dt">DateTime object</param>
+        public Date(DateTime dt)
+        {
+            Year = dt.Year;
+            Month = dt.Month;
+            Day = dt.Day;
+        }
+
+        /// <summary>
+        /// Constructor for Date class.
+        /// </summary>
+        /// <param name="year">The year (1 through 9999)</param>
+        /// <param name="month">The month (1 through 12)</param>
+        /// <param name="day">The day (1 through the number of days in month)</param>
+        public Date(int year, int month, int day)
+        {
+            Year = year;
+            Month = month;
+            Day = day;
+        }
+
+        /// <summary>
+        /// Returns the year component of the date.
+        /// </summary>
+        public int Year { get; private set; }
+
+        /// <summary>
+        /// Returns the month component of the date.
+        /// </summary>
+        public int Month { get; private set; }
+
+        /// <summary>
+        /// Returns the day component of the date.
+        /// </summary>
+        public int Day { get; private set; }
+
+        /// <summary>
+        /// Readable string representation for this type.
+        /// </summary>
+        public override string ToString() => $"{Month}/{Day}/{Year}";
+
+        /// <summary>
+        /// Returns DateTime object describing this type.
+        /// </summary>
+        public DateTime ToDateTime() => new DateTime(Year, Month, Day);
+
+        /// <summary>
+        /// Returns an integer object that represents a count of days from 1970-01-01.
+        /// </summary>
+        internal int GetInterval()
+        {
+            var unixTimeEpoch = new DateTime(1970, 1, 1);
+            return (new DateTime(Year, Month, Day) - unixTimeEpoch).Days;
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Spark.Sql.Types
         /// <summary>
         /// Constructor for Date class.
         /// </summary>
-        /// <param name="dt">DateTime object</param>
-        public Date(DateTime dt)
+        /// <param name="dateTime">DateTime object</param>
+        public Date(DateTime dateTime)
         {
-            _dateTime = dt;
+            _dateTime = dateTime;
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -62,6 +62,22 @@ namespace Microsoft.Spark.Sql.Types
         public string ToString(string format) => new DateTime(Year, Month, Day).ToString(format);
 
         /// <summary>
+        /// Checks if the given object is same as the current object.
+        /// </summary>
+        /// <param name="obj">Other object to compare against</param>
+        /// <returns>True if the other object is equal.</returns>
+        public override bool Equals(object obj) =>
+            ReferenceEquals(this, obj) ||
+            ((obj is Date date) && Year.Equals(date.Year) &&
+            Month.Equals(date.Month) && Day.Equals(date.Day));
+
+        /// <summary>
+        /// Returns the hash code of the current object.
+        /// </summary>
+        /// <returns>The hash code of the current object</returns>
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
         /// Returns DateTime object describing this type.
         /// </summary>
         public DateTime ToDateTime() => new DateTime(Year, Month, Day);

--- a/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/Date.cs
@@ -11,15 +11,16 @@ namespace Microsoft.Spark.Sql.Types
     /// </summary>
     public class Date
     {
+        private readonly DateTime _dateTime;
+        private static readonly DateTime s_unixTimeEpoch = new DateTime(1970, 1, 1);
+
         /// <summary>
         /// Constructor for Date class.
         /// </summary>
         /// <param name="dt">DateTime object</param>
         public Date(DateTime dt)
         {
-            Year = dt.Year;
-            Month = dt.Month;
-            Day = dt.Day;
+            _dateTime = dt;
         }
 
         /// <summary>
@@ -30,36 +31,28 @@ namespace Microsoft.Spark.Sql.Types
         /// <param name="day">The day (1 through the number of days in month)</param>
         public Date(int year, int month, int day)
         {
-            Year = year;
-            Month = month;
-            Day = day;
+            _dateTime = new DateTime(year, month, day);
         }
 
         /// <summary>
         /// Returns the year component of the date.
         /// </summary>
-        public int Year { get; private set; }
+        public int Year => _dateTime.Year;
 
         /// <summary>
         /// Returns the month component of the date.
         /// </summary>
-        public int Month { get; private set; }
+        public int Month => _dateTime.Month;
 
         /// <summary>
         /// Returns the day component of the date.
         /// </summary>
-        public int Day { get; private set; }
+        public int Day => _dateTime.Day;
 
         /// <summary>
         /// Readable string representation for this type.
         /// </summary>
-        public override string ToString() => $"{Month}/{Day}/{Year}";
-
-        /// <summary>
-        /// Readable string representation for this type using the specified format.
-        /// </summary>
-        /// <param name="format">A standard or custom date and time format string</param>
-        public string ToString(string format) => new DateTime(Year, Month, Day).ToString(format);
+        public override string ToString() => _dateTime.ToString("yyyy-MM-dd");
 
         /// <summary>
         /// Checks if the given object is same as the current object.
@@ -68,8 +61,8 @@ namespace Microsoft.Spark.Sql.Types
         /// <returns>True if the other object is equal.</returns>
         public override bool Equals(object obj) =>
             ReferenceEquals(this, obj) ||
-            ((obj is Date date) && Year.Equals(date.Year) &&
-            Month.Equals(date.Month) && Day.Equals(date.Day));
+            ((obj is Date date) && Year.Equals(date.Year) && Month.Equals(date.Month) &&
+                Day.Equals(date.Day));
 
         /// <summary>
         /// Returns the hash code of the current object.
@@ -80,15 +73,11 @@ namespace Microsoft.Spark.Sql.Types
         /// <summary>
         /// Returns DateTime object describing this type.
         /// </summary>
-        public DateTime ToDateTime() => new DateTime(Year, Month, Day);
+        public DateTime ToDateTime() => _dateTime;
 
         /// <summary>
         /// Returns an integer object that represents a count of days from 1970-01-01.
         /// </summary>
-        internal int GetInterval()
-        {
-            var unixTimeEpoch = new DateTime(1970, 1, 1);
-            return (new DateTime(Year, Month, Day) - unixTimeEpoch).Days;
-        }
+        internal int GetInterval() => (_dateTime - s_unixTimeEpoch).Days;
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Spark.Sql.Types
 
         internal override object FromInternal(object obj)
         {
-            var unixTimeEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var unixTimeEpoch = new DateTime(1970, 1, 1);
             return new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks);
         }
     }

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Spark.Sql.Types
     public sealed class DateType : AtomicType
     {
         private static readonly DateTime s_unixTimeEpoch = new DateTime(1970, 1, 1);
+
         internal override bool NeedConversion() => true;
 
         internal override object FromInternal(object obj)

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Spark.Sql.Types
         internal override object FromInternal(object obj)
         {
             var unixTimeEpoch = new DateTime(1970, 1, 1);
-            return new Date(new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks));
+            return new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks);
         }
     }
 

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Spark.Sql.Types
     /// </summary>
     public sealed class DateType : AtomicType
     {
+        private static readonly DateTime s_unixTimeEpoch = new DateTime(1970, 1, 1);
         internal override bool NeedConversion() => true;
 
         internal override object FromInternal(object obj)
         {
-            var unixTimeEpoch = new DateTime(1970, 1, 1);
-            return new Date(new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks));
+            return new Date(new DateTime((int)obj * TimeSpan.TicksPerDay + s_unixTimeEpoch.Ticks));
         }
     }
 

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Spark.Sql.Types
@@ -63,10 +64,18 @@ namespace Microsoft.Spark.Sql.Types
     }
 
     /// <summary>
-    /// Represents a date type.
+    /// Represents a date type. It represents a valid date in the proleptic Gregorian
+    /// calendar. Valid range is [0001-01-01, 9999-12-31].
     /// </summary>
     public sealed class DateType : AtomicType
     {
+        internal override bool NeedConversion() => true;
+
+        internal override object FromInternal(object obj)
+        {
+            var unixTimeEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks);
+        }
     }
 
     /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/SimpleTypes.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Spark.Sql.Types
         internal override object FromInternal(object obj)
         {
             var unixTimeEpoch = new DateTime(1970, 1, 1);
-            return new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks);
+            return new Date(new DateTime((int)obj * TimeSpan.TicksPerDay + unixTimeEpoch.Ticks));
         }
     }
 

--- a/src/csharp/Microsoft.Spark/Utils/PythonSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/PythonSerDe.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 using Razorvine.Pickle;
 using Razorvine.Pickle.Objects;
 
@@ -39,6 +40,7 @@ namespace Microsoft.Spark.Utils
             // Register custom picklers.
             Pickler.registerCustomPickler(typeof(Row), new RowPickler());
             Pickler.registerCustomPickler(typeof(GenericRow), new GenericRowPickler());
+            Pickler.registerCustomPickler(typeof(Date), new DatePickler());
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -11,6 +11,7 @@ using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Internal.Java.Util;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.Utils
 {
@@ -92,6 +93,7 @@ namespace Microsoft.Spark.Utils
                 {typeof(int), "integer"},
                 {typeof(long), "long"},
                 {typeof(short), "short"},
+                {typeof(Date), "date"},
 
                 // Arrow array types
                 {typeof(BooleanArray), "boolean"},


### PR DESCRIPTION
This PR exposes `DateType` which will support one of the `DataType` in #26. This PR will also fix #389 and #410. It provides the `DateType` support as below:
1. Support `DataFrame.Collect()` for `DateType`.
2. Support `CreateDataFrame` that takes in `Date`. Please see examples as below.
3. Support UDF that takes in `Date` and UDF that returns `Date`. Please see examples as below.
```csharp
// create df using CreateDataFrame.
var data = new List<GenericRow>();
data.Add(new GenericRow(new object[] { "Alice", new Date(2020, 1, 1) }));
data.Add(new GenericRow(new object[] { "Bob", new Date(2020, 1, 2) }));

var schema = new StructType(new List<StructField>()
{
    new StructField("name", new StringType()),
    new StructField("date", new DateType())
});
DataFrame df = spark.CreateDataFrame(data, schema);

// PrintSchema() prints:
// root
//  |-- name: string (nullable = true)
//  |-- date: date (nullable = true)
df.PrintSchema();

// Show() prints:
// +-----+----------+
// | name|      date|
// +-----+----------+
// |Alice|2020-01-01|
// |  Bob|2020-01-02|
// +-----+----------+
df.Show();

// udf that takes in DateTime.
Func<Column, Column> udf1 = Udf<Date, string>(s => s.ToString());
DataFrame udfDf1 = df.Select(udf1(df["date"]).As("udf1"));
Row[] rows1 = udfDf1.Collect().ToArray();

// PrintSchema() prints:
// root
//  |-- udf1: string (nullable = true)
udfDf1.PrintSchema();

// Show() prints:
// +----------+
// |   udf1   |
// +----------+
// |2020-01-01|
// |2020-01-02|
// +---------+
udfDf1.Show();

//udf that returns Date.
Func<Column, Column> udf2 = Udf<string, Date>(s => new Date(2020, 2, 2));
DataFrame udfDf2 = df.Select(udf2(df["name"]).As("udf2"));
Row[] rows2 = udfDf2.Collect().ToArray();

// PrintSchema() prints:
// root
//  |-- udf2: date (nullable = true)
udfDf2.PrintSchema();

// Show() prints:
// +----------+
// |      udf2|
// +----------+
// |2020-02-02|
// |2020-02-02|
// +----------+
udfDf2.Show();
```