### PR TITLE
Fix AppName in examples to follow Spark naming convention

### DIFF
--- a/examples/Microsoft.Spark.CSharp.Examples/MachineLearning/Sentiment/Program.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/MachineLearning/Sentiment/Program.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Spark.Examples.MachineLearning.Sentiment
 
             SparkSession spark = SparkSession
                 .Builder()
-                .AppName(".NET for Apache Spark Sentiment Analysis")
+                .AppName("Sentiment Analysis using .NET for Apache Spark")
                 .GetOrCreate();
 
             // Read in and display Yelp reviews

--- a/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Basic.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Basic.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.Examples.Sql.Batch
 
             SparkSession spark = SparkSession
                 .Builder()
-                .AppName(".NET Spark SQL basic example")
+                .AppName("SQL basic example using .NET for Apache Spark")
                 .Config("spark.some.config.option", "some-value")
                 .GetOrCreate();
 

--- a/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Datasource.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Datasource.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Spark.Examples.Sql.Batch
 
             SparkSession spark = SparkSession
                 .Builder()
-                .AppName(".NET Spark SQL Datasource example")
+                .AppName("SQL Datasource example using .NET for Apache Spark")
                 .Config("spark.some.config.option", "some-value")
                 .GetOrCreate();
 

--- a/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/VectorDataFrameUdfs.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/VectorDataFrameUdfs.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Spark.Examples.Sql.Batch
                 .Builder()
                 // Lower the shuffle partitions to speed up groupBy() operations.
                 .Config("spark.sql.shuffle.partitions", "3")
-                .AppName(".NET Spark SQL VectorUdfs example")
+                .AppName("SQL VectorUdfs example using .NET for Apache Spark")
                 .GetOrCreate();
 
             DataFrame df = spark.Read().Schema("age INT, name STRING").Json(args[0]);

--- a/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/VectorUdfs.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/VectorUdfs.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Spark.Examples.Sql.Batch
                 .Builder()
                 // Lower the shuffle partitions to speed up groupBy() operations.
                 .Config("spark.sql.shuffle.partitions", "3")
-                .AppName(".NET Spark SQL VectorUdfs example")
+                .AppName("SQL VectorUdfs example using .NET for Apache Spark")
                 .GetOrCreate();
 
             DataFrame df = spark.Read().Schema("age INT, name STRING").Json(args[0]);


### PR DESCRIPTION
Fixes #544

Following rename structure suggested by [imback82](https://github.com/dotnet/spark/issues/544#issuecomment-643664224), I'm fixing `AppName` in those examples starting with an invalid character according to the Spark docs. This will allow running the examples using k8s as the resource manager. Using the previous AppNames the executor pods couldn't be created.

