### PR TITLE
Run Delta E2ETests with Delta Lake 0.6.0

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         {
             Environment.SetEnvironmentVariable(
                 SparkFixture.EnvironmentVariableNames.ExtraSparkSubmitArgs,
-                "--packages io.delta:delta-core_2.11:0.5.0 " +
+                "--packages io.delta:delta-core_2.11:0.6.0 " +
                 "--conf spark.databricks.delta.snapshotPartitions=2 " +
                 "--conf spark.sql.sources.parallelPartitionDiscovery.parallelism=5");
             SparkFixture = new SparkFixture();


### PR DESCRIPTION
This PR changes `Microsoft.Spark.Extensions.Delta.E2ETest` to use [Delta Lake 0.6.0](https://github.com/delta-io/delta/releases/tag/v0.6.0) JAR when running tests.  This change helps us ensure that our extension is compatible with the latest Delta Lake release.