### PR TITLE
README.md for Extension directory

### DIFF
--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -2,6 +2,8 @@
 
 ## Table of Contents
 - [NuGet Packages](#nuget-packages)
+-- [First-Party](#first-party)
+-- [Third-Party](#third-party)
 
 ## NuGet Packages
 

--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -1,0 +1,8 @@
+# .Net for Spark Extensions
+
+The following .Net for Spark extensions are available as NuGet packages:
+
+* [Microsoft.Spark.Extensions.Azure.Synapse.Analytics](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Azure.Synapse.Analytics/)
+* [Microsoft.Spark.Extensions.Delta](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Delta/)
+* [Microsoft.Spark.Extensions.DotNet.Interactive](https://www.nuget.org/packages/Microsoft.Spark.Extensions.DotNet.Interactive/)
+* [Microsoft.Spark.Extensions.Hyperspace](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Hyperspace/)

--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -1,13 +1,19 @@
-# .Net for Spark Extensions
+# .Net for Apache Spark Extensions
 
 ## Table of Contents
 - [NuGet Packages](#nuget-packages)
 
 ## NuGet Packages
 
-The following .Net for Spark extensions are available as NuGet packages:
+The following .Net for Apache Spark extensions are available as NuGet packages:
+
+### First-Party
 
 * [Microsoft.Spark.Extensions.Azure.Synapse.Analytics](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Azure.Synapse.Analytics/)
 * [Microsoft.Spark.Extensions.Delta](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Delta/)
 * [Microsoft.Spark.Extensions.DotNet.Interactive](https://www.nuget.org/packages/Microsoft.Spark.Extensions.DotNet.Interactive/)
 * [Microsoft.Spark.Extensions.Hyperspace](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Hyperspace/)
+
+### Third-Party
+
+* Community-created extensions can be added here.

--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -2,8 +2,6 @@
 
 ## Table of Contents
 * [NuGet Packages](#nuget-packages)
-    * [First-Party](#first-party)
-    * [Third-Party](#third-party)
 
 ## NuGet Packages
 

--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -1,9 +1,9 @@
 # .Net for Apache Spark Extensions
 
 ## Table of Contents
-- [NuGet Packages](#nuget-packages)
--- [First-Party](#first-party)
--- [Third-Party](#third-party)
+* [NuGet Packages](#nuget-packages)
+    * [First-Party](#first-party)
+    * [Third-Party](#third-party)
 
 ## NuGet Packages
 

--- a/src/csharp/Extensions/README.md
+++ b/src/csharp/Extensions/README.md
@@ -1,5 +1,10 @@
 # .Net for Spark Extensions
 
+## Table of Contents
+- [NuGet Packages](#nuget-packages)
+
+## NuGet Packages
+
 The following .Net for Spark extensions are available as NuGet packages:
 
 * [Microsoft.Spark.Extensions.Azure.Synapse.Analytics](https://www.nuget.org/packages/Microsoft.Spark.Extensions.Azure.Synapse.Analytics/)

--- a/src/csharp/Microsoft.Spark.sln
+++ b/src/csharp/Microsoft.Spark.sln
@@ -28,9 +28,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.E2ETest.ExternalLibrary", "Microsoft.Spark.E2ETest.ExternalLibrary\Microsoft.Spark.E2ETest.ExternalLibrary.csproj", "{920A2CC8-4075-41D1-BC30-C496430BD9E4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{71A19F75-8279-40AB-BEA0-7D4B153FC416}"
-	ProjectSection(SolutionItems) = preProject
-		Extensions\README.md = Extensions\README.md
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Delta", "Extensions\Microsoft.Spark.Extensions.Delta\Microsoft.Spark.Extensions.Delta.csproj", "{2048446B-45AB-4304-B230-50EDF6E8E6A4}"
 EndProject
@@ -40,9 +37,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.DotNet.Interactive", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive\Microsoft.Spark.Extensions.DotNet.Interactive.csproj", "{9C32014D-8C0C-40F1-9ABA-C3BF19687E5C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj", "{7BDE09ED-04B3-41B2-A466-3D6F7225291E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj", "{7BDE09ED-04B3-41B2-A466-3D6F7225291E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Hyperspace", "Extensions\Microsoft.Spark.Extensions.Hyperspace\Microsoft.Spark.Extensions.Hyperspace.csproj", "{70DDA4E9-1195-4A29-9AA1-96A8223A6D4F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Spark.Extensions.Hyperspace", "Extensions\Microsoft.Spark.Extensions.Hyperspace\Microsoft.Spark.Extensions.Hyperspace.csproj", "{70DDA4E9-1195-4A29-9AA1-96A8223A6D4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Hyperspace.E2ETest", "Extensions\Microsoft.Spark.Extensions.Hyperspace.E2ETest\Microsoft.Spark.Extensions.Hyperspace.E2ETest.csproj", "{C6019E44-C777-4DE2-B70E-EA025B7D044D}"
 EndProject

--- a/src/csharp/Microsoft.Spark.sln
+++ b/src/csharp/Microsoft.Spark.sln
@@ -28,6 +28,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.E2ETest.ExternalLibrary", "Microsoft.Spark.E2ETest.ExternalLibrary\Microsoft.Spark.E2ETest.ExternalLibrary.csproj", "{920A2CC8-4075-41D1-BC30-C496430BD9E4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{71A19F75-8279-40AB-BEA0-7D4B153FC416}"
+	ProjectSection(SolutionItems) = preProject
+		Extensions\README.md = Extensions\README.md
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Delta", "Extensions\Microsoft.Spark.Extensions.Delta\Microsoft.Spark.Extensions.Delta.csproj", "{2048446B-45AB-4304-B230-50EDF6E8E6A4}"
 EndProject
@@ -37,9 +40,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.DotNet.Interactive", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive\Microsoft.Spark.Extensions.DotNet.Interactive.csproj", "{9C32014D-8C0C-40F1-9ABA-C3BF19687E5C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj", "{7BDE09ED-04B3-41B2-A466-3D6F7225291E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest", "Extensions\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest\Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj", "{7BDE09ED-04B3-41B2-A466-3D6F7225291E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Spark.Extensions.Hyperspace", "Extensions\Microsoft.Spark.Extensions.Hyperspace\Microsoft.Spark.Extensions.Hyperspace.csproj", "{70DDA4E9-1195-4A29-9AA1-96A8223A6D4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Hyperspace", "Extensions\Microsoft.Spark.Extensions.Hyperspace\Microsoft.Spark.Extensions.Hyperspace.csproj", "{70DDA4E9-1195-4A29-9AA1-96A8223A6D4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spark.Extensions.Hyperspace.E2ETest", "Extensions\Microsoft.Spark.Extensions.Hyperspace.E2ETest\Microsoft.Spark.Extensions.Hyperspace.E2ETest.csproj", "{C6019E44-C777-4DE2-B70E-EA025B7D044D}"
 EndProject


### PR DESCRIPTION
This small PR adds a `README.md` to the Extension directory.  For now, this file only contains a list of available extensions.  Eventually, it will be expanded to include instructions for how to develop a third-party extension.

I chose to make this a `README.md` and not a doc file in the `docs` directory because I think it is nice to have it immediately available when you look at the `Extensions` directory.  However, if folks feel strongly about moving it to the `docs` folder, I don't mind.

![image](https://user-images.githubusercontent.com/2154530/85893559-eeada400-b7a7-11ea-8434-5d5f1a4f56a4.png)
