### PR TITLE
Add more Data Frame examples

### DIFF
--- a/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Basic.cs
+++ b/examples/Microsoft.Spark.CSharp.Examples/Sql/Batch/Basic.cs
@@ -108,6 +108,25 @@ namespace Microsoft.Spark.Examples.Sql.Batch
 
             DataFrame joinedDf3 = df.Join(df, df["name"] == df["name"], "outer");
             joinedDf3.Show();
+            
+            // Union of two data frames
+            DataFrame unionDf = df.Union(df);
+            unionDf.Show();
+
+            // Add new column to data frame
+            df.WithColumn("location", Lit("Seattle")).Show();
+
+            // Rename existing column
+            df.WithColumnRenamed("name", "fullname").Show();
+
+            // Filter rows with null age
+            df.Filter(Col("age").IsNull()).Show();
+
+            // Fill null values in age column with -1
+            df.Na().Fill(-1, new[] { "age" }).Show();
+
+            // Drop age column
+            df.Drop(new[] { "age" }).Show();
 
             spark.Stop();
         }

--- a/examples/Microsoft.Spark.FSharp.Examples/Sql/Basic.fs
+++ b/examples/Microsoft.Spark.FSharp.Examples/Sql/Basic.fs
@@ -78,6 +78,25 @@ type Basic() =
 
             let joinedDf3 = df.Join(df, df.["name"].EqualTo(df.["name"]), "outer")
             joinedDf3.Show()
+            
+            // Union of two data frames
+            let unionDf = df.Union(df)
+            unionDf.Show()
+
+            // Add new column to data frame
+            df.WithColumn("location", Functions.Lit("Seattle")).Show()
+
+            // Rename existing column
+            df.WithColumnRenamed("name", "fullname").Show()
+
+            // Filter rows with null age
+            df.Filter(df.["age"].IsNull()).Show()
+
+            // Fill null values in age column with -1
+            df.Na().Fill(-1L, ["age"]).Show()
+
+            // Drop age column
+            df.Drop(df.["age"]).Show()
 
             spark.Stop()
             0


### PR DESCRIPTION
Fixes https://github.com/dotnet/spark/issues/600

I think it could be beneficial to show more examples on how to manipulate data frames.

### Union of two data frames
```csharp
DataFrame unionDf = df.Union(df);
unionDf.Show();

+----+-------+
| age|   name|
+----+-------+
|null|Michael|
|  30|   Andy|
|  19| Justin|
|null|Michael|
|  30|   Andy|
|  19| Justin|
+----+-------+
```

### Add new column
```csharp
df.WithColumn("location", Lit("Seattle")).Show();

+----+-------+--------+
| age|   name|location|
+----+-------+--------+
|null|Michael| Seattle|
|  30|   Andy| Seattle|
|  19| Justin| Seattle|
+----+-------+--------+
```

###  Rename existing column
```csharp
df.WithColumnRenamed("name", "fullname").Show();

+----+--------+
| age|fullname|
+----+--------+
|null| Michael|
|  30|    Andy|
|  19|  Justin|
+----+--------+
```
###  Filter null rows in age column
```csharp
df.Filter(Col("age").IsNull()).Show();

+----+-------+
| age|   name|
+----+-------+
|null|Michael|
+----+-------+
```

###  Fill null values in age column with -1
```csharp 
df.Na().Fill(-1, new[] { "age" }).Show();

+---+-------+
|age|   name|
+---+-------+
| -1|Michael|
| 30|   Andy|
| 19| Justin|
+---+-------+
```

###  Drop age column
```csharp
df.Drop(new[] { "age" }).Show();

+-------+
|   name|
+-------+
|Michael|
|   Andy|
| Justin|
+-------+
```