### PR TITLE
Update azure-pipeline.yml to include comments on why E2E forward compatibility test does not run against Spark 2.4.6.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,6 +408,15 @@ stages:
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
+    - task: DotNetCoreCLI@2
+      displayName: 'E2E tests for Spark 2.4.6'
+      inputs:
+        command: test
+        projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
+        arguments: '--configuration $(buildConfiguration)'
+      env:
+        SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.6-bin-hadoop2.7
+
 - stage: BackwardCompatibility
   displayName: E2E Backward Compatibility Tests
   dependsOn: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,14 +408,8 @@ stages:
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
-    - task: DotNetCoreCLI@2
-      displayName: 'E2E tests for Spark 2.4.6'
-      inputs:
-        command: test
-        projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
-      env:
-        SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.6-bin-hadoop2.7
+    # Forward compatibility is tested only up to Spark 2.4.5 since it is the lastest Spark version
+    # tested for "forwardCompatibleRelease". This can be updated when "forwardCompatibleRelease" is updated.
 
 - stage: BackwardCompatibility
   displayName: E2E Backward Compatibility Tests


### PR DESCRIPTION
It appears that E2E forward compatibility tests are missing against Spark 2.4.6. The reason is that 2.4.5 is the latest version that 0.9.0 was tested against. I am adding a comment to `azure-pipeline.yml` not to forget about this (I knew about this during review, but forgot about it after few months).
