### PR TITLE
xxhash64 - function for Spark 3.0 Readiness #633

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -796,5 +796,14 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             col = MapConcat(col);
             col = MapConcat(col, col);
         }
+
+        /// <summary>
+        /// Test signatures for APIs introduced in Spark 3.0.*.
+        /// </summary>
+        [SkipIfSparkVersionIsLessThan(Versions.V3_0_0)]
+        public void TestSignaturesV3_0_X()
+        {
+            Column col = XXHash64(Column("col"), Column("col2"));
+        }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Functions.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Functions.cs
@@ -3611,6 +3611,18 @@ namespace Microsoft.Spark.Sql
         {
             return ApplyFunction("map_concat", (object)columns);
         }
+        
+        /// <summary>
+        /// Calculates the hash code of given columns using the 64-bit variant of the xxHash
+        /// algorithm, and returns the result as a long column.
+        /// </summary>
+        /// <param name="columns">Columns to apply</param>
+        /// <returns>Column object</returns>
+        [Since(Versions.V3_0_0)]
+        public static Column XXHash64(params Column[] columns)
+        {
+            return ApplyFunction("xxhash64", (object)columns);
+        }
 
         /////////////////////////////////////////////////////////////////////////////////
         // UDF helper functions


### PR DESCRIPTION
From Spark 3.0 Readiness #633 - this is one of the functions, I wasn't 100% sure on the name xxhash64 - I went with XXHash64 but let me know if that isn't right.

