### PR TITLE
Adding testing E2E tests against oldest compatible worker version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf'
+      arguments: '--configuration $(buildConfiguration) --filter FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf"'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter ((Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf))'
+      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName\!~TestDataFrameGroupedMapUdf) & (FullyQualifiedName\!~TestDataFrameVectorUdf))'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
-    oldestCompatibleWorker: '0.8.0'
+    oldestCompatibleWorker: '0.9.0'
 
   steps:
   - task: Maven@3
@@ -66,7 +66,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker {{oldestCompatibleWorker}}
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -76,7 +76,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -86,7 +86,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -96,7 +96,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -106,7 +106,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -116,7 +116,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -126,7 +126,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
   
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
@@ -136,7 +136,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
@@ -146,7 +146,7 @@ jobs:
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker (0.8.0)'
+    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
@@ -155,6 +155,105 @@ jobs:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.0'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.1'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.2'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.3'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.4'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.0'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.1'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.3'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.4'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.5'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
 
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
     DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
-    oldestCompatibleWorker: 0.9.0
+    oldestCompatibleWorker: '0.9.0'
 
   steps:
   - task: Maven@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
-      command: test --filter ((Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf))
+      command: test --filter (Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf)
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   buildConfiguration: 'Release'
   _SignType: real
   _TeamName: DotNetSpark
-  oldestCompatibleWorker: '0.8.0'
+  oldestCompatibleWorker: '0.9.0'
 
   # Azure DevOps variables are transformed into environment variables, with these variables we
   # avoid the first time experience and telemetry to speed up the build.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
+      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\\Microsoft.Spark.Worker\\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
 
   - task: DotNetCoreCLI@2
     displayName: '.NET unit tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName\!~TestDataFrameGroupedMapUdf) & (FullyQualifiedName\!~TestDataFrameVectorUdf))'
+      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf) & (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf))'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,16 @@ variables:
   _SignType: real
   _TeamName: DotNetSpark
   oldestCompatibleWorker: '0.9.0'
-  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
-  DotnetNewWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
-  DotnetOldWorkerDir: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
+  LatestDotnetWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
+  OldestCompatibleDotnetWorkerDir: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   # Azure DevOps variables are transformed into environment variables, with these variables we
   # avoid the first time experience and telemetry to speed up the build.
@@ -51,7 +58,7 @@ jobs:
     displayName: Download oldest compatible worker version
     inputs:
       filename: script\download-worker-release.cmd
-      arguments: $(Build.BinariesDirectory)
+      arguments: '$(Build.BinariesDirectory) $(oldestCompatibleWorker)'
 
   - script: build.cmd -pack
               -c $(buildConfiguration)
@@ -69,106 +76,6 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-  
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
-
-  - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'
     inputs:
       command: test
@@ -176,7 +83,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1'
@@ -186,7 +93,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2'
@@ -196,7 +103,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3'
@@ -206,7 +113,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4'
@@ -216,7 +123,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0'
@@ -226,7 +133,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1'
@@ -236,7 +143,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3'
@@ -246,7 +153,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4'
@@ -256,7 +163,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5'
@@ -266,8 +173,107 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
+      DOTNET_WORKER_DIR: $(LatestDotnetWorkerDir)
 
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -80,7 +80,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -90,7 +90,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -100,7 +100,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -110,7 +110,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -120,7 +120,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -130,7 +130,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -140,7 +140,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -150,7 +150,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -160,7 +160,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,16 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+
+  - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
@@ -73,87 +83,87 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
   
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
-    oldestCompatibleWorker: '0.9.0'
+    oldestCompatibleWorker: "{{ 0.9.0 }}"
 
   steps:
   - task: Maven@3
@@ -73,7 +73,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\\Microsoft.Spark.Worker\\Microsoft.Spark.Worker-{{ oldestCompatibleWorker }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,9 +68,9 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
-      command: test --filter (Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf)
+      command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf") & (FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf"))'
+      arguments: '--configuration $(buildConfiguration) --filter FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf)'
+      arguments: '--configuration $(buildConfiguration) --filter ((Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf))'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf"'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ jobs:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})'
+    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
     DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
-    oldestCompatibleWorker: '0.9.0'
+    oldestCompatibleWorker: '0.8.0'
 
   steps:
   - task: Maven@3
@@ -65,6 +65,96 @@ jobs:
       command: test
       projects: '**/*UnitTest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker (0.8.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'
@@ -156,95 +246,6 @@ jobs:
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
-  - task: DotNetCoreCLI@2
-    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-  
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker (0.9.0)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
       filename: script\download-spark-distros.cmd
       arguments: $(Build.BinariesDirectory)
 
-  - task: BatchScript@2
+  - task: BatchScript@1
     displayName: Download oldest compatible worker version
     inputs:
       filename: script\download-worker-release.cmd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,14 +11,14 @@ variables:
   _SignType: real
   _TeamName: DotNetSpark
   oldestCompatibleWorker: '0.9.0'
-  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
+  TestsToFilterOut: "(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)"
   LatestDotnetWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
   OldestCompatibleDotnetWorkerDir: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,13 +11,13 @@ variables:
   _SignType: real
   _TeamName: DotNetSpark
   oldestCompatibleWorker: '0.9.0'
-  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
-  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
+  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
   LatestDotnetWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
   OldestCompatibleDotnetWorkerDir: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -74,6 +74,16 @@ jobs:
       command: test
       projects: '**/*UnitTest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\\Microsoft.Spark.Worker\\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: '.NET unit tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -95,7 +95,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -105,7 +105,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -115,7 +115,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -125,7 +125,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -135,7 +135,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -145,7 +145,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -155,7 +155,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -165,7 +165,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'
@@ -175,7 +175,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1'
@@ -185,7 +185,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2'
@@ -195,7 +195,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3'
@@ -205,7 +205,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4'
@@ -215,7 +215,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0'
@@ -225,7 +225,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1'
@@ -235,7 +235,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3'
@@ -245,7 +245,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4'
@@ -255,7 +255,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5'
@@ -265,7 +265,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,12 @@ jobs:
       filename: script\download-spark-distros.cmd
       arguments: $(Build.BinariesDirectory)
 
+  - task: BatchScript@2
+    displayName: Download oldest compatible worker version
+    inputs:
+      filename: script\download-worker-release.cmd
+      arguments: $(Build.BinariesDirectory)
+
   - script: build.cmd -pack
               -c $(buildConfiguration)
               -ci
@@ -148,6 +154,97 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker (0.9.0)'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,8 @@ variables:
   _TeamName: DotNetSpark
   oldestCompatibleWorker: '0.9.0'
   TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
-  DotnetWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
+  DotnetNewWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
+  DotnetOldWorkerDir: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   # Azure DevOps variables are transformed into environment variables, with these variables we
   # avoid the first time experience and telemetry to speed up the build.
@@ -75,7 +76,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -85,7 +86,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -95,7 +96,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -105,7 +106,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -115,7 +116,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -125,7 +126,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -135,7 +136,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -145,7 +146,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -155,7 +156,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker $(oldestCompatibleWorker)'
@@ -165,7 +166,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetOldWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'
@@ -175,7 +176,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1'
@@ -185,7 +186,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2'
@@ -195,7 +196,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3'
@@ -205,7 +206,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4'
@@ -215,7 +216,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0'
@@ -225,7 +226,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1'
@@ -235,7 +236,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3'
@@ -245,7 +246,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4'
@@ -255,7 +256,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5'
@@ -265,7 +266,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
+      DOTNET_WORKER_DIR: $(DotnetNewWorkerDir)
 
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -90,7 +90,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -100,7 +100,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -110,7 +110,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -120,7 +120,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -130,7 +130,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -140,7 +140,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -150,7 +150,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -160,7 +160,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
+      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,16 +76,6 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(OldestCompatibleDotnetWorkerDir)
-
-  - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0'
     inputs:
       command: test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ variables:
   _SignType: real
   _TeamName: DotNetSpark
   oldestCompatibleWorker: '0.9.0'
+  TestsToFilterOut: '(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)'
+  DotnetWorkerDir: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64'
 
   # Azure DevOps variables are transformed into environment variables, with these variables we
   # avoid the first time experience and telemetry to speed up the build.
@@ -70,17 +72,17 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
+      DOTNET_WORKER_DIR: $(DotnetWorkerDir)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -90,7 +92,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -100,7 +102,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -110,7 +112,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -120,7 +122,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -130,7 +132,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -140,7 +142,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -150,7 +152,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
@@ -160,7 +162,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)'
+      arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.9.0)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.0 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
-      command: test
+      command: test --filter ((Name!~TestDataFrameGroupedMapUdf) & (Name!~TestDataFrameVectorUdf))
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   buildConfiguration: 'Release'
   _SignType: real
   _TeamName: DotNetSpark
+  oldestCompatibleWorker: '0.8.0'
 
   # Azure DevOps variables are transformed into environment variables, with these variables we
   # avoid the first time experience and telemetry to speed up the build.
@@ -25,8 +26,6 @@ jobs:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
-    - name: oldestCompatibleWorker
-      value: 0.8.0
 
   steps:
   - task: Maven@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
     DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
+    oldestCompatibleWorker: '0.9.0'
 
   steps:
   - task: Maven@3
@@ -57,6 +58,16 @@ jobs:
               /p:PublishSparkWorker=true
               /p:SparkWorkerPublishDir=$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker
     displayName: '.NET build'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})'
+    inputs:
+      command: test
+      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+    env:
+      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
+      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
 
   - task: DotNetCoreCLI@2
     displayName: '.NET unit tests'
@@ -156,14 +167,14 @@ jobs:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker (0.9.0)'
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}"
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker (0.9.0)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
-    DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
     oldestCompatibleWorker: '0.8.0'
 
   steps:
@@ -67,7 +66,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})
+    displayName: E2E tests for Spark 2.3.1 with oldest compatible worker {{oldestCompatibleWorker}}
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
@@ -155,96 +154,6 @@ jobs:
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.0'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.2'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.3'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.4'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.0'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.1'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-  
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.3'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.4'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.4.5'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,8 @@ jobs:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
-    oldestCompatibleWorker: "{{ 0.9.0 }}"
+    - name: oldestCompatibleWorker
+      value: 0.8.0
 
   steps:
   - task: Maven@3
@@ -66,14 +67,14 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker'
+    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker $(oldestCompatibleWorker)'
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: "$(Build.BinariesDirectory)\\Microsoft.Spark.Worker\\Microsoft.Spark.Worker-{{ oldestCompatibleWorker }}"
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-$(oldestCompatibleWorker)
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.2 with oldest compatible worker'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
     DOTNET_WORKER_DIR: $(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker\netcoreapp3.1\win-x64
-    oldestCompatibleWorker: '0.9.0'
+    oldestCompatibleWorker: 0.9.0
 
   steps:
   - task: Maven@3
@@ -58,16 +58,6 @@ jobs:
               /p:PublishSparkWorker=true
               /p:SparkWorkerPublishDir=$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Worker
     displayName: '.NET build'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'E2E tests for Spark 2.3.1 with oldest compatible worker ({{oldestCompatibleWorker}})'
-    inputs:
-      command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration)'
-    env:
-      SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: '.NET unit tests'
@@ -184,7 +174,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.3 with oldest compatible worker (0.9.0)'
@@ -194,7 +184,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.3.4 with oldest compatible worker (0.9.0)'
@@ -204,7 +194,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.0 with oldest compatible worker (0.9.0)'
@@ -214,7 +204,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.1 with oldest compatible worker (0.9.0)'
@@ -224,7 +214,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
   
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.3 with oldest compatible worker (0.9.0)'
@@ -234,7 +224,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.4 with oldest compatible worker (0.9.0)'
@@ -244,7 +234,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark 2.4.5 with oldest compatible worker (0.9.0)'
@@ -254,7 +244,7 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
-      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-0.9.0
+      DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker\Microsoft.Spark.Worker-{{oldestCompatibleWorker}}
 
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf) & (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf))'
+      arguments: '--configuration $(buildConfiguration) --filter ((FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf") & (FullyQualifiedName!="Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf"))'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
       DOTNET_WORKER_DIR: $(Build.BinariesDirectory)\Microsoft.Spark.Worker-$(oldestCompatibleWorker)

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -5,7 +5,7 @@ setlocal
 set OutputDir=%1
 cd %OutputDir%
 
-echo "Download oldest backwards compatible worker release- 0.9.0 for current version 0.10.0."
+echo "Download oldest backwards compatible worker release"
 curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.9.0.zip
 unzip Microsoft.Spark.Worker.zip
 mkdir -p Microsoft.Spark.Worker

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -8,7 +8,5 @@ cd %OutputDir%
 echo "Download oldest backwards compatible worker release"
 curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.8.0.zip
 unzip Microsoft.Spark.Worker.zip
-mkdir -p Microsoft.Spark.Worker
-cp -a Microsoft.Spark.Worker-0.8.0/ Microsoft.Spark.Worker/
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -6,9 +6,9 @@ set OutputDir=%1
 cd %OutputDir%
 
 echo "Download oldest backwards compatible worker release"
-curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.8.0.zip
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.9.0.zip
 unzip Microsoft.Spark.Worker.zip
 mkdir -p Microsoft.Spark.Worker
-cp -a Microsoft.Spark.Worker-0.8.0/ Microsoft.Spark.Worker/
+cp -a Microsoft.Spark.Worker-0.9.0/ Microsoft.Spark.Worker/
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -6,9 +6,9 @@ set OutputDir=%1
 cd %OutputDir%
 
 echo "Download oldest backwards compatible worker release"
-curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.9.0.zip
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.8.0.zip
 unzip Microsoft.Spark.Worker.zip
 mkdir -p Microsoft.Spark.Worker
-cp -a Microsoft.Spark.Worker-0.9.0/ Microsoft.Spark.Worker/
+cp -a Microsoft.Spark.Worker-0.8.0/ Microsoft.Spark.Worker/
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -3,10 +3,11 @@
 setlocal
 
 set OutputDir=%1
+set OldestCompatibleWorkerVersion=%2
 cd %OutputDir%
 
-echo "Download oldest backwards compatible worker release"
-curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.win-x64-0.9.0.zip
+echo "Download oldest backwards compatible worker release - %OldestCompatibleWorkerVersion%"
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v%OldestCompatibleWorkerVersion%/Microsoft.Spark.Worker.netcoreapp3.1.win-x64-%OldestCompatibleWorkerVersion%.zip
 unzip Microsoft.Spark.Worker.zip
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -6,7 +6,7 @@ set OutputDir=%1
 cd %OutputDir%
 
 echo "Download oldest backwards compatible worker release"
-curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.win-x64-0.8.0.zip
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.win-x64-0.9.0.zip
 unzip Microsoft.Spark.Worker.zip
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -6,7 +6,7 @@ set OutputDir=%1
 cd %OutputDir%
 
 echo "Download oldest backwards compatible worker release"
-curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.8.0.zip
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.8.0/Microsoft.Spark.Worker.netcoreapp3.1.win-x64-0.8.0.zip
 unzip Microsoft.Spark.Worker.zip
 
 endlocal

--- a/script/download-worker-release.cmd
+++ b/script/download-worker-release.cmd
@@ -1,0 +1,14 @@
+@echo off
+
+setlocal
+
+set OutputDir=%1
+cd %OutputDir%
+
+echo "Download oldest backwards compatible worker release- 0.9.0 for current version 0.10.0."
+curl -k -L -o Microsoft.Spark.Worker.zip https://github.com/dotnet/spark/releases/download/v0.9.0/Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.9.0.zip
+unzip Microsoft.Spark.Worker.zip
+mkdir -p Microsoft.Spark.Worker
+cp -a Microsoft.Spark.Worker-0.9.0/ Microsoft.Spark.Worker/
+
+endlocal

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -142,17 +142,17 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             }
 
             // Calling CreateDataFrame(IEnumerable<Timestamp> _) without schema
-            {
-                var data = new Timestamp[]
-                {
-                    new Timestamp(2020, 1, 1, 0, 0, 0, 0),
-                    new Timestamp(2020, 1, 2, 15, 30, 30, 0)
-                };
-                StructType schema = SchemaWithSingleColumn(new TimestampType());
+            //{
+            //    var data = new Timestamp[]
+            //    {
+            //        new Timestamp(2020, 1, 1, 0, 0, 0, 0),
+            //        new Timestamp(2020, 1, 2, 15, 30, 30, 0)
+            //    };
+            //    StructType schema = SchemaWithSingleColumn(new TimestampType());
 
-                DataFrame df = _spark.CreateDataFrame(data);
-                ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
-            }
+            //    DataFrame df = _spark.CreateDataFrame(data);
+            //    ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
+            //}
         }
 
         private void ValidateDataFrame(

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -140,19 +140,23 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                 DataFrame df = _spark.CreateDataFrame(data);
                 ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
             }
+        }
 
-            // Calling CreateDataFrame(IEnumerable<Timestamp> _) without schema
-            //{
-            //    var data = new Timestamp[]
-            //    {
-            //        new Timestamp(2020, 1, 1, 0, 0, 0, 0),
-            //        new Timestamp(2020, 1, 2, 15, 30, 30, 0)
-            //    };
-            //    StructType schema = SchemaWithSingleColumn(new TimestampType());
+        /// <summary>
+        /// Test CreateDataFrame API with Timestamp as data
+        /// </summary>
+        [Fact]
+        public void TestCreateDataFrameWithTimestamp()
+        {
+            var data = new Timestamp[]
+                {
+                    new Timestamp(2020, 1, 1, 0, 0, 0, 0),
+                    new Timestamp(2020, 1, 2, 15, 30, 30, 0)
+                };
+            StructType schema = SchemaWithSingleColumn(new TimestampType());
 
-            //    DataFrame df = _spark.CreateDataFrame(data);
-            //    ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
-            //}
+            DataFrame df = _spark.CreateDataFrame(data);
+            ValidateDataFrame(df, data.Select(a => new object[] { a }), schema);
         }
 
         private void ValidateDataFrame(


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

This PR adds running E2E tests against the oldest compatible version of Microsoft.Spark.Worker to test backward compatibility. Fixes #453 
