### PR TITLE
Support for Spark 2.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     <tbody align="center">
         <tr>
             <td >2.3.*</td>
-            <td rowspan=5><a href="https://github.com/dotnet/spark/releases/tag/v0.8.0">v0.8.0</a></td>
+            <td rowspan=6><a href="https://github.com/dotnet/spark/releases/tag/v0.8.0">v0.8.0</a></td>
         </tr>
         <tr>
             <td>2.4.0</td>
@@ -52,6 +52,9 @@
         </tr>
         <tr>
             <td>2.4.4</td>
+        </tr>
+        <tr>
+            <td>2.4.5</td>
         </tr>
         <tr>
             <td>2.4.2</td>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,15 @@ jobs:
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
 
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.5'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2
       displayName: Stage .NET artifacts

--- a/script/download-spark-distros.cmd
+++ b/script/download-spark-distros.cmd
@@ -22,5 +22,6 @@ curl -k -L -o spark-2.4.0.tgz https://archive.apache.org/dist/spark/spark-2.4.0/
 curl -k -L -o spark-2.4.1.tgz https://archive.apache.org/dist/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz && tar xzvf spark-2.4.1.tgz
 curl -k -L -o spark-2.4.3.tgz https://archive.apache.org/dist/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz && tar xzvf spark-2.4.3.tgz
 curl -k -L -o spark-2.4.4.tgz https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && tar xzvf spark-2.4.4.tgz
+curl -k -L -o spark-2.4.5.tgz https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz && tar xzvf spark-2.4.5.tgz
 
 endlocal


### PR DESCRIPTION
Spark 2.4.5 has been just released: https://spark.apache.org/releases/spark-release-2-4-5.html

This PR adds E2E tests with Spark 2.4.5 along with doc updates. Note that jar is updated in #392.