### PR TITLE
[WIP] possible approach to fixing #333 get/set SparkSession on all calls across to the JVM

### DIFF
--- a/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
@@ -65,5 +65,6 @@ namespace Microsoft.Spark.Interop.Ipc
             JvmObjectReference objectId,
             string methodName,
             params object[] args);
+        
     }
 }

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Spark.Interop.Ipc
         /// </summary>
         private readonly DateTime _creationTime;
 
+        internal int SparkSessionId { get; set; } = 0;
+
         /// <summary>
         /// Constructor for the JvmObjectReference class.
         /// </summary>

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/PayloadHelper.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Spark.Interop.Ipc
 
         internal static void BuildPayload(
             MemoryStream destination,
+            int sparkSessionHashCode,
             bool isStaticMethod,
             object classNameOrJvmObjectReference,
             string methodName,
@@ -45,7 +46,8 @@ namespace Microsoft.Spark.Interop.Ipc
             // Reserve space for total length.
             long originalPosition = destination.Position;
             destination.Position += sizeof(int);
-
+            
+            SerDe.Write(destination, sparkSessionHashCode);
             SerDe.Write(destination, isStaticMethod);
             SerDe.Write(destination, classNameOrJvmObjectReference.ToString());
             SerDe.Write(destination, methodName);

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/SparkSessionStore.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/SparkSessionStore.scala
@@ -1,0 +1,48 @@
+package org.apache.spark.api.dotnet
+
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.spark.sql.SparkSession
+
+object SparkSessionStore {
+
+    var sessions: ConcurrentHashMap[Int, SparkSession] = new ConcurrentHashMap()
+
+    def saveSession(possibleSession: SparkSession): Int = {
+        val session = SparkSession.getActiveSession
+        if(session == None && possibleSession == None) {
+            0
+        }else{
+            val hashCode = session.getOrElse(possibleSession).hashCode()
+            if(!sessions.contains(hashCode)){
+                sessions.put(hashCode, session.getOrElse(possibleSession))
+            }
+            hashCode
+        }
+    }
+
+    def saveSession(): Int = {
+        val session = SparkSession.getActiveSession
+        if(session != None ){
+            val hashCode = session.get.hashCode()
+            if(!sessions.contains(hashCode)){
+                sessions.put(hashCode, session.get)
+            }
+            hashCode
+        }else{
+            0
+        }
+    }
+
+    def setSession(sessionId : Int) = {
+        if(sessionId != 0){
+            val session = sessions.get(sessionId)
+            session.range(1).show()
+            SparkSession.setActiveSession(session)
+        }
+    }
+
+    def removeSession(session: SparkSession): Unit = {
+        sessions.remove(session.hashCode())
+    }
+}


### PR DESCRIPTION
Hi - I was wondering if this was a possible approach to fixing #333?

The idea is that when we return the response from the JVM to take a note of the current SparkSession, store it the SparkSession and return the hash code which is stored on the managed thread in c#.

When making a call from c#, include the hash code of the last set SparkSession on the managed thread and calling SparkSession.setActiveSession

If this isn't an approach you like let me know, happy to bin it but it works for me so delta calls stop failing.

If this is a good approach, i'll redo it a bit tider!
