### PR TITLE
Fixes #421: Orphaning of DotnetBackend and .NET process in Databricks

### DIFF
--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -132,9 +132,9 @@ object DotnetRunner extends Logging {
           process.waitFor()
         } catch {
           case t: Throwable =>
-            logError(s"${t.getMessage} \n ${t.getStackTrace}")
+            logThrowable(t)
         } finally {
-          returnCode = destroyDotnetProcess(process)
+          returnCode = closeDotnetProcess(process)
           closeBackend(dotnetBackend)
         }
 
@@ -235,12 +235,28 @@ object DotnetRunner extends Logging {
     dotnetBackend.close()
   }
 
-  private def destroyDotnetProcess(dotnetProcess: Process): Int = dotnetProcess match {
-    case process: Process if process.isAlive =>
-      logInfo("Destroying .NET Process")
-      process.destroyForcibly().waitFor()
-    case process: Process => process.exitValue()
-    case _ => 0
+  private def closeDotnetProcess(dotnetProcess: Process): Int = {
+    if (dotnetProcess == null) {
+      return -1
+    } else if (!dotnetProcess.isAlive) {
+      return dotnetProcess.exitValue()
+    }
+
+    // Try to (gracefully on Linux) kill the process and resort to force if interrupted
+    var returnCode = -1
+    logInfo("Closing .NET process")
+    try {
+      dotnetProcess.destroy()
+      returnCode = dotnetProcess.waitFor()
+    } catch {
+      case _: InterruptedException =>
+        logInfo("Thread interrupted while waiting for graceful close. Forcefully closing .NET process")
+        returnCode = dotnetProcess.destroyForcibly().waitFor()
+      case t: Throwable =>
+        logThrowable(t)
+    }
+
+    returnCode
   }
 
   private def initializeSettings(args: Array[String]): (Boolean, Int) = {
@@ -257,4 +273,7 @@ object DotnetRunner extends Logging {
 
     (runInDebugMode, portNumber)
   }
+
+  private def logThrowable(throwable: Throwable): Unit =
+    logError(s"${throwable.getMessage} \n ${throwable.getStackTrace.mkString("\n")}")
 }

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -110,6 +110,7 @@ object DotnetRunner extends Logging {
     if (initialized.tryAcquire(backendTimeout, TimeUnit.SECONDS)) {
       if (!runInDebugMode) {
         var returnCode = -1
+        var process: Process = null
         try {
           val builder = new ProcessBuilder(processParameters)
           val env = builder.environment()
@@ -120,7 +121,7 @@ object DotnetRunner extends Logging {
             logInfo(s"Adding key=$key and value=$value to environment")
           }
           builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
-          val process = builder.start()
+          process = builder.start()
 
           // Redirect stdin of JVM process to stdin of .NET process.
           new RedirectThread(System.in, process.getOutputStream, "redirect JVM input").start()
@@ -128,11 +129,13 @@ object DotnetRunner extends Logging {
           new RedirectThread(process.getInputStream, System.out, "redirect .NET stdout").start()
           new RedirectThread(process.getErrorStream, System.out, "redirect .NET stderr").start()
 
-          returnCode = process.waitFor()
-          closeBackend(dotnetBackend)
+           process.waitFor()
         } catch {
           case t: Throwable =>
             logError(s"${t.getMessage} \n ${t.getStackTrace}")
+        } finally {
+          returnCode = destroyDotnetProcess(process)
+          closeBackend(dotnetBackend)
         }
 
         if (returnCode != 0) {
@@ -230,6 +233,14 @@ object DotnetRunner extends Logging {
   private def closeBackend(dotnetBackend: DotnetBackend): Unit = {
     logInfo("Closing DotnetBackend")
     dotnetBackend.close()
+  }
+
+  private def destroyDotnetProcess(dotnetProcess: Process): Int = dotnetProcess match {
+    case process: Process if process.isAlive =>
+      logInfo("Destroying .NET Process")
+      process.destroyForcibly().waitFor()
+    case process: Process => process.exitValue()
+    case _ => 0
   }
 
   private def initializeSettings(args: Array[String]): (Boolean, Int) = {

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -132,9 +132,9 @@ object DotnetRunner extends Logging {
           process.waitFor()
         } catch {
           case t: Throwable =>
-            logError(s"${t.getMessage} \n ${t.getStackTrace}")
+            logThrowable(t)
         } finally {
-          returnCode = destroyDotnetProcess(process)
+          returnCode = closeDotnetProcess(process)
           closeBackend(dotnetBackend)
         }
 
@@ -235,12 +235,28 @@ object DotnetRunner extends Logging {
     dotnetBackend.close()
   }
 
-  private def destroyDotnetProcess(dotnetProcess: Process): Int = dotnetProcess match {
-    case process: Process if process.isAlive =>
-      logInfo("Destroying .NET Process")
-      process.destroyForcibly().waitFor()
-    case process: Process => process.exitValue()
-    case _ => 0
+  private def closeDotnetProcess(dotnetProcess: Process): Int = {
+    if (dotnetProcess == null) {
+      return -1
+    } else if (!dotnetProcess.isAlive) {
+      return dotnetProcess.exitValue()
+    }
+
+    // Try to (gracefully on Linux) kill the process and resort to force if interrupted
+    var returnCode = -1
+    logInfo("Closing .NET process")
+    try {
+      dotnetProcess.destroy()
+      returnCode = dotnetProcess.waitFor()
+    } catch {
+      case _: InterruptedException =>
+        logInfo("Thread interrupted while waiting for graceful close. Forcefully closing .NET process")
+        returnCode = dotnetProcess.destroyForcibly().waitFor()
+      case t: Throwable =>
+        logThrowable(t)
+    }
+
+    returnCode
   }
 
   private def initializeSettings(args: Array[String]): (Boolean, Int) = {
@@ -257,4 +273,7 @@ object DotnetRunner extends Logging {
 
     (runInDebugMode, portNumber)
   }
+
+  private def logThrowable(throwable: Throwable): Unit =
+    logError(s"${throwable.getMessage} \n ${throwable.getStackTrace.mkString("\n")}")
 }


### PR DESCRIPTION
Addresses #421 and additionally fixes `logError` to actually print the stack trace from the `Throwable` (previously it printed the object string).

### Changes
- Added `closeDotnetProcess` for cleaning up the started .NET process
- Added `finally` for cleaning up `DotnetBackend` as well as the .NET process
- Added `logThrowable` for code reuse

### Tested scenarios
- `process.destroy()` vs `process.destroyForcibly()`
  - `SIGTERM` sent vs `SIGKILL` sent respectively
- Confirming request to terminate is received inside of .NET when `process.destroy()` is called
  - Can be caught via `AppDomain.CurrentDomain.ProcessExit`
- Determined what happens when .NET tries to continue running indefinitely after termination signal
  - Another thread interrupt is made by Databricks after ~6 seconds
  - I did not test what happens after the second interrupt
- Concluded that Windows doesn't have a reasonable graceful termination story
  - Windows doesn't have termination signals like Linux
  - OpenJDK8 calls [TerminateProcess](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess) to destroy a process on Windows
- Validated that `process.destroyForcibly()` does in fact kill the process ungracefully
- Validated that the `DotnetBackend` thread is getting closed inside of the the Java process

### Additional details
#### Cleanup logic
Databricks sends an interrupt signal to the DotnetRunner's thread, which causes `process.waitFor()` to throw an `InterruptedException`. When cleanup occurs after the initial interrupt, Databricks may send a second interrupt if the DotnetRunner thread hasn't stopped within about 6 seconds (based on log timestamps). The idea here is that if a second interrupt occurs, then we should forcibly kill the .NET process via `process.destroyForcibly()`.

On Windows, if this same logic occurred, the .NET process would be forcibly killed once `process.destroy()` was called. Through minor testing, it doesn't seem like we can manually send an equivalent signal via the stdin of the process.

#### stdin, stdout, stderr notes
It should be noted that once `process.destroy()` is called, the standard streams of the process are closed. Printing to the console from .NET will stop working once called.

#### Throwable logging fix
I noticed that the stack trace from `catch` was printing the stack trace array's object string instead of the actual stack trace, so I added `.mkString("\n")` to the call.