### PR TITLE
Addresses issue of assembly.zip contents not unzipped to current directory, preventing UDF failures by default.

### DIFF
--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -60,7 +60,10 @@ object DotnetRunner extends Logging {
         var zipFileName = args(0)
         val zipFileUri = Try(new URI(zipFileName)).getOrElse(new File(zipFileName).toURI)
         val workingDir = new File("").getAbsoluteFile
-        val driverDir = new File(workingDir, FilenameUtils.getBaseName(zipFileUri.getPath()))
+        //val driverDir = new File(workingDir, FilenameUtils.getBaseName(zipFileUri.getPath()))
+		// ZZ: By unzipping into the working directory, this ensures currentdir is the dir containing the files that is needed to properly handle UDF's, without the need to set ASSEMBLY_PATHS
+		// The alternative here would be to change current working directory to the subdirectory path, but that seems like it could have more unintended side effects
+		val driverDir = workingDir
 
         // Standalone cluster mode where .NET application is remotely located.
         if (zipFileUri.getScheme() != "file") {


### PR DESCRIPTION
…bly or UDF's fail with serialization errors

Code change to unzip contents of assembly.zip to current directory instead.

We are excited to review your PR.

So we can do the best job, please check:

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

