### PR TITLE
Return UTF-8 encoded string from JVM => CLR

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SerDeTests.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Spark.Sql;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Spark.Sql;
 using Xunit;
 
 namespace Microsoft.Spark.E2ETest.IpcTests

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SerDeTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Spark.Sql;
+using Xunit;
+
+namespace Microsoft.Spark.E2ETest.IpcTests
+{
+    [Collection("Spark E2E Tests")]
+    public class SerDeTests
+    {
+        private readonly SparkSession _spark;
+
+        public SerDeTests(SparkFixture fixture)
+        {
+            _spark = fixture.Spark;
+        }
+
+        [Fact]
+        public void TestUnicode()
+        {
+            string expected =
+                "①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙–⿻〇㐀㐁㐃㐄䶴䶵U1[]U2[]U3[]";
+
+            RuntimeConfig conf = _spark.Conf();
+            string key = "SerDeTests.TestUnicode";
+            conf.Set(key, expected);
+
+            string actual = conf.Get(key);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
@@ -7,6 +7,7 @@
 package org.apache.spark.api.dotnet
 
 import java.io.{DataInputStream, DataOutputStream}
+import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
 
 import org.apache.spark.sql.Row
@@ -318,11 +319,11 @@ object SerDe {
     out.writeDouble((value.getTime / 1000).toDouble + value.getNanos.toDouble / 1e9)
   }
 
-  // NOTE: Only works for ASCII right now
   def writeString(out: DataOutputStream, value: String): Unit = {
-    val len = value.length
+    val utf8 = value.getBytes(StandardCharsets.UTF_8)
+    val len = utf8.length
     out.writeInt(len)
-    out.writeBytes(value)
+    out.write(utf8, 0, len)
   }
 
   def writeBytes(out: DataOutputStream, value: Array[Byte]): Unit = {

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
@@ -7,6 +7,7 @@
 package org.apache.spark.api.dotnet
 
 import java.io.{DataInputStream, DataOutputStream}
+import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
 
 import org.apache.spark.sql.Row
@@ -318,11 +319,11 @@ object SerDe {
     out.writeDouble((value.getTime / 1000).toDouble + value.getNanos.toDouble / 1e9)
   }
 
-  // NOTE: Only works for ASCII right now
   def writeString(out: DataOutputStream, value: String): Unit = {
-    val len = value.length
+    val utf8 = value.getBytes(StandardCharsets.UTF_8)
+    val len = utf8.length
     out.writeInt(len)
-    out.writeBytes(value)
+    out.write(utf8, 0, len)
   }
 
   def writeBytes(out: DataOutputStream, value: Array[Byte]): Unit = {

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
@@ -7,6 +7,7 @@
 package org.apache.spark.api.dotnet
 
 import java.io.{DataInputStream, DataOutputStream}
+import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
 
 import org.apache.spark.sql.Row
@@ -320,9 +321,10 @@ object SerDe {
 
   // NOTE: Only works for ASCII right now
   def writeString(out: DataOutputStream, value: String): Unit = {
-    val len = value.length
+    val utf8 = value.getBytes(StandardCharsets.UTF_8)
+    val len = utf8.length
     out.writeInt(len)
-    out.writeBytes(value)
+    out.write(utf8, 0, len)
   }
 
   def writeBytes(out: DataOutputStream, value: Array[Byte]): Unit = {

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/SerDe.scala
@@ -319,7 +319,6 @@ object SerDe {
     out.writeDouble((value.getTime / 1000).toDouble + value.getNanos.toDouble / 1e9)
   }
 
-  // NOTE: Only works for ASCII right now
   def writeString(out: DataOutputStream, value: String): Unit = {
     val utf8 = value.getBytes(StandardCharsets.UTF_8)
     val len = utf8.length


### PR DESCRIPTION
We were previously only returning ASCII strings from JVM=>CLR.  This PR supports encoding the string as UTF-8.