### PR TITLE
Add testcases for spark version

### DIFF
--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Spark.Worker.UnitTest
 
             for (int i = 0; i < taskRunnerNumber; ++i)
             {
-                CreateAndVerifyConnection(daemonSocket);
+                CreateAndVerifyConnection(daemonSocket, typedVersion);
             }
             
             Assert.Equal(taskRunnerNumber, daemonWorker.CurrentNumTaskRunners);
         }
 
-        private static void CreateAndVerifyConnection(ISocketWrapper daemonSocket)
+        private static void CreateAndVerifyConnection(ISocketWrapper daemonSocket, Version version)
         {
             var ipEndpoint = (IPEndPoint)daemonSocket.LocalEndPoint;
             int port = ipEndpoint.Port;
@@ -42,7 +42,7 @@ namespace Microsoft.Spark.Worker.UnitTest
             clientSocket.Connect(ipEndpoint.Address, port);
 
             // Now process the bytes flowing in from the client.
-            PayloadWriter payloadWriter = new PayloadWriterFactory().Create();
+            PayloadWriter payloadWriter = new PayloadWriterFactory().Create(version);
             payloadWriter.WriteTestData(clientSocket.OutputStream);
             List<object[]> rowsReceived = PayloadReader.Read(clientSocket.InputStream);
 

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
@@ -14,13 +14,14 @@ namespace Microsoft.Spark.Worker.UnitTest
     [Collection("Spark Unit Tests")]
     public class DaemonWorkerTests
     {
-        [Fact]
-        public void TestsDaemonWorkerTaskRunners()
+        [Theory]
+        [MemberData(nameof(TestData.versionTests), MemberType = typeof(TestData))]
+        public void TestsDaemonWorkerTaskRunners(string version)
         {
             ISocketWrapper daemonSocket = SocketFactory.CreateSocket();
             
             int taskRunnerNumber = 3;
-            var typedVersion = new Version(Versions.V2_4_0);
+            var typedVersion = new Version(version);
             var daemonWorker = new DaemonWorker(typedVersion);
             
             Task.Run(() => daemonWorker.Run(daemonSocket));

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Spark.Worker.UnitTest
     public class DaemonWorkerTests
     {
         [Theory]
-        [MemberData(nameof(TestData.versionTests), MemberType = typeof(TestData))]
+        [MemberData(nameof(TestData.VersionData), MemberType = typeof(TestData))]
         public void TestsDaemonWorkerTaskRunners(string version)
         {
             ISocketWrapper daemonSocket = SocketFactory.CreateSocket();

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/PayloadProcessorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/PayloadProcessorTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Spark.Worker.UnitTest
     public class PayloadProcessorTests
     {
         [Theory]
-        [MemberData(nameof(TestData.versionTests), MemberType = typeof(TestData))]
+        [MemberData(nameof(TestData.VersionData), MemberType = typeof(TestData))]
         public void TestPayloadProcessor(string version)
         {
             CommandPayload commandPayload = TestData.GetDefaultCommandPayload();

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/PayloadProcessorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/PayloadProcessorTests.cs
@@ -18,12 +18,7 @@ namespace Microsoft.Spark.Worker.UnitTest
     public class PayloadProcessorTests
     {
         [Theory]
-        [InlineData(Versions.V2_3_0)]
-        [InlineData(Versions.V2_3_1)]
-        [InlineData(Versions.V2_3_2)]
-        [InlineData(Versions.V2_3_3)]
-        [InlineData(Versions.V2_4_0)]
-        [InlineData(Versions.V3_0_0)]
+        [MemberData(nameof(TestData.versionTests), MemberType = typeof(TestData))]
         public void TestPayloadProcessor(string version)
         {
             CommandPayload commandPayload = TestData.GetDefaultCommandPayload();

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Utils;
 
@@ -12,6 +14,16 @@ namespace Microsoft.Spark.Worker.UnitTest
     /// </summary>
     internal static class TestData
     {
+        public static IEnumerable<object[]> versionTests()
+        {
+            yield return new object[] { Versions.V2_3_0 };
+            yield return new object[] { Versions.V2_3_1 };
+            yield return new object[] { Versions.V2_3_2 };
+            yield return new object[] { Versions.V2_3_3 };
+            yield return new object[] { Versions.V2_4_0 };
+            yield return new object[] { Versions.V3_0_0 };
+        }
+
         internal static Payload GetDefaultPayload()
         {
             var taskContext = new TaskContext()

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Utils;
@@ -14,15 +13,16 @@ namespace Microsoft.Spark.Worker.UnitTest
     /// </summary>
     internal static class TestData
     {
-        public static IEnumerable<object[]> versionTests()
-        {
-            yield return new object[] { Versions.V2_3_0 };
-            yield return new object[] { Versions.V2_3_1 };
-            yield return new object[] { Versions.V2_3_2 };
-            yield return new object[] { Versions.V2_3_3 };
-            yield return new object[] { Versions.V2_4_0 };
-            yield return new object[] { Versions.V3_0_0 };
-        }
+        public static IEnumerable<object[]> VersionData() =>
+            new List<object[]>
+            {
+                new object[] { Versions.V2_3_0 },
+                new object[] { Versions.V2_3_1 },
+                new object[] { Versions.V2_3_2 },
+                new object[] { Versions.V2_3_3 },
+                new object[] { Versions.V2_4_0 },
+                new object[] { Versions.V3_0_0 },
+            };
 
         internal static Payload GetDefaultPayload()
         {

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Spark.Worker.UnitTest
     {
         public static IEnumerable<object[]> versionTests()
         {
-         //   yield return new object[] { Versions.V2_3_0 };
-         //   yield return new object[] { Versions.V2_3_1 };
-         //   yield return new object[] { Versions.V2_3_2 };
-         //   yield return new object[] { Versions.V2_3_3 };
+            yield return new object[] { Versions.V2_3_0 };
+            yield return new object[] { Versions.V2_3_1 };
+            yield return new object[] { Versions.V2_3_2 };
+            yield return new object[] { Versions.V2_3_3 };
             yield return new object[] { Versions.V2_4_0 };
             yield return new object[] { Versions.V3_0_0 };
         }

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Spark.Worker.UnitTest
          //   yield return new object[] { Versions.V2_3_2 };
          //   yield return new object[] { Versions.V2_3_3 };
             yield return new object[] { Versions.V2_4_0 };
-         //   yield return new object[] { Versions.V3_0_0 };
+            yield return new object[] { Versions.V3_0_0 };
         }
 
         internal static Payload GetDefaultPayload()

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/TestData.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Spark.Worker.UnitTest
     {
         public static IEnumerable<object[]> versionTests()
         {
-            yield return new object[] { Versions.V2_3_0 };
-            yield return new object[] { Versions.V2_3_1 };
-            yield return new object[] { Versions.V2_3_2 };
-            yield return new object[] { Versions.V2_3_3 };
+         //   yield return new object[] { Versions.V2_3_0 };
+         //   yield return new object[] { Versions.V2_3_1 };
+         //   yield return new object[] { Versions.V2_3_2 };
+         //   yield return new object[] { Versions.V2_3_3 };
             yield return new object[] { Versions.V2_4_0 };
-            yield return new object[] { Versions.V3_0_0 };
+         //   yield return new object[] { Versions.V3_0_0 };
         }
 
         internal static Payload GetDefaultPayload()


### PR DESCRIPTION
There are a lot of spark versions but only 2.4.0 has been tested.

so I've added test cases, also move test cases to `TestData.cs`

also moved test cases have been reused in `PayloadProcessTests` 



