### PR TITLE
Improve build pipeline (add binlog and disable unnecessary packing)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,7 +296,7 @@ jobs:
     inputs:
       mavenPomFile: $(forwardCompatibleRelease)/src/scala/pom.xml
       
-  - script: $(forwardCompatibleRelease)\build.cmd -pack
+  - script: $(forwardCompatibleRelease)\build.cmd
               -c $(buildConfiguration)
               -ci
               $(_OfficialBuildIdArgs)
@@ -412,6 +412,12 @@ jobs:
           **/*.nupkg
           **/*.snupkg
         targetFolder: $(Build.ArtifactStagingDirectory)/BuildArtifacts/artifacts/packages/$(buildConfiguration)/Shipping
+
+    - task: CopyFiles@2
+      displayName: Stage build logs
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/master/artifacts/log
+        targetFolder: $(Build.ArtifactStagingDirectory)/BuildArtifacts/artifacts/log
 
     - task: PublishBuildArtifacts@1
       inputs:


### PR DESCRIPTION
This PR improves the build pipeline by publishing binlog for each build (for a better debugging) and remove the unnecessary packing for forward compatibility repo.