### PR TITLE
Change SparkSession.Catalog to a property

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -672,7 +672,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         /// Tests for the Catclog Functions - returned from SparkSession.Catalog
         public void CatalogFunctions()
         {
-            Catalog catalog = _spark.Catalog();
+            Catalog catalog = _spark.Catalog;
 
             Assert.IsType<DataFrame>(catalog.ListDatabases());
             Assert.IsType<DataFrame>(catalog.ListFunctions());

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             Assert.IsType<UdfRegistration>(_spark.Udf());
 
-            Assert.IsType<Catalog>(_spark.Catalog());
+            Assert.IsType<Catalog>(_spark.Catalog);
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Spark.Sql
         private readonly JvmObjectReference _jvmObject;
 
         private readonly Lazy<SparkContext> _sparkContext;
+        private readonly Lazy<Catalog.Catalog> _catalog;
 
         private static readonly string s_sparkSessionClassName =
             "org.apache.spark.sql.SparkSession";
@@ -36,22 +37,23 @@ namespace Microsoft.Spark.Sql
             _sparkContext = new Lazy<SparkContext>(
                 () => new SparkContext(
                     (JvmObjectReference)_jvmObject.Invoke("sparkContext")));
+            _catalog = new Lazy<Catalog.Catalog>(
+                () => new Catalog.Catalog((JvmObjectReference)_jvmObject.Invoke("catalog")));
         }
 
         JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+
+        /// <summary>
+        /// Returns SparkContext object associated with this SparkSession.
+        /// </summary>
+        public SparkContext SparkContext => _sparkContext.Value;
 
         /// <summary>
         /// Interface through which the user may create, drop, alter or query underlying databases,
         /// tables, functions etc.
         /// </summary>
         /// <returns>Catalog object</returns>
-        public Catalog.Catalog Catalog =>
-            new Catalog.Catalog((JvmObjectReference)_jvmObject.Invoke("catalog"));
-
-        /// <summary>
-        /// Returns SparkContext object associated with this SparkSession.
-        /// </summary>
-        public SparkContext SparkContext => _sparkContext.Value;
+        public Catalog.Catalog Catalog => _catalog.Value;
 
         /// <summary>
         /// Creates a Builder object for SparkSession.

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -41,6 +41,14 @@ namespace Microsoft.Spark.Sql
         JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
 
         /// <summary>
+        /// Interface through which the user may create, drop, alter or query underlying databases,
+        /// tables, functions etc.
+        /// </summary>
+        /// <returns>Catalog object</returns>
+        public Catalog.Catalog Catalog =>
+            new Catalog.Catalog((JvmObjectReference)_jvmObject.Invoke("catalog"));
+
+        /// <summary>
         /// Returns SparkContext object associated with this SparkSession.
         /// </summary>
         public SparkContext SparkContext => _sparkContext.Value;
@@ -279,14 +287,6 @@ namespace Microsoft.Spark.Sql
         /// <returns>UDFRegistration object</returns>
         public UdfRegistration Udf() =>
             new UdfRegistration((JvmObjectReference)_jvmObject.Invoke("udf"));
-
-        /// <summary>
-        /// Interface through which the user may create, drop, alter or query underlying databases,
-        /// tables, functions etc.
-        /// </summary>
-        /// <returns>Catalog object</returns>
-        public Catalog.Catalog Catalog() =>
-            new Catalog.Catalog((JvmObjectReference)_jvmObject.Invoke("catalog"));
 
         /// <summary>
         /// Stops the underlying SparkContext.


### PR DESCRIPTION
Modify the SparkSession.Catalog call from a method to a property.  This helps make the experience similar to scala and python.

Fixes #497