### PR TITLE
Bugfix for Microsoft.Spark.Extensions.DotNet.Interactive duplicate file exception

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
 
                 kernelBase.AddMiddleware(async (command, context, next) =>
                 {
+                    await next(command, context);
+
                     if ((context.HandlingKernel is CSharpKernel kernel) &&
                         (command is SubmitCode) &&
                         TryGetSparkSession(out SparkSession sparkSession) &&
@@ -57,8 +59,6 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                             sparkSession.SparkContext.AddFile(filePath);
                         }
                     }
-
-                    await next(command, context);
                 });
             }
 


### PR DESCRIPTION
The extension attempts to emit the assembly of the previous compilation object.  This works with cases where code submissions have no errors.  However, because we throw an exception if we have already emitted the assembly, if a user submits code that contains an error, then we will hit this exception.

Instead of emitting the previous submission's assembly, first run the code submission, then emit the assembly for the current compilation object.