### PR TITLE
Add Delta Lake version annotations to `Microsoft.Spark.Extensions.Delta` APIs.

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace Microsoft.Spark.Extensions.Delta
 {

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Spark.Extensions.Delta
     /// Custom attribute to denote the Delta Lake version in which an API is introduced.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class DeltaSinceAttribute : VersionAttribute
+    public sealed class DeltaLakeSinceAttribute : VersionAttribute
     {
         /// <summary>
-        /// Constructor for DeltaSinceAttribute class.
+        /// Constructor for DeltaLakeSinceAttribute class.
         /// </summary>
         /// <param name="version">Delta Lake version</param>
-        public DeltaSinceAttribute(string version)
+        public DeltaLakeSinceAttribute(string version)
             : base(version)
         {
         }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Attributes.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Microsoft.Spark.Extensions.Delta
+{
+    /// <summary>
+    /// Custom attribute to denote the Delta Lake version in which an API is introduced.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class DeltaSinceAttribute : VersionAttribute
+    {
+        /// <summary>
+        /// Constructor for DeltaSinceAttribute class.
+        /// </summary>
+        /// <param name="version">Delta Lake version</param>
+        public DeltaSinceAttribute(string version)
+            : base(version)
+        {
+        }
+    }
+}

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Microsoft.Spark.Extensions.Delta
+﻿namespace Microsoft.Spark.Extensions.Delta
 {
     internal static class DeltaLakeVersions
     {

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Spark.Extensions.Delta
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Spark.Extensions.Delta
 {
     internal static class DeltaLakeVersions
     {
@@ -11,4 +15,3 @@
         internal const string V0_6_1 = "0.6.1";
     }
 }
-

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Spark.Extensions.Delta
+{
+    internal static class DeltaLakeVersions
+    {
+        internal const string V0_1_0 = "0.1.0";
+        internal const string V0_2_0 = "0.2.0";
+        internal const string V0_3_0 = "0.3.0";
+        internal const string V0_4_0 = "0.4.0";
+        internal const string V0_5_0 = "0.5.0";
+        internal const string V0_6_0 = "0.6.0";
+        internal const string V0_6_1 = "0.6.1";
+    }
+}
+

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// </code>
     /// </example>
     /// </summary>
-    [DeltaSince(DeltaLakeVersions.V0_3_0)]
+    [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -93,7 +93,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// delete the matched target table row with the source row.
         /// </summary>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched() =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched"));
@@ -106,7 +106,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a SQL formatted string.</param>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(string condition) =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
@@ -119,7 +119,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a Column object.</param>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(Column condition) =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
@@ -130,7 +130,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// new sourced row into the target table.
         /// </summary>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched() =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched"));
@@ -142,7 +142,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a SQL formatted string.</param>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(string condition) =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
@@ -154,7 +154,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a Column object.</param>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(Column condition) =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
@@ -162,7 +162,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <summary>
         /// Execute the merge operation based on the built matched and not matched actions.
         /// </summary>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Execute() => _jvmObject.Invoke("execute");
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// </code>
     /// </example>
     /// </summary>
+    [DeltaSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -92,6 +93,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// delete the matched target table row with the source row.
         /// </summary>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched() =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched"));
@@ -104,6 +106,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a SQL formatted string.</param>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(string condition) =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
@@ -116,6 +119,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a Column object.</param>
         /// <returns>DeltaMergeMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(Column condition) =>
             new DeltaMergeMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
@@ -126,6 +130,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// new sourced row into the target table.
         /// </summary>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched() =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched"));
@@ -137,6 +142,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a SQL formatted string.</param>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(string condition) =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
@@ -148,6 +154,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="condition">Boolean expression as a Column object.</param>
         /// <returns>DeltaMergeNotMatchedActionBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(Column condition) =>
             new DeltaMergeNotMatchedActionBuilder(
                 (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
@@ -155,6 +162,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <summary>
         /// Execute the merge operation based on the built matched and not matched actions.
         /// </summary>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Execute() => _jvmObject.Invoke("execute");
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// Builder class to specify the actions to perform when a target table row has matched a
     /// source row based on the given merge condition and optional match condition.
     /// </summary>
+    [DeltaSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeMatchedActionBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -29,6 +30,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="set">Rules to update a row as amap between target column names and
         /// corresponding update expressions as Column objects.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Update(Dictionary<string, Column> set) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("update", set));
 
@@ -38,6 +40,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="set">Rules to update a row as a map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateExpr(Dictionary<string, string> set) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateExpr", set));
 
@@ -46,6 +49,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// columns in the source row.
         /// </summary>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateAll() =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateAll"));
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// Builder class to specify the actions to perform when a target table row has matched a
     /// source row based on the given merge condition and optional match condition.
     /// </summary>
-    [DeltaSince(DeltaLakeVersions.V0_3_0)]
+    [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeMatchedActionBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -30,7 +30,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="set">Rules to update a row as amap between target column names and
         /// corresponding update expressions as Column objects.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Update(Dictionary<string, Column> set) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("update", set));
 
@@ -40,7 +40,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="set">Rules to update a row as a map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateExpr(Dictionary<string, string> set) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateExpr", set));
 
@@ -49,7 +49,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// columns in the source row.
         /// </summary>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateAll() =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateAll"));
 
@@ -57,6 +57,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Delete a matched row from the table.
         /// </summary>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Delete() =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("delete"));
     }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// 
     /// See <see cref="DeltaMergeBuilder"/> for more information.
     /// </summary>
-    [DeltaSince(DeltaLakeVersions.V0_3_0)]
+    [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeNotMatchedActionBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -33,7 +33,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="values">Rules to insert a row as a map between target column names and
         /// corresponding expressions as Column objects.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Insert(Dictionary<string, Column> values) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insert", values));
 
@@ -43,7 +43,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="values">Rules to insert a row as a map between target column names and
         /// corresponding expressions as SQL formatted strings.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertExpr(Dictionary<string, string> values) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertExpr", values));
 
@@ -52,7 +52,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// corresponding columns in the source row.
         /// </summary>
         /// <returns>DeltaMergeBuilder object.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertAll() =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertAll"));
     }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// 
     /// See <see cref="DeltaMergeBuilder"/> for more information.
     /// </summary>
+    [DeltaSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeNotMatchedActionBuilder : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -32,6 +33,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="values">Rules to insert a row as a map between target column names and
         /// corresponding expressions as Column objects.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Insert(Dictionary<string, Column> values) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insert", values));
 
@@ -41,6 +43,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="values">Rules to insert a row as a map between target column names and
         /// corresponding expressions as SQL formatted strings.</param>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertExpr(Dictionary<string, string> values) =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertExpr", values));
 
@@ -49,6 +52,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// corresponding columns in the source row.
         /// </summary>
         /// <returns>DeltaMergeBuilder object.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertAll() =>
             new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertAll"));
     }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// DeltaTable.ForPath(sparkSession, pathToTheDeltaTable)
     /// </code>
     /// </summary>
-    [DeltaSince(DeltaLakeVersions.V0_3_0)]
+    [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaTable : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -57,7 +57,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">StructType representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_4_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(
             SparkSession spark,
             string identifier,
@@ -88,7 +88,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">String representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_4_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(
             SparkSession spark,
             string identifier,
@@ -117,7 +117,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="spark">The relevant session.</param>
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <returns>The converted DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_4_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -135,7 +135,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="path">The path to the data.</param>
         /// <returns>DeltaTable loaded from the path.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public static DeltaTable ForPath(string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -150,7 +150,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="sparkSession">The active SparkSession.</param>
         /// <param name="path">The path to the data.</param>
         /// <returns>DeltaTable loaded from the path.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public static DeltaTable ForPath(SparkSession sparkSession, string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -171,7 +171,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="sparkSession">The relevant session.</param>
         /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
         /// <returns>True if the table is a DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_4_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_4_0)]
         public static bool IsDeltaTable(SparkSession sparkSession, string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 s_deltaTableClassName,
@@ -194,7 +194,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
         /// <returns>True if the table is a DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_4_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_4_0)]
         public static bool IsDeltaTable(string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 s_deltaTableClassName,
@@ -207,7 +207,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="alias">The table alias.</param>
         /// <returns>Aliased DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable As(string alias) =>
             new DeltaTable((JvmObjectReference)_jvmObject.Invoke("as", alias));
 
@@ -217,7 +217,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="alias">The table alias.</param>
         /// <returns>Aliased DeltaTable.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable Alias(string alias) =>
             new DeltaTable((JvmObjectReference)_jvmObject.Invoke("alias", alias));
 
@@ -225,7 +225,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
         /// </summary>
         /// <returns>DataFrame representation of Delta table.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame ToDF() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("toDF"));
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// table for reading versions earlier than this will be preserved and the rest of them
         /// will be deleted.</param>
         /// <returns>Vacuumed DataFrame.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum(double retentionHours) =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum", retentionHours));
 
@@ -249,7 +249,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Note: This will use the default retention period of 7 days.
         /// </summary>
         /// <returns>Vacuumed DataFrame.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum() =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum"));
 
@@ -259,7 +259,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="limit">The number of previous commands to get history for.</param>
         /// <returns>History DataFrame.</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History(int limit) =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("history", limit));
 
@@ -268,7 +268,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// information is in reverse chronological order.
         /// </summary>
         /// <returns>History DataFrame</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History() =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("history"));
 
@@ -280,27 +280,27 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// - "symlink_format_manifest" : This will generate manifests in symlink format
         /// for Presto and Athena read support.
         /// See the online documentation for more information.</param>
-        [DeltaSince(DeltaLakeVersions.V0_5_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_5_0)]
         public void Generate(string mode) => _jvmObject.Invoke("generate", mode);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Delete(string condition) => _jvmObject.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Delete(Column condition) => _jvmObject.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table.
         /// </summary>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Delete() => _jvmObject.Invoke("delete");
 
         /// <summary>
@@ -316,7 +316,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </example>
         /// <param name="set">Pules to update a row as a Scala map between target column names
         /// and corresponding update expressions as Column objects.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Update(Dictionary<string, Column> set) => _jvmObject.Invoke("update", set);
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// to update.</param>
         /// <param name="set">Rules to update a row as a Scala map between target column names and
         /// corresponding update expressions as Column objects.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Update(Column condition, Dictionary<string, Column> set) =>
             _jvmObject.Invoke("update", condition, set);
 
@@ -355,7 +355,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </example>
         /// <param name="set">Rules to update a row as a Scala map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(Dictionary<string, string> set) =>
             _jvmObject.Invoke("updateExpr", set);
 
@@ -377,7 +377,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// which rows to update.</param>
         /// <param name="set">Rules to update a row as a map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(string condition, Dictionary<string, string> set) =>
             _jvmObject.Invoke("updateExpr", condition, set);
 
@@ -418,7 +418,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="source">Source Dataframe to be merged.</param>
         /// <param name="condition">Boolean expression as SQL formatted string.</param>
         /// <returns>DeltaMergeBuilder</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, string condition) =>
             new DeltaMergeBuilder(
                 (JvmObjectReference)_jvmObject.Invoke(
@@ -460,7 +460,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="source">Source Dataframe to be merged.</param>
         /// <param name="condition">Coolean expression as a Column object</param>
         /// <returns>DeltaMergeBuilder</returns>
-        [DeltaSince(DeltaLakeVersions.V0_3_0)]
+        [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, Column condition) =>
             new DeltaMergeBuilder(
                 (JvmObjectReference)_jvmObject.Invoke(

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     /// DeltaTable.ForPath(sparkSession, pathToTheDeltaTable)
     /// </code>
     /// </summary>
+    [DeltaSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaTable : IJvmObjectReferenceProvider
     {
         private readonly JvmObjectReference _jvmObject;
@@ -56,6 +57,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">StructType representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(
             SparkSession spark,
             string identifier,
@@ -86,6 +88,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <param name="partitionSchema">String representing the partition schema.</param>
         /// <returns>The converted DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(
             SparkSession spark,
             string identifier,
@@ -114,6 +117,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="spark">The relevant session.</param>
         /// <param name="identifier">String used to identify the parquet table.</param>
         /// <returns>The converted DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_4_0)]
         public static DeltaTable ConvertToDelta(SparkSession spark, string identifier) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -131,6 +135,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="path">The path to the data.</param>
         /// <returns>DeltaTable loaded from the path.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public static DeltaTable ForPath(string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -145,6 +150,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="sparkSession">The active SparkSession.</param>
         /// <param name="path">The path to the data.</param>
         /// <returns>DeltaTable loaded from the path.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public static DeltaTable ForPath(SparkSession sparkSession, string path) =>
             new DeltaTable(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -165,6 +171,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="sparkSession">The relevant session.</param>
         /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
         /// <returns>True if the table is a DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_4_0)]
         public static bool IsDeltaTable(SparkSession sparkSession, string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 s_deltaTableClassName,
@@ -187,6 +194,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="identifier">String that identifies the table, e.g. path to table.</param>
         /// <returns>True if the table is a DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_4_0)]
         public static bool IsDeltaTable(string identifier) =>
             (bool)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 s_deltaTableClassName,
@@ -199,6 +207,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="alias">The table alias.</param>
         /// <returns>Aliased DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable As(string alias) =>
             new DeltaTable((JvmObjectReference)_jvmObject.Invoke("as", alias));
 
@@ -208,6 +217,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="alias">The table alias.</param>
         /// <returns>Aliased DeltaTable.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable Alias(string alias) =>
             new DeltaTable((JvmObjectReference)_jvmObject.Invoke("alias", alias));
 
@@ -215,6 +225,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
         /// </summary>
         /// <returns>DataFrame representation of Delta table.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame ToDF() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("toDF"));
 
         /// <summary>
@@ -226,6 +237,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// table for reading versions earlier than this will be preserved and the rest of them
         /// will be deleted.</param>
         /// <returns>Vacuumed DataFrame.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum(double retentionHours) =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum", retentionHours));
 
@@ -237,6 +249,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// Note: This will use the default retention period of 7 days.
         /// </summary>
         /// <returns>Vacuumed DataFrame.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum() =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum"));
 
@@ -246,6 +259,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </summary>
         /// <param name="limit">The number of previous commands to get history for.</param>
         /// <returns>History DataFrame.</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History(int limit) =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("history", limit));
 
@@ -254,6 +268,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// information is in reverse chronological order.
         /// </summary>
         /// <returns>History DataFrame</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History() =>
             new DataFrame((JvmObjectReference)_jvmObject.Invoke("history"));
 
@@ -265,23 +280,27 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// - "symlink_format_manifest" : This will generate manifests in symlink format
         /// for Presto and Athena read support.
         /// See the online documentation for more information.</param>
+        [DeltaSince(DeltaLakeVersions.V0_5_0)]
         public void Generate(string mode) => _jvmObject.Invoke("generate", mode);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Delete(string condition) => _jvmObject.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Delete(Column condition) => _jvmObject.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table.
         /// </summary>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Delete() => _jvmObject.Invoke("delete");
 
         /// <summary>
@@ -297,6 +316,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </example>
         /// <param name="set">Pules to update a row as a Scala map between target column names
         /// and corresponding update expressions as Column objects.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Update(Dictionary<string, Column> set) => _jvmObject.Invoke("update", set);
 
         /// <summary>
@@ -317,6 +337,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// to update.</param>
         /// <param name="set">Rules to update a row as a Scala map between target column names and
         /// corresponding update expressions as Column objects.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void Update(Column condition, Dictionary<string, Column> set) =>
             _jvmObject.Invoke("update", condition, set);
 
@@ -334,6 +355,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// </example>
         /// <param name="set">Rules to update a row as a Scala map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(Dictionary<string, string> set) =>
             _jvmObject.Invoke("updateExpr", set);
 
@@ -355,6 +377,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// which rows to update.</param>
         /// <param name="set">Rules to update a row as a map between target column names and
         /// corresponding update expressions as SQL formatted strings.</param>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(string condition, Dictionary<string, string> set) =>
             _jvmObject.Invoke("updateExpr", condition, set);
 
@@ -395,6 +418,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="source">Source Dataframe to be merged.</param>
         /// <param name="condition">Boolean expression as SQL formatted string.</param>
         /// <returns>DeltaMergeBuilder</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, string condition) =>
             new DeltaMergeBuilder(
                 (JvmObjectReference)_jvmObject.Invoke(
@@ -436,6 +460,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="source">Source Dataframe to be merged.</param>
         /// <param name="condition">Coolean expression as a Column object</param>
         /// <returns>DeltaMergeBuilder</returns>
+        [DeltaSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, Column condition) =>
             new DeltaMergeBuilder(
                 (JvmObjectReference)_jvmObject.Invoke(


### PR DESCRIPTION
This PR adds Delta Lake version annotations to all Delta Lake APIs in `Microsoft.Spark.Extensions.Delta`.  Versions were determined according to equivalent annotations found in the [official Delta Lake API docs](https://docs.delta.io/0.6.1/api/scala/io/delta/tables/index.html).

This PR contributes to #618.