### PR TITLE
Expose logger for override by consumer

### DIFF
--- a/src/csharp/Microsoft.Spark/Services/ILoggerService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ILoggerService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Spark.Services
     /// <summary>
     /// Defines a logger what be used in service
     /// </summary>
-    internal interface ILoggerService
+    public interface ILoggerService
     {
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the Debug level.

--- a/src/csharp/Microsoft.Spark/Services/LoggerServiceFactory.cs
+++ b/src/csharp/Microsoft.Spark/Services/LoggerServiceFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Spark.Services
     /// <summary>
     /// Used to get logger service instances for different types
     /// </summary>
-    internal class LoggerServiceFactory
+    public class LoggerServiceFactory
     {
         private static Lazy<ILoggerService> s_loggerService =
             new Lazy<ILoggerService>(() => GetDefaultLogger());


### PR DESCRIPTION
Expose `LoggerServiceFactory` and `ILoggerService` as public for override by consuming applications

Fixes #473 