### PR TITLE
Dispose MemoryStream

### DIFF
--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -229,14 +229,16 @@ namespace Microsoft.Spark
         internal RDD<T> Parallelize<T>(IEnumerable<T> seq, int? numSlices = null)
         {
             var formatter = new BinaryFormatter();
-            var memoryStream = new MemoryStream();
-
             var values = new List<byte[]>();
-            foreach (T obj in seq)
+
+            using (var memoryStream = new MemoryStream())
             {
-                formatter.Serialize(memoryStream, obj);
-                values.Add(memoryStream.ToArray());
-                memoryStream.SetLength(0);
+                foreach (T obj in seq)
+                {
+                    formatter.Serialize(memoryStream, obj);
+                    values.Add(memoryStream.ToArray());
+                    memoryStream.SetLength(0);
+                }
             }
 
             return new RDD<T>(

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -229,16 +229,14 @@ namespace Microsoft.Spark
         internal RDD<T> Parallelize<T>(IEnumerable<T> seq, int? numSlices = null)
         {
             var formatter = new BinaryFormatter();
-            var values = new List<byte[]>();
+            using var memoryStream = new MemoryStream();
 
-            using (var memoryStream = new MemoryStream())
+            var values = new List<byte[]>();
+            foreach (T obj in seq)
             {
-                foreach (T obj in seq)
-                {
-                    formatter.Serialize(memoryStream, obj);
-                    values.Add(memoryStream.ToArray());
-                    memoryStream.SetLength(0);
-                }
+                formatter.Serialize(memoryStream, obj);
+                values.Add(memoryStream.ToArray());
+                memoryStream.SetLength(0);
             }
 
             return new RDD<T>(


### PR DESCRIPTION
This small PR makes sure the `MemoryStream` in `SparkContext` gets disposed.