### PR TITLE
Streamline logging when there is a failure

### DIFF
--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -244,9 +244,9 @@ namespace Microsoft.Spark.Interop.Ipc
             object[] args)
         {
             var errorMessage = new StringBuilder("JVM method execution failed: ");
-            const string ConstructorFormat = "Constructor failed for class {0}";
-            const string StaticMethodFormat = "Static method {0} failed for class {1}";
-            const string NonStaticMethodFormat = "Nonstatic method {0} failed for class {1}";
+            const string ConstructorFormat = "Constructor failed for class '{0}'";
+            const string StaticMethodFormat = "Static method '{0}' failed for class '{1}'";
+            const string NonStaticMethodFormat = "Nonstatic method '{0}' failed for class '{1}'";
 
             try
             {

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -185,21 +185,21 @@ class DotnetBackendHandler(server: DotnetBackend)
           case Some(jObj) => jObj.getClass.getName
           case None => "NullObject"
         }
-        logError(s"On object of type $jvmObjName failed", e)
+        val argsStr = args.map(arg => {
+          if (arg != null) {
+            s"[Type=${arg.getClass.getCanonicalName}, Value: $arg]"
+          } else {
+            "[Value: NULL]"
+          }
+        }).mkString(", ")
+
+        logError(s"Failed to execute '$methodName' on '$jvmObjName' with args=($argsStr)")
+
         if (methods != null) {
-          logError("methods:")
-          methods.foreach(m => logError(m.toString))
+          logDebug(s"All methods for $jvmObjName:")
+          methods.foreach(m => logDebug(m.toString))
         }
-        if (args != null) {
-          logError("args:")
-          args.foreach(arg => {
-            if (arg != null) {
-              logError(s"argType: ${arg.getClass.getCanonicalName}, argValue: $arg")
-            } else {
-              logError("arg: NULL")
-            }
-          })
-        }
+
         writeInt(dos, -1)
         writeString(dos, Utils.exceptionString(e.getCause))
     }

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -185,21 +185,21 @@ class DotnetBackendHandler(server: DotnetBackend)
           case Some(jObj) => jObj.getClass.getName
           case None => "NullObject"
         }
-        logError(s"On object of type $jvmObjName failed", e)
+        val argsStr = args.map(arg => {
+          if (arg != null) {
+            s"[Type=${arg.getClass.getCanonicalName}, Value: $arg]"
+          } else {
+            "[Value: NULL]"
+          }
+        }).mkString(", ")
+
+        logError(s"Failed to execute '$methodName' on '$jvmObjName' with args=($argsStr)")
+
         if (methods != null) {
-          logError("methods:")
-          methods.foreach(m => logError(m.toString))
+          logDebug(s"All methods for $jvmObjName:")
+          methods.foreach(m => logDebug(m.toString))
         }
-        if (args != null) {
-          logError("args:")
-          args.foreach(arg => {
-            if (arg != null) {
-              logError(s"argType: ${arg.getClass.getCanonicalName}, argValue: $arg")
-            } else {
-              logError("arg: NULL")
-            }
-          })
-        }
+
         writeInt(dos, -1)
         writeString(dos, Utils.exceptionString(e.getCause))
     }

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -185,21 +185,21 @@ class DotnetBackendHandler(server: DotnetBackend)
           case Some(jObj) => jObj.getClass.getName
           case None => "NullObject"
         }
-        logError(s"On object of type $jvmObjName failed", e)
+        val argsStr = args.map(arg => {
+          if (arg != null) {
+            s"[Type=${arg.getClass.getCanonicalName}, Value: $arg]"
+          } else {
+            "[Value: NULL]"
+          }
+        }).mkString(", ")
+
+        logError(s"Failed to execute '$methodName' on '$jvmObjName' with args=($argsStr)")
+
         if (methods != null) {
-          logError("methods:")
-          methods.foreach(m => logError(m.toString))
+          logDebug(s"All methods for $jvmObjName:")
+          methods.foreach(m => logDebug(m.toString))
         }
-        if (args != null) {
-          logError("args:")
-          args.foreach(arg => {
-            if (arg != null) {
-              logError(s"argType: ${arg.getClass.getCanonicalName}, argValue: $arg")
-            } else {
-              logError("arg: NULL")
-            }
-          })
-        }
+
         writeInt(dos, -1)
         writeString(dos, Utils.exceptionString(e.getCause))
     }


### PR DESCRIPTION
Currently, when there is a failure on an operation (e.g., `spark.Read().Json(path)` because `path was invalid`), the JVM side pollutes the logs by printing out unnecessary info such as all the methods belonging to a class of the object in action.

This PR proposes to streamline the logging and now it will print out more descriptive one ERROR log line for such a failure:
`20/03/03 17:14:34 ERROR DotnetBackendHandler: Failed to execute 'json' on 'org.apache.spark.sql.DataFrameReader' with args=([Type=scala.collection.mutable.WrappedArray.ofRef, Value: WrappedArray(aslkdf)])`

The C# side logging remains the same, and you can turn on printing "all methods" by setting the log level to DEBUG.