### PR TITLE
Run Delta Lake tests against Delta Lake 0.6.1

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         {
             Environment.SetEnvironmentVariable(
                 SparkFixture.EnvironmentVariableNames.ExtraSparkSubmitArgs,
-                "--packages io.delta:delta-core_2.11:0.6.0 " +
+                "--packages io.delta:delta-core_2.11:0.6.1 " +
                 "--conf spark.databricks.delta.snapshotPartitions=2 " +
                 "--conf spark.sql.sources.parallelPartitionDiscovery.parallelism=5");
             SparkFixture = new SparkFixture();


### PR DESCRIPTION
This PR updates`Microsoft.Spark.Extensions.Delta.E2ETest` to run tests against Delta Lake 0.6.1, which is the latest version of Delta Lake that targets Spark 2.4.x.