### PR TITLE
Adding SPARK_VERSION_OVERRIDE environment variable

### DIFF
--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -183,6 +183,8 @@ namespace Microsoft.Spark.Utils
                     AssemblySearchPathResolver.AssemblySearchPathsEnvVarName,
                     assemblySearchPath);
             }
+            // DOTNET_WORKER_SPARK_VERSION is used to handle different versions of Spark on the worker.
+            environmentVars.Put("DOTNET_WORKER_SPARK_VERSION", SparkEnvironment.SparkVersion.ToString());
 
             return environmentVars;
         }

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
@@ -25,8 +25,6 @@ object SQLUtils {
       pythonVersion: String,
       broadcastVars: JList[Broadcast[PythonBroadcast]],
       accumulator: PythonAccumulatorV2): PythonFunction = {
-    // DOTNET_WORKER_SPARK_VERSION is used to handle different versions of Spark on the worker.
-    envVars.put("DOTNET_WORKER_SPARK_VERSION", DotnetRunner.SPARK_VERSION)
 
     PythonFunction(
       command,

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
@@ -25,8 +25,6 @@ object SQLUtils {
       pythonVersion: String,
       broadcastVars: JList[Broadcast[PythonBroadcast]],
       accumulator: PythonAccumulatorV2): PythonFunction = {
-    // DOTNET_WORKER_SPARK_VERSION is used to handle different versions of Spark on the worker.
-    envVars.put("DOTNET_WORKER_SPARK_VERSION", DotnetRunner.SPARK_VERSION)
 
     PythonFunction(
       command,

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/sql/api/dotnet/SQLUtils.scala
@@ -25,8 +25,6 @@ object SQLUtils {
       pythonVersion: String,
       broadcastVars: JList[Broadcast[PythonBroadcast]],
       accumulator: PythonAccumulatorV2): PythonFunction = {
-    // DOTNET_WORKER_SPARK_VERSION is used to handle different versions of Spark on the worker.
-    envVars.put("DOTNET_WORKER_SPARK_VERSION", DotnetRunner.SPARK_VERSION)
 
     PythonFunction(
       command,


### PR DESCRIPTION
This PR adds the `SPARK_VERSION_OVERRIDE` environment variable.

If `SPARK_VERSION_OVERRIDE` is set, it will override the `DOTNET_WORKER_SPARK_VERSION`. For example, if the driver uses Spark version 2.4.1. And `SPARK_VERSION_OVERRIDE` is set to 2.3.1. When running UDF, the job will hang since the version is not matching.

One the other hand, if we want to run Microsoft.Spark.Worker in specific Spark version. The `SPARK_VERSION_OVERRIDE` should be set to match that version. So it can help avoid (patch)version mismatch problems.