### PR TITLE
[Bug] AssemblyLoader should use absolute assembly path when loading assemblies

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Spark.UnitTest
             _mockJvm = _fixture.MockJvm;
         }
 
-
         [Fact]
         public void TestAssemblySearchPathResolver()
         {

--- a/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
@@ -4,7 +4,11 @@
 
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Utils;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Spark.UnitTest
@@ -12,6 +16,14 @@ namespace Microsoft.Spark.UnitTest
     [Collection("Spark Unit Tests")]
     public class AssemblyLoaderTests
     {
+        private readonly Mock<IJvmBridge> _mockJvm;
+
+        public AssemblyLoaderTests(SparkFixture _fixture)
+        {
+            _mockJvm = _fixture.MockJvm;
+        }
+
+
         [Fact]
         public void TestAssemblySearchPathResolver()
         {
@@ -44,6 +56,18 @@ namespace Microsoft.Spark.UnitTest
             Environment.SetEnvironmentVariable(
                 AssemblySearchPathResolver.AssemblySearchPathsEnvVarName,
                 null);
+        }
+
+        [Fact]
+        public void TestResolveAssemblyWithRelativePath()
+        {
+            _mockJvm.Setup(m => m.CallStaticJavaMethod(
+                "org.apache.spark.SparkFiles",
+                "getRootDirectory"))
+                .Returns(".");
+
+            AssemblyLoader.LoadFromFile = AssemblyLoadContext.Default.LoadFromAssemblyPath;
+            AssemblyLoader.ResolveAssembly(Assembly.GetExecutingAssembly().FullName);
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/AssemblyLoaderTests.cs
@@ -66,7 +66,10 @@ namespace Microsoft.Spark.UnitTest
                 .Returns(".");
 
             AssemblyLoader.LoadFromFile = AssemblyLoadContext.Default.LoadFromAssemblyPath;
-            AssemblyLoader.ResolveAssembly(Assembly.GetExecutingAssembly().FullName);
+            Assembly expectedAssembly = Assembly.GetExecutingAssembly();
+            Assembly actualAssembly = AssemblyLoader.ResolveAssembly(expectedAssembly.FullName);
+
+            Assert.Equal(expectedAssembly, actualAssembly);
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Spark.Utils
         {
             foreach (string searchPath in s_searchPaths.Value)
             {
-                FileInfo assemblyFile = new FileInfo(Path.Combine(searchPath, assemblyFileName));
+                var assemblyFile = new FileInfo(Path.Combine(searchPath, assemblyFileName));
                 if (assemblyFile.Exists)
                 {
                     try

--- a/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
+++ b/src/csharp/Microsoft.Spark/Utils/AssemblyLoader.cs
@@ -189,12 +189,12 @@ namespace Microsoft.Spark.Utils
         {
             foreach (string searchPath in s_searchPaths.Value)
             {
-                string assemblyPath = Path.Combine(searchPath, assemblyFileName);
-                if (File.Exists(assemblyPath))
+                FileInfo assemblyFile = new FileInfo(Path.Combine(searchPath, assemblyFileName));
+                if (assemblyFile.Exists)
                 {
                     try
                     {
-                        assembly = LoadFromFile(assemblyPath);
+                        assembly = LoadFromFile(assemblyFile.FullName);
                         return true;
                     }
                     catch (Exception ex) when (


### PR DESCRIPTION
`AssemblyLoader.ResolveAssembly` uses `AssemblySearchPathResolver.GetAssemblySearchPaths` to build paths when checking for assemblies.  An assembly was found to exist within one of the built paths, but this was a relative path.  When resolving dotnet core assemblies, `AssemblyLoader.ResolveAssembly` uses `AssemblyLoadContext.Default.LoadFromAssemblyPath` and this requires an `absolute` assembly path.