### PR TITLE
Support ArrayType and MapType

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,13 @@ variables:
   # forwardCompatibleRelease/backwardCompatibleRelease is the "oldest" releases that work with the current release
   forwardCompatibleRelease: '0.9.0'
   backwardCompatibleRelease: '0.9.0'
-  TestsToFilterOut: "(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&\
+  forwardCompatibleTestsToFilterOut: "(FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayType)"
+  backwardCompatibleTestsToFilterOut: "(FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameGroupedMapUdf)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestDataFrameVectorUdf)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestDestroy)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)"
@@ -332,7 +334,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
 
@@ -341,7 +343,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
 
@@ -350,7 +352,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
 
@@ -359,7 +361,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
 
@@ -368,7 +370,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
 
@@ -377,7 +379,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
 
@@ -386,7 +388,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
   
@@ -395,7 +397,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
 
@@ -404,7 +406,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
 
@@ -413,7 +415,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
+        arguments: '--configuration $(buildConfiguration) --filter $(forwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
@@ -464,7 +466,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.0-bin-hadoop2.7
 
@@ -473,7 +475,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.1-bin-hadoop2.7
 
@@ -482,7 +484,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.2-bin-hadoop2.7
 
@@ -491,7 +493,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.3-bin-hadoop2.7
 
@@ -500,7 +502,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.3.4-bin-hadoop2.7
 
@@ -509,7 +511,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.0-bin-hadoop2.7
 
@@ -518,7 +520,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.1-bin-hadoop2.7
   
@@ -527,7 +529,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.3-bin-hadoop2.7
 
@@ -536,7 +538,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.4-bin-hadoop2.7
 
@@ -545,7 +547,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.5-bin-hadoop2.7
 
@@ -554,7 +556,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: '--configuration $(buildConfiguration) --filter $(TestsToFilterOut)'
+        arguments: '--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)'
       env:
         SPARK_HOME: $(Build.BinariesDirectory)\spark-2.4.6-bin-hadoop2.7
 
@@ -566,7 +568,7 @@ stages:
       inputs:
         command: test
         projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
-        arguments: "--configuration $(buildConfiguration) --filter $(TestsToFilterOut)&\
+        arguments: "--configuration $(buildConfiguration) --filter $(backwardCompatibleTestsToFilterOut)&\
         (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestGroupedMapUdf)&\
         (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.DataFrameTests.TestVectorUdf)"
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ variables:
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithMapType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,11 @@ variables:
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestMultipleBroadcastWithoutEncryption)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayOfArrayType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithRowArrayType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithSimpleArrayType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithMapType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithMapOfMapType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithReturnAsMapType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ variables:
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.BroadcastTests.TestUnpersist)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithArrayType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithMapType)&\
+  (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfComplexTypesTests.TestUdfWithReturnAsMapType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithReturnAsTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.UdfTests.UdfSimpleTypesTests.TestUdfWithTimestampType)&\
   (FullyQualifiedName!=Microsoft.Spark.E2ETest.IpcTests.SparkSessionTests.TestCreateDataFrameWithTimestamp)"

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
@@ -178,7 +178,8 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                         new StructType(new StructField[]
                         {
                             new StructField("first", new StringType()),
-                            new StructField("second", new StringType())
+                            new StructField("second", new StringType()),
+                            new StructField("ids", new ArrayType(new IntegerType())),
                         })))
                 });
 
@@ -192,12 +193,14 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                             new GenericRow(new object[]
                             {
                                 "f1",
-                                "s1"
+                                "s1",
+                                new int[] { 1, 2, 3 }
                             }),
                             new GenericRow(new object[]
                             {
                                 "f2",
-                                "s2"
+                                "s2",
+                                new int[] { 4, 5 }
                             })
                         }
                     }),
@@ -214,7 +217,8 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                             new GenericRow(new object[]
                             {
                                 "f3",
-                                "s3"
+                                "s3",
+                                new int[] { 6 }
                             })
                         }
                     }),
@@ -230,8 +234,18 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                             if (rows != null)
                             {
                                 sb.Append("|" + string.Join(
-                                    ",",
-                                    rows.Select(r => r.GetAs<string>(0) + r.GetAs<string>(1))));
+                                    "|",
+                                    rows.Select(r =>
+                                    {
+                                        string firstlast = r.GetAs<string>(0) + r.GetAs<string>(1);
+                                        int[] ids = r.GetAs<int[]>("ids");
+                                        if (ids == null)
+                                        {
+                                            return firstlast;
+                                        }
+
+                                        return firstlast + "," + string.Join(",", ids);
+                                    })));
                             }
 
                             return sb.ToString();
@@ -242,9 +256,9 @@ namespace Microsoft.Spark.E2ETest.UdfTests
 
                 var expected = new string[]
                 {
-                    "Name1|f1s1,f2s2",
+                    "Name1|f1s1,1,2,3|f2s2,4,5",
                     "Name2",
-                    "Name3|f3s3"
+                    "Name3|f3s3,6"
                 };
                 Assert.Equal(expected, rows.Select(r => r.GetAs<string>(0)));
             }

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
@@ -156,7 +156,10 @@ namespace Microsoft.Spark.E2ETest.UdfTests
                         });
 
                 DataFrame df = _spark.CreateDataFrame(data, schema);
-                Row[] rows = df.Select(udf(df["name"], df["ids"], df["arrIds"], df["arrArrIds"])).Collect().ToArray();
+                Row[] rows =
+                    df.Select(udf(df["name"], df["ids"], df["arrIds"], df["arrArrIds"]))
+                    .Collect()
+                    .ToArray();
 
                 var expected = new string[]
                 {

--- a/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfComplexTypesTests.cs
@@ -154,9 +154,9 @@ namespace Microsoft.Spark.E2ETest.UdfTests
 
             var expected = new string[]
             {
-                "Name1|1,2,3|10,11,12|100,101,102,103",
+                "Name1|1,2,3|+10,+11,+12|++100,++101,++102,++103",
                 "Name2",
-                "Name3|4|13|104"
+                "Name3|4|+13|++104"
             };
 
             {
@@ -175,14 +175,17 @@ namespace Microsoft.Spark.E2ETest.UdfTests
 
                             if (arrIds != null)
                             {
-                                AppendEnumerable(sb, arrIds.SelectMany(i => i));
+                                AppendEnumerable(
+                                    sb,
+                                    arrIds.SelectMany(i => i.Select(j => $"+{j}")));
                             }
 
                             if (arrArrIds != null)
                             {
                                 AppendEnumerable(
                                     sb,
-                                    arrArrIds.SelectMany(i => i.SelectMany(j => j)));
+                                    arrArrIds.SelectMany(
+                                        i => i.SelectMany(j => j.Select(k => $"++{k}"))));
                             }
 
                             return sb.ToString();
@@ -211,17 +214,20 @@ namespace Microsoft.Spark.E2ETest.UdfTests
 
                             if (arrIds != null)
                             {
-                                IEnumerable<object> idsEnum =
-                                    arrIds.ToArray().SelectMany(i => ((ArrayList)i).ToArray());
+                                IEnumerable<object> idsEnum = arrIds
+                                    .ToArray()
+                                    .SelectMany(
+                                        i => ((ArrayList)i).ToArray().Select(j => $"+{j}"));
                                 AppendEnumerable(sb, idsEnum);
                             }
 
                             if (arrArrIds != null)
                             {
-                                IEnumerable<object> idsEnum =
-                                    arrArrIds.ToArray()
-                                        .SelectMany(i => ((ArrayList)i).ToArray()
-                                            .SelectMany(j => ((ArrayList)j).ToArray()));
+                                IEnumerable<object> idsEnum = arrArrIds
+                                    .ToArray()
+                                    .SelectMany(i => ((ArrayList)i).ToArray()
+                                        .SelectMany(
+                                            j => ((ArrayList)j).ToArray().Select(k => $"++{k}")));
                                 AppendEnumerable(sb, idsEnum);
                             }
 

--- a/src/csharp/Microsoft.Spark.UnitTest/Sql/TypesTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Sql/TypesTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Spark.UnitTest
 
                 var expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
                 var actual = (ArrayList)arrayType.FromInternal(expected);
-                Assert.Equal(expected, actual);
+                Assert.Same(expected, actual);
             }
             {
                 var dateType = new DateType();
@@ -103,7 +103,7 @@ namespace Microsoft.Spark.UnitTest
                     Enumerable.Range(0, 10).ToDictionary(i => i, i => i * i);
                 var expected = new Hashtable(dict);
                 var actual = (Hashtable)mapType.FromInternal(expected);
-                Assert.Equal(expected, actual);
+                Assert.Same(expected, actual);
             }
             {
                 var integerType = new IntegerType();

--- a/src/csharp/Microsoft.Spark.UnitTest/Sql/TypesTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Sql/TypesTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Spark.Sql.Types;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -45,6 +48,30 @@ namespace Microsoft.Spark.UnitTest
             Assert.Equal("integer", arrayType.ElementType.TypeName);
             Assert.False(arrayType.ContainsNull);
         }
+
+        [Fact]
+        public void TestArrayTypeFromInternal()
+        {
+            {
+                var arrayType = new ArrayType(new IntegerType());
+                Assert.False(arrayType.NeedConversion());
+
+                var expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
+                var actual = (ArrayList)arrayType.FromInternal(expected);
+                Assert.Equal(expected, actual);
+            }
+            {
+                var dateType = new DateType();
+                var arrayType = new ArrayType(dateType);
+                Assert.True(arrayType.NeedConversion());
+
+                var internalDates = new int[] { 10, 100 };
+                Date[] expected =
+                    internalDates.Select(i => (Date)dateType.FromInternal(i)).ToArray();
+                var actual = (ArrayList)arrayType.FromInternal(new ArrayList(internalDates));
+                Assert.Equal(expected, actual.ToArray());
+            }
+        }
         
         [Fact]
         public void TestMapType()
@@ -62,6 +89,35 @@ namespace Microsoft.Spark.UnitTest
             Assert.Equal("integer", mapType.KeyType.TypeName);
             Assert.Equal("double", mapType.ValueType.TypeName);
             Assert.False(mapType.ValueContainsNull);
+        }
+
+        [Fact]
+        public void TestMapTypeFromInternal()
+        {
+            {
+                var integerType = new IntegerType();
+                var mapType = new MapType(integerType, integerType);
+                Assert.False(mapType.NeedConversion());
+
+                Dictionary<int, int> dict =
+                    Enumerable.Range(0, 10).ToDictionary(i => i, i => i * i);
+                var expected = new Hashtable(dict);
+                var actual = (Hashtable)mapType.FromInternal(expected);
+                Assert.Equal(expected, actual);
+            }
+            {
+                var integerType = new IntegerType();
+                var dateType = new DateType();
+                var mapType = new MapType(integerType, dateType);
+                Assert.True(mapType.NeedConversion());
+
+                var internalDates = new int[] { 10, 100 };
+                var expected = new Hashtable(
+                    internalDates.ToDictionary(i => i, i => (Date)dateType.FromInternal(i)));
+                var actual = (Hashtable)mapType.FromInternal(
+                    new Hashtable(internalDates.ToDictionary(i => i, i => i)));
+                Assert.Equal(expected, actual);
+            }
         }
         
         [Fact]

--- a/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Spark.Utils;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    public class TypeConverterTests
+    {
+        [Fact]
+        public void TestBaseCase()
+        {
+            Assert.Equal(0x01, TypeConverter.Convert<byte>((byte)0x01));
+            Assert.Equal(1, TypeConverter.Convert<sbyte>((sbyte)0x01));
+            Assert.Equal(1, TypeConverter.Convert<short>((short)1));
+            Assert.Equal(1, TypeConverter.Convert<ushort>((ushort)1));
+            Assert.Equal(1, TypeConverter.Convert<int>(1));
+            Assert.Equal(1u, TypeConverter.Convert<uint>(1u));
+            Assert.Equal(1L, TypeConverter.Convert<long>(1L));
+            Assert.Equal(1ul, TypeConverter.Convert<ulong>(1ul));
+            Assert.Equal(1.0f, TypeConverter.Convert<float>(1.0f));
+            Assert.Equal(1.0d, TypeConverter.Convert<double>(1.0d));
+            Assert.Equal(1.0m, TypeConverter.Convert<decimal>(1.0m));
+            Assert.Equal('a', TypeConverter.Convert<char>('a'));
+            Assert.Equal("test", TypeConverter.Convert<string>("test"));
+            Assert.True(TypeConverter.Convert<bool>(true));
+        }
+
+        [Fact]
+        public void TestArrayList()
+        {
+            ArrayList expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
+            ArrayList actual = TypeConverter.Convert<ArrayList>(expected);
+            Assert.True(ReferenceEquals(expected, actual));
+        }
+
+        [Fact]
+        public void TestArray()
+        {
+            int[] expected = Enumerable.Range(0, 10).ToArray();
+            ArrayList arrayList = new ArrayList(expected);
+            int[] actual = TypeConverter.Convert<int[]>(arrayList);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestArrayArray()
+        {
+            int[][] expected =
+                Enumerable.Range(0, 10).Select(i => Enumerable.Range(i, 10).ToArray()).ToArray();
+
+            ArrayList arrayList = new ArrayList(expected.Length);
+            for (int i = 0; i < expected.Length; ++i)
+            {
+                int[] innerExpected = expected[i];
+                ArrayList innerArrayList = new ArrayList(innerExpected.Length);
+                for (int j = 0; j < innerExpected.Length; ++j)
+                {
+                    innerArrayList.Add(innerExpected[j]);
+                }
+
+                arrayList.Add(innerArrayList);
+            }
+
+            int[][] actual = TypeConverter.Convert<int[][]>(arrayList);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestArrayArrayArray()
+        {
+            int[][][] expected = Enumerable.Range(0, 10)
+                .Select(i => Enumerable.Range(i, 10))
+                .Select(arr => arr.Select(j => Enumerable.Range(j, 10).ToArray()).ToArray())
+                .ToArray();
+
+            ArrayList arrayList = new ArrayList(expected.Length);
+            for (int i = 0; i < expected.Length; ++i)
+            {
+                int[][] innerExpected = expected[i];
+                ArrayList innerArrayList = new ArrayList(innerExpected.Length);
+                for (int j = 0; j < innerExpected.Length; ++j)
+                {
+                    int[] innerInnerExpected = expected[i][j];
+                    ArrayList innerInnerArrayList = new ArrayList(innerInnerExpected.Length);
+                    for (int k = 0; k < innerInnerExpected.Length; ++k)
+                    {
+                        innerInnerArrayList.Add(innerInnerExpected[k]);
+                    }
+
+                    innerArrayList.Add(innerInnerArrayList);
+                }
+
+                arrayList.Add(innerArrayList);
+            }
+
+            int[][][] actual = TypeConverter.Convert<int[][][]>(arrayList);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestHashtable()
+        {
+            Hashtable expected =
+                new Hashtable(Enumerable.Range(0, 10).ToDictionary(k => k, v => v * v));
+            Hashtable actual = TypeConverter.Convert<Hashtable>(expected);
+            Assert.True(ReferenceEquals(expected, actual));
+        }
+
+        [Fact]
+        public void TestDictionary()
+        {
+            Dictionary<int, int> expected =
+                Enumerable.Range(0, 10).ToDictionary(i => i, i => i * i);
+            Hashtable hashtable = new Hashtable(expected);
+            Dictionary<int, int> actual = TypeConverter.Convert<Dictionary<int, int>>(hashtable);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDictionaryDictionary()
+        {
+            Dictionary<int, Dictionary<int, int>> expected = Enumerable
+                .Range(0, 10)
+                .ToDictionary(
+                    i => i,
+                    i => Enumerable.Range(i, 10).ToDictionary(j => j, j => j * j));
+
+            Hashtable hashtable = new Hashtable();
+            foreach (KeyValuePair<int, Dictionary<int, int>> kvp in expected)
+            {
+                Hashtable innerHashtable = new Hashtable();
+                foreach(KeyValuePair<int, int> innerKvp in kvp.Value)
+                {
+                    innerHashtable[innerKvp.Key] = innerKvp.Value;
+                }
+
+                hashtable[kvp.Key] = innerHashtable;
+            }
+
+            Dictionary<int, Dictionary<int, int>> actual =
+                TypeConverter.Convert<Dictionary<int, Dictionary<int, int>>>(hashtable);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDictionaryAndArray()
+        {
+            {
+                Dictionary<int, int[]> expected = Enumerable
+                    .Range(0, 10)
+                    .ToDictionary(
+                        i => i,
+                        i => Enumerable.Range(i, 10).ToArray());
+
+                Hashtable hashtable = new Hashtable();
+                foreach (KeyValuePair<int, int[]> kvp in expected)
+                {
+                    ArrayList arrayList = new ArrayList();
+                    for (int i = 0; i < kvp.Value.Length; ++i)
+                    {
+                        arrayList.Add(kvp.Value[i]);
+                    }
+
+                    hashtable[kvp.Key] = arrayList;
+                }
+
+                Dictionary<int, int[]> actual =
+                    TypeConverter.Convert<Dictionary<int, int[]>>(hashtable);
+                Assert.Equal(expected, actual);
+            }
+            {
+                Dictionary<int, int>[] expected = Enumerable
+                    .Range(0, 10)
+                    .Select(i => Enumerable.Range(i, 10).ToDictionary(j => j, j => j * j))
+                    .ToArray();
+                
+                ArrayList arrayList = new ArrayList();
+                for (int i = 0; i < expected.Length; ++i)
+                {
+                    Hashtable hashtable = new Hashtable();
+                    foreach (KeyValuePair<int, int> kvp in expected[i])
+                    {
+                        hashtable[kvp.Key] = kvp.Value;
+                    }
+
+                    arrayList.Add(hashtable);
+                }
+
+                Dictionary<int, int>[] actual =
+                    TypeConverter.Convert<Dictionary<int, int>[]>(arrayList);
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestBaseCase()
         {
-            Assert.Equal(0x01, TypeConverter.Convert<byte>((byte)0x01));
-            Assert.Equal(1, TypeConverter.Convert<sbyte>((sbyte)0x01));
-            Assert.Equal(1, TypeConverter.Convert<short>((short)1));
-            Assert.Equal(1, TypeConverter.Convert<ushort>((ushort)1));
+            Assert.Equal((byte)0x01, TypeConverter.Convert<byte>((byte)0x01));
+            Assert.Equal((sbyte)0x01, TypeConverter.Convert<sbyte>((sbyte)0x01));
+            Assert.Equal((short)1, TypeConverter.Convert<short>((short)1));
+            Assert.Equal((ushort)1, TypeConverter.Convert<ushort>((ushort)1));
             Assert.Equal(1, TypeConverter.Convert<int>(1));
             Assert.Equal(1u, TypeConverter.Convert<uint>(1u));
             Assert.Equal(1L, TypeConverter.Convert<long>(1L));
@@ -34,7 +34,7 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestArrayList()
         {
-            ArrayList expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
+            var expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
             ArrayList actual = TypeConverter.Convert<ArrayList>(expected);
             Assert.True(ReferenceEquals(expected, actual));
         }
@@ -43,7 +43,7 @@ namespace Microsoft.Spark.UnitTest
         public void TestArray()
         {
             int[] expected = Enumerable.Range(0, 10).ToArray();
-            ArrayList arrayList = new ArrayList(expected);
+            var arrayList = new ArrayList(expected);
             int[] actual = TypeConverter.Convert<int[]>(arrayList);
             Assert.Equal(expected, actual);
         }
@@ -54,11 +54,11 @@ namespace Microsoft.Spark.UnitTest
             int[][] expected =
                 Enumerable.Range(0, 10).Select(i => Enumerable.Range(i, 10).ToArray()).ToArray();
 
-            ArrayList arrayList = new ArrayList(expected.Length);
+            var arrayList = new ArrayList(expected.Length);
             for (int i = 0; i < expected.Length; ++i)
             {
                 int[] innerExpected = expected[i];
-                ArrayList innerArrayList = new ArrayList(innerExpected.Length);
+                var innerArrayList = new ArrayList(innerExpected.Length);
                 for (int j = 0; j < innerExpected.Length; ++j)
                 {
                     innerArrayList.Add(innerExpected[j]);
@@ -79,15 +79,15 @@ namespace Microsoft.Spark.UnitTest
                 .Select(arr => arr.Select(j => Enumerable.Range(j, 10).ToArray()).ToArray())
                 .ToArray();
 
-            ArrayList arrayList = new ArrayList(expected.Length);
+            var arrayList = new ArrayList(expected.Length);
             for (int i = 0; i < expected.Length; ++i)
             {
                 int[][] innerExpected = expected[i];
-                ArrayList innerArrayList = new ArrayList(innerExpected.Length);
+                var innerArrayList = new ArrayList(innerExpected.Length);
                 for (int j = 0; j < innerExpected.Length; ++j)
                 {
                     int[] innerInnerExpected = expected[i][j];
-                    ArrayList innerInnerArrayList = new ArrayList(innerInnerExpected.Length);
+                    var innerInnerArrayList = new ArrayList(innerInnerExpected.Length);
                     for (int k = 0; k < innerInnerExpected.Length; ++k)
                     {
                         innerInnerArrayList.Add(innerInnerExpected[k]);
@@ -106,7 +106,7 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestHashtable()
         {
-            Hashtable expected =
+            var expected =
                 new Hashtable(Enumerable.Range(0, 10).ToDictionary(k => k, v => v * v));
             Hashtable actual = TypeConverter.Convert<Hashtable>(expected);
             Assert.True(ReferenceEquals(expected, actual));
@@ -117,7 +117,7 @@ namespace Microsoft.Spark.UnitTest
         {
             Dictionary<int, int> expected =
                 Enumerable.Range(0, 10).ToDictionary(i => i, i => i * i);
-            Hashtable hashtable = new Hashtable(expected);
+            var hashtable = new Hashtable(expected);
             Dictionary<int, int> actual = TypeConverter.Convert<Dictionary<int, int>>(hashtable);
             Assert.Equal(expected, actual);
         }
@@ -131,10 +131,10 @@ namespace Microsoft.Spark.UnitTest
                     i => i,
                     i => Enumerable.Range(i, 10).ToDictionary(j => j, j => j * j));
 
-            Hashtable hashtable = new Hashtable();
+            var hashtable = new Hashtable();
             foreach (KeyValuePair<int, Dictionary<int, int>> kvp in expected)
             {
-                Hashtable innerHashtable = new Hashtable();
+                var innerHashtable = new Hashtable();
                 foreach(KeyValuePair<int, int> innerKvp in kvp.Value)
                 {
                     innerHashtable[innerKvp.Key] = innerKvp.Value;
@@ -158,10 +158,10 @@ namespace Microsoft.Spark.UnitTest
                         i => i,
                         i => Enumerable.Range(i, 10).ToArray());
 
-                Hashtable hashtable = new Hashtable();
+                var hashtable = new Hashtable();
                 foreach (KeyValuePair<int, int[]> kvp in expected)
                 {
-                    ArrayList arrayList = new ArrayList();
+                    var arrayList = new ArrayList();
                     for (int i = 0; i < kvp.Value.Length; ++i)
                     {
                         arrayList.Add(kvp.Value[i]);
@@ -180,10 +180,10 @@ namespace Microsoft.Spark.UnitTest
                     .Select(i => Enumerable.Range(i, 10).ToDictionary(j => j, j => j * j))
                     .ToArray();
                 
-                ArrayList arrayList = new ArrayList();
+                var arrayList = new ArrayList();
                 for (int i = 0; i < expected.Length; ++i)
                 {
-                    Hashtable hashtable = new Hashtable();
+                    var hashtable = new Hashtable();
                     foreach (KeyValuePair<int, int> kvp in expected[i])
                     {
                         hashtable[kvp.Key] = kvp.Value;

--- a/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/TypeConverterTests.cs
@@ -15,28 +15,28 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestBaseCase()
         {
-            Assert.Equal((byte)0x01, TypeConverter.Convert<byte>((byte)0x01));
-            Assert.Equal((sbyte)0x01, TypeConverter.Convert<sbyte>((sbyte)0x01));
-            Assert.Equal((short)1, TypeConverter.Convert<short>((short)1));
-            Assert.Equal((ushort)1, TypeConverter.Convert<ushort>((ushort)1));
-            Assert.Equal(1, TypeConverter.Convert<int>(1));
-            Assert.Equal(1u, TypeConverter.Convert<uint>(1u));
-            Assert.Equal(1L, TypeConverter.Convert<long>(1L));
-            Assert.Equal(1ul, TypeConverter.Convert<ulong>(1ul));
-            Assert.Equal(1.0f, TypeConverter.Convert<float>(1.0f));
-            Assert.Equal(1.0d, TypeConverter.Convert<double>(1.0d));
-            Assert.Equal(1.0m, TypeConverter.Convert<decimal>(1.0m));
-            Assert.Equal('a', TypeConverter.Convert<char>('a'));
-            Assert.Equal("test", TypeConverter.Convert<string>("test"));
-            Assert.True(TypeConverter.Convert<bool>(true));
+            Assert.Equal((byte)0x01, TypeConverter.ConvertTo<byte>((byte)0x01));
+            Assert.Equal((sbyte)0x01, TypeConverter.ConvertTo<sbyte>((sbyte)0x01));
+            Assert.Equal((short)1, TypeConverter.ConvertTo<short>((short)1));
+            Assert.Equal((ushort)1, TypeConverter.ConvertTo<ushort>((ushort)1));
+            Assert.Equal(1, TypeConverter.ConvertTo<int>(1));
+            Assert.Equal(1u, TypeConverter.ConvertTo<uint>(1u));
+            Assert.Equal(1L, TypeConverter.ConvertTo<long>(1L));
+            Assert.Equal(1ul, TypeConverter.ConvertTo<ulong>(1ul));
+            Assert.Equal(1.0f, TypeConverter.ConvertTo<float>(1.0f));
+            Assert.Equal(1.0d, TypeConverter.ConvertTo<double>(1.0d));
+            Assert.Equal(1.0m, TypeConverter.ConvertTo<decimal>(1.0m));
+            Assert.Equal('a', TypeConverter.ConvertTo<char>('a'));
+            Assert.Equal("test", TypeConverter.ConvertTo<string>("test"));
+            Assert.True(TypeConverter.ConvertTo<bool>(true));
         }
 
         [Fact]
         public void TestArrayList()
         {
             var expected = new ArrayList(Enumerable.Range(0, 10).ToArray());
-            ArrayList actual = TypeConverter.Convert<ArrayList>(expected);
-            Assert.True(ReferenceEquals(expected, actual));
+            ArrayList actual = TypeConverter.ConvertTo<ArrayList>(expected);
+            Assert.Same(expected, actual);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Microsoft.Spark.UnitTest
         {
             int[] expected = Enumerable.Range(0, 10).ToArray();
             var arrayList = new ArrayList(expected);
-            int[] actual = TypeConverter.Convert<int[]>(arrayList);
+            int[] actual = TypeConverter.ConvertTo<int[]>(arrayList);
             Assert.Equal(expected, actual);
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Spark.UnitTest
                 arrayList.Add(innerArrayList);
             }
 
-            int[][] actual = TypeConverter.Convert<int[][]>(arrayList);
+            int[][] actual = TypeConverter.ConvertTo<int[][]>(arrayList);
             Assert.Equal(expected, actual);
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.Spark.UnitTest
                 arrayList.Add(innerArrayList);
             }
 
-            int[][][] actual = TypeConverter.Convert<int[][][]>(arrayList);
+            int[][][] actual = TypeConverter.ConvertTo<int[][][]>(arrayList);
             Assert.Equal(expected, actual);
         }
 
@@ -108,8 +108,8 @@ namespace Microsoft.Spark.UnitTest
         {
             var expected =
                 new Hashtable(Enumerable.Range(0, 10).ToDictionary(k => k, v => v * v));
-            Hashtable actual = TypeConverter.Convert<Hashtable>(expected);
-            Assert.True(ReferenceEquals(expected, actual));
+            Hashtable actual = TypeConverter.ConvertTo<Hashtable>(expected);
+            Assert.Same(expected, actual);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Microsoft.Spark.UnitTest
             Dictionary<int, int> expected =
                 Enumerable.Range(0, 10).ToDictionary(i => i, i => i * i);
             var hashtable = new Hashtable(expected);
-            Dictionary<int, int> actual = TypeConverter.Convert<Dictionary<int, int>>(hashtable);
+            Dictionary<int, int> actual = TypeConverter.ConvertTo<Dictionary<int, int>>(hashtable);
             Assert.Equal(expected, actual);
         }
 
@@ -144,7 +144,7 @@ namespace Microsoft.Spark.UnitTest
             }
 
             Dictionary<int, Dictionary<int, int>> actual =
-                TypeConverter.Convert<Dictionary<int, Dictionary<int, int>>>(hashtable);
+                TypeConverter.ConvertTo<Dictionary<int, Dictionary<int, int>>>(hashtable);
             Assert.Equal(expected, actual);
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.Spark.UnitTest
                 }
 
                 Dictionary<int, int[]> actual =
-                    TypeConverter.Convert<Dictionary<int, int[]>>(hashtable);
+                    TypeConverter.ConvertTo<Dictionary<int, int[]>>(hashtable);
                 Assert.Equal(expected, actual);
             }
             {
@@ -193,7 +193,7 @@ namespace Microsoft.Spark.UnitTest
                 }
 
                 Dictionary<int, int>[] actual =
-                    TypeConverter.Convert<Dictionary<int, int>[]>(arrayList);
+                    TypeConverter.ConvertTo<Dictionary<int, int>[]>(arrayList);
                 Assert.Equal(expected, actual);
             }
         }

--- a/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
+++ b/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Spark.Sql
 
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
-            return _func(TypeConverter.Convert<T>(input[argOffsets[0]]));
+            return _func(TypeConverter.ConvertTo<T>(input[argOffsets[0]]));
         }
     }
 
@@ -67,8 +67,8 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]));
         }
     }
 
@@ -92,9 +92,9 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]));
         }
     }
 
@@ -119,10 +119,10 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]));
         }
     }
 
@@ -148,11 +148,11 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]));
         }
     }
 
@@ -179,12 +179,12 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]),
-                TypeConverter.Convert<T6>(input[argOffsets[5]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]),
+                TypeConverter.ConvertTo<T6>(input[argOffsets[5]]));
         }
     }
 
@@ -212,13 +212,13 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]),
-                TypeConverter.Convert<T6>(input[argOffsets[5]]),
-                TypeConverter.Convert<T7>(input[argOffsets[6]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]),
+                TypeConverter.ConvertTo<T6>(input[argOffsets[5]]),
+                TypeConverter.ConvertTo<T7>(input[argOffsets[6]]));
         }
     }
 
@@ -247,14 +247,14 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]),
-                TypeConverter.Convert<T6>(input[argOffsets[5]]),
-                TypeConverter.Convert<T7>(input[argOffsets[6]]),
-                TypeConverter.Convert<T8>(input[argOffsets[7]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]),
+                TypeConverter.ConvertTo<T6>(input[argOffsets[5]]),
+                TypeConverter.ConvertTo<T7>(input[argOffsets[6]]),
+                TypeConverter.ConvertTo<T8>(input[argOffsets[7]]));
         }
     }
 
@@ -283,15 +283,15 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]),
-                TypeConverter.Convert<T6>(input[argOffsets[5]]),
-                TypeConverter.Convert<T7>(input[argOffsets[6]]),
-                TypeConverter.Convert<T8>(input[argOffsets[7]]),
-                TypeConverter.Convert<T9>(input[argOffsets[8]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]),
+                TypeConverter.ConvertTo<T6>(input[argOffsets[5]]),
+                TypeConverter.ConvertTo<T7>(input[argOffsets[6]]),
+                TypeConverter.ConvertTo<T8>(input[argOffsets[7]]),
+                TypeConverter.ConvertTo<T9>(input[argOffsets[8]]));
         }
     }
 
@@ -322,16 +322,16 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                TypeConverter.Convert<T1>(input[argOffsets[0]]),
-                TypeConverter.Convert<T2>(input[argOffsets[1]]),
-                TypeConverter.Convert<T3>(input[argOffsets[2]]),
-                TypeConverter.Convert<T4>(input[argOffsets[3]]),
-                TypeConverter.Convert<T5>(input[argOffsets[4]]),
-                TypeConverter.Convert<T6>(input[argOffsets[5]]),
-                TypeConverter.Convert<T7>(input[argOffsets[6]]),
-                TypeConverter.Convert<T8>(input[argOffsets[7]]),
-                TypeConverter.Convert<T9>(input[argOffsets[8]]),
-                TypeConverter.Convert<T10>(input[argOffsets[9]]));
+                TypeConverter.ConvertTo<T1>(input[argOffsets[0]]),
+                TypeConverter.ConvertTo<T2>(input[argOffsets[1]]),
+                TypeConverter.ConvertTo<T3>(input[argOffsets[2]]),
+                TypeConverter.ConvertTo<T4>(input[argOffsets[3]]),
+                TypeConverter.ConvertTo<T5>(input[argOffsets[4]]),
+                TypeConverter.ConvertTo<T6>(input[argOffsets[5]]),
+                TypeConverter.ConvertTo<T7>(input[argOffsets[6]]),
+                TypeConverter.ConvertTo<T8>(input[argOffsets[7]]),
+                TypeConverter.ConvertTo<T9>(input[argOffsets[8]]),
+                TypeConverter.ConvertTo<T10>(input[argOffsets[9]]));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
+++ b/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Spark.Sql
 
             for (int i = 0; i < length; ++i)
             {
-
                 object convertedElement = convertMethod.Invoke(null, new[] { arrayList[i] });
                 Debug.Assert(genericElementType == convertedElement.GetType());
                 convertedArray.SetValue(convertedElement, i);

--- a/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
+++ b/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
@@ -3,9 +3,53 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace Microsoft.Spark.Sql
 {
+    internal static class PicklingUdfWrapperHelper
+    {
+        internal static T Convert<T>(object obj)
+        {
+            if (obj == null)
+            {
+                return default;
+            }
+
+            Type type = obj.GetType();
+            return (T)(type switch
+            {
+                _ when type == typeof(ArrayList) => ConvertToArray<T>((ArrayList)obj),
+                _ => obj
+            });
+        }
+
+        private static object ConvertToArray<T>(ArrayList arrayList)
+        {
+            Type genericType = typeof(T);
+            Debug.Assert(genericType.IsArray);
+            Type genericElementType = genericType.GetElementType();
+
+            int length = arrayList.Count;
+            Array convertedArray = Array.CreateInstance(genericElementType, length);
+            MethodInfo convertMethod = typeof(PicklingUdfWrapperHelper)
+                .GetMethod("Convert", BindingFlags.Static | BindingFlags.NonPublic)
+                .MakeGenericMethod(new[] { genericElementType });
+
+            for (int i = 0; i < length; ++i)
+            {
+
+                object convertedElement = convertMethod.Invoke(null, new[] { arrayList[i] });
+                Debug.Assert(genericElementType == convertedElement.GetType());
+                convertedArray.SetValue(convertedElement, i);
+            }
+
+            return convertedArray;
+        }
+    }
+
     /// <summary>
     /// Wraps the given Func object, which represents a UDF.
     /// </summary>
@@ -43,7 +87,7 @@ namespace Microsoft.Spark.Sql
 
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
-            return _func((T)(input[argOffsets[0]]));
+            return _func(PicklingUdfWrapperHelper.Convert<T>(input[argOffsets[0]]));
         }
     }
 
@@ -65,7 +109,9 @@ namespace Microsoft.Spark.Sql
 
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
-            return _func((T1)(input[argOffsets[0]]), (T2)(input[argOffsets[1]]));
+            return _func(
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]));
         }
     }
 
@@ -89,9 +135,9 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]));
         }
     }
 
@@ -116,10 +162,10 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]));
         }
     }
 
@@ -145,11 +191,11 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]));
         }
     }
 
@@ -176,12 +222,12 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]),
-                (T6)(input[argOffsets[5]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
+                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]));
         }
     }
 
@@ -209,13 +255,13 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]),
-                (T6)(input[argOffsets[5]]),
-                (T7)(input[argOffsets[6]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
+                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
+                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]));
         }
     }
 
@@ -244,14 +290,14 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]),
-                (T6)(input[argOffsets[5]]),
-                (T7)(input[argOffsets[6]]),
-                (T8)(input[argOffsets[7]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
+                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
+                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
+                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]));
         }
     }
 
@@ -280,15 +326,15 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]),
-                (T6)(input[argOffsets[5]]),
-                (T7)(input[argOffsets[6]]),
-                (T8)(input[argOffsets[7]]),
-                (T9)(input[argOffsets[8]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
+                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
+                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
+                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]),
+                PicklingUdfWrapperHelper.Convert<T9>(input[argOffsets[8]]));
         }
     }
 
@@ -319,16 +365,16 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                (T1)(input[argOffsets[0]]),
-                (T2)(input[argOffsets[1]]),
-                (T3)(input[argOffsets[2]]),
-                (T4)(input[argOffsets[3]]),
-                (T5)(input[argOffsets[4]]),
-                (T6)(input[argOffsets[5]]),
-                (T7)(input[argOffsets[6]]),
-                (T8)(input[argOffsets[7]]),
-                (T9)(input[argOffsets[8]]),
-                (T10)(input[argOffsets[9]]));
+                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
+                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
+                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
+                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
+                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
+                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
+                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
+                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]),
+                PicklingUdfWrapperHelper.Convert<T9>(input[argOffsets[8]]),
+                PicklingUdfWrapperHelper.Convert<T10>(input[argOffsets[9]]));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
+++ b/src/csharp/Microsoft.Spark/Sql/PicklingUdfWrapper.cs
@@ -3,52 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
-using System.Diagnostics;
-using System.Reflection;
+using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Sql
 {
-    internal static class PicklingUdfWrapperHelper
-    {
-        internal static T Convert<T>(object obj)
-        {
-            if (obj == null)
-            {
-                return default;
-            }
-
-            Type type = obj.GetType();
-            return (T)(type switch
-            {
-                _ when type == typeof(ArrayList) => ConvertToArray<T>((ArrayList)obj),
-                _ => obj
-            });
-        }
-
-        private static object ConvertToArray<T>(ArrayList arrayList)
-        {
-            Type genericType = typeof(T);
-            Debug.Assert(genericType.IsArray);
-            Type genericElementType = genericType.GetElementType();
-
-            int length = arrayList.Count;
-            Array convertedArray = Array.CreateInstance(genericElementType, length);
-            MethodInfo convertMethod = typeof(PicklingUdfWrapperHelper)
-                .GetMethod("Convert", BindingFlags.Static | BindingFlags.NonPublic)
-                .MakeGenericMethod(new[] { genericElementType });
-
-            for (int i = 0; i < length; ++i)
-            {
-                object convertedElement = convertMethod.Invoke(null, new[] { arrayList[i] });
-                Debug.Assert(genericElementType == convertedElement.GetType());
-                convertedArray.SetValue(convertedElement, i);
-            }
-
-            return convertedArray;
-        }
-    }
-
     /// <summary>
     /// Wraps the given Func object, which represents a UDF.
     /// </summary>
@@ -86,7 +44,7 @@ namespace Microsoft.Spark.Sql
 
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
-            return _func(PicklingUdfWrapperHelper.Convert<T>(input[argOffsets[0]]));
+            return _func(TypeConverter.Convert<T>(input[argOffsets[0]]));
         }
     }
 
@@ -109,8 +67,8 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]));
         }
     }
 
@@ -134,9 +92,9 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]));
         }
     }
 
@@ -161,10 +119,10 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]));
         }
     }
 
@@ -190,11 +148,11 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]));
         }
     }
 
@@ -221,12 +179,12 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
-                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]),
+                TypeConverter.Convert<T6>(input[argOffsets[5]]));
         }
     }
 
@@ -254,13 +212,13 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
-                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
-                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]),
+                TypeConverter.Convert<T6>(input[argOffsets[5]]),
+                TypeConverter.Convert<T7>(input[argOffsets[6]]));
         }
     }
 
@@ -289,14 +247,14 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
-                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
-                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
-                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]),
+                TypeConverter.Convert<T6>(input[argOffsets[5]]),
+                TypeConverter.Convert<T7>(input[argOffsets[6]]),
+                TypeConverter.Convert<T8>(input[argOffsets[7]]));
         }
     }
 
@@ -325,15 +283,15 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
-                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
-                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
-                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]),
-                PicklingUdfWrapperHelper.Convert<T9>(input[argOffsets[8]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]),
+                TypeConverter.Convert<T6>(input[argOffsets[5]]),
+                TypeConverter.Convert<T7>(input[argOffsets[6]]),
+                TypeConverter.Convert<T8>(input[argOffsets[7]]),
+                TypeConverter.Convert<T9>(input[argOffsets[8]]));
         }
     }
 
@@ -364,16 +322,16 @@ namespace Microsoft.Spark.Sql
         internal object Execute(int splitIndex, object[] input, int[] argOffsets)
         {
             return _func(
-                PicklingUdfWrapperHelper.Convert<T1>(input[argOffsets[0]]),
-                PicklingUdfWrapperHelper.Convert<T2>(input[argOffsets[1]]),
-                PicklingUdfWrapperHelper.Convert<T3>(input[argOffsets[2]]),
-                PicklingUdfWrapperHelper.Convert<T4>(input[argOffsets[3]]),
-                PicklingUdfWrapperHelper.Convert<T5>(input[argOffsets[4]]),
-                PicklingUdfWrapperHelper.Convert<T6>(input[argOffsets[5]]),
-                PicklingUdfWrapperHelper.Convert<T7>(input[argOffsets[6]]),
-                PicklingUdfWrapperHelper.Convert<T8>(input[argOffsets[7]]),
-                PicklingUdfWrapperHelper.Convert<T9>(input[argOffsets[8]]),
-                PicklingUdfWrapperHelper.Convert<T10>(input[argOffsets[9]]));
+                TypeConverter.Convert<T1>(input[argOffsets[0]]),
+                TypeConverter.Convert<T2>(input[argOffsets[1]]),
+                TypeConverter.Convert<T3>(input[argOffsets[2]]),
+                TypeConverter.Convert<T4>(input[argOffsets[3]]),
+                TypeConverter.Convert<T5>(input[argOffsets[4]]),
+                TypeConverter.Convert<T6>(input[argOffsets[5]]),
+                TypeConverter.Convert<T7>(input[argOffsets[6]]),
+                TypeConverter.Convert<T8>(input[argOffsets[7]]),
+                TypeConverter.Convert<T9>(input[argOffsets[8]]),
+                TypeConverter.Convert<T10>(input[argOffsets[9]]));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Row.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Row.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.Spark.Sql.Types;
+using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Sql
 {
@@ -108,7 +109,7 @@ namespace Microsoft.Spark.Sql
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="index">Index to look up</param>
         /// <returns>A column value as a type T</returns>
-        public T GetAs<T>(int index) => (T)Get(index);
+        public T GetAs<T>(int index) => TypeConverter.Convert<T>(Get(index));
 
         /// <summary>
         /// Returns the column value whose column name is given, as a type T.
@@ -119,7 +120,7 @@ namespace Microsoft.Spark.Sql
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="columnName">Column name to look up</param>
         /// <returns>A column value as a type T</returns>
-        public T GetAs<T>(string columnName) => (T)Get(columnName);
+        public T GetAs<T>(string columnName) => TypeConverter.Convert<T>(Get(columnName));
 
         /// <summary>
         /// Checks if the given object is same as the current object.

--- a/src/csharp/Microsoft.Spark/Sql/Row.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Row.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Spark.Sql
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="index">Index to look up</param>
         /// <returns>A column value as a type T</returns>
-        public T GetAs<T>(int index) => TypeConverter.Convert<T>(Get(index));
+        public T GetAs<T>(int index) => TypeConverter.ConvertTo<T>(Get(index));
 
         /// <summary>
         /// Returns the column value whose column name is given, as a type T.
@@ -120,7 +120,7 @@ namespace Microsoft.Spark.Sql
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="columnName">Column name to look up</param>
         /// <returns>A column value as a type T</returns>
-        public T GetAs<T>(string columnName) => TypeConverter.Convert<T>(Get(columnName));
+        public T GetAs<T>(string columnName) => TypeConverter.ConvertTo<T>(Get(columnName));
 
         /// <summary>
         /// Checks if the given object is same as the current object.

--- a/src/csharp/Microsoft.Spark/Sql/Types/ComplexTypes.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Types/ComplexTypes.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.Spark.Interop.Ipc;
 using Newtonsoft.Json.Linq;
@@ -75,17 +73,18 @@ namespace Microsoft.Spark.Sql.Types
 
         internal override object FromInternal(object obj)
         {
-            if (NeedConversion())
+            if (!NeedConversion() || obj == null)
             {
-                ArrayList arrayList = obj as ArrayList;
-                int length = arrayList != null ? arrayList.Count : 0;
-                for (int i = 0; i < length; ++i)
-                {
-                    arrayList[i] = ElementType.FromInternal(arrayList[i]);
-                }
+                return obj;
+            }
+            
+            var arrayList = (ArrayList)obj;
+            for (int i = 0; i < arrayList.Count; ++i)
+            {
+                arrayList[i] = ElementType.FromInternal(arrayList[i]);
             }
 
-            return obj;
+            return arrayList;
         }
     }
 
@@ -162,15 +161,13 @@ namespace Microsoft.Spark.Sql.Types
 
         internal override object FromInternal(object obj)
         {
-            if (!NeedConversion())
+            if (!NeedConversion() || obj == null)
             {
                 return obj;
             }
 
-            Debug.Assert(obj is Hashtable);
-            Hashtable hashTable = obj as Hashtable;
-
-            Hashtable convertedHashtable = new Hashtable();
+            var hashTable = (Hashtable)obj;
+            var convertedHashtable = new Hashtable(hashTable.Count);
             foreach (DictionaryEntry entry in hashTable)
             {
                 convertedHashtable[KeyType.FromInternal(entry.Key)] =

--- a/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
+++ b/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 namespace Microsoft.Spark.Utils
 {
     /// <summary>
-    /// Converts one type to another.
     /// Supports converting <see cref="ArrayList"/> to a typed <see cref="Array"/> and
     /// <see cref="Hashtable"/> to a typed <see cref="Dictionary{TKey, TValue}"/>.
     /// </summary>

--- a/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
+++ b/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Spark.Utils
+{
+    /// <summary>
+    /// Converts one type to another.
+    /// </summary>
+    internal static class TypeConverter
+    {
+        /// <summary>
+        /// Convert obj to type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Type to convert to</typeparam>
+        /// <param name="obj">The object to convert</param>
+        /// <returns></returns>
+        internal static T Convert<T>(object obj) => (T)Convert(obj, typeof(T));
+
+        private static object Convert(object obj, Type toType)
+        {
+            if (obj == null)
+            {
+                return obj;
+            }
+
+            Type fromType = obj.GetType();
+            return fromType switch
+            {
+                _ when fromType == toType => obj,
+                _ when (fromType == typeof(ArrayList)) && toType.IsArray =>
+                    ConvertArrayList((ArrayList)obj, toType),
+                _ when (fromType == typeof(Hashtable)) && toType.IsGenericType &&
+                    (toType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) =>
+                    ConvertHashtable((Hashtable)obj, toType),
+                _ => obj
+            };
+        }
+
+        private static object ConvertArrayList(ArrayList arrayList, Type type)
+        {
+            Type elementType = type.GetElementType();
+            int length = arrayList.Count;
+            Array convertedArray = Array.CreateInstance(elementType, length);
+            for (int i = 0; i < length; ++i)
+            {
+                convertedArray.SetValue(Convert(arrayList[i], elementType), i);
+            }
+
+            return convertedArray;
+        }
+
+        private static object ConvertHashtable(Hashtable hashtable, Type type)
+        {
+            Type[] genericTypes = type.GetGenericArguments();
+            IDictionary dict =
+                (IDictionary)Activator.CreateInstance(type, new object[] { hashtable.Count });
+            foreach (DictionaryEntry entry in hashtable)
+            {
+                dict[Convert(entry.Key, genericTypes[0])] = Convert(entry.Value, genericTypes[1]);
+            }
+
+            return dict;
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
+++ b/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Spark.Utils
 {
     /// <summary>
     /// Converts one type to another.
+    /// Supports converting <see cref="ArrayList"/> to a typed <see cref="Array"/> and
+    /// <see cref="Hashtable"/> to a typed <see cref="Dictionary{TKey, TValue}"/>.
     /// </summary>
     internal static class TypeConverter
     {
@@ -19,24 +21,24 @@ namespace Microsoft.Spark.Utils
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="obj">The object to convert</param>
         /// <returns>Converted object.</returns>
-        internal static T Convert<T>(object obj) => obj is T t ? t : (T)Convert(obj, typeof(T));
+        internal static T ConvertTo<T>(object obj) => obj is T t ? t : (T)Convert(obj, typeof(T));
 
         private static object Convert(object obj, Type toType)
         {
             if ((obj is ArrayList arrayList) && toType.IsArray)
             {
-                return ConvertArrayList(arrayList, toType);
+                return ConvertToArray(arrayList, toType);
             }
             else if ((obj is Hashtable hashtable) && toType.IsGenericType &&
                 (toType.GetGenericTypeDefinition() == typeof(Dictionary<,>)))
             {
-                return ConvertHashtable(hashtable, toType);
+                return ConvertToDictionary(hashtable, toType);
             }
 
             return obj;
         }
 
-        private static object ConvertArrayList(ArrayList arrayList, Type type)
+        private static object ConvertToArray(ArrayList arrayList, Type type)
         {
             Type elementType = type.GetElementType();
             int length = arrayList.Count;
@@ -49,10 +51,10 @@ namespace Microsoft.Spark.Utils
             return convertedArray;
         }
 
-        private static object ConvertHashtable(Hashtable hashtable, Type type)
+        private static object ConvertToDictionary(Hashtable hashtable, Type type)
         {
             Type[] genericTypes = type.GetGenericArguments();
-            IDictionary dict =
+            var dict =
                 (IDictionary)Activator.CreateInstance(type, new object[] { hashtable.Count });
             foreach (DictionaryEntry entry in hashtable)
             {

--- a/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
+++ b/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
@@ -18,27 +18,22 @@ namespace Microsoft.Spark.Utils
         /// </summary>
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="obj">The object to convert</param>
-        /// <returns></returns>
+        /// <returns>Converted object.</returns>
         internal static T Convert<T>(object obj) => obj is T t ? t : (T)Convert(obj, typeof(T));
 
         private static object Convert(object obj, Type toType)
         {
-            if (obj == null)
+            if ((obj is ArrayList arrayList) && toType.IsArray)
             {
-                return obj;
+                return ConvertArrayList(arrayList, toType);
+            }
+            else if ((obj is Hashtable hashtable) && toType.IsGenericType &&
+                (toType.GetGenericTypeDefinition() == typeof(Dictionary<,>)))
+            {
+                return ConvertHashtable(hashtable, toType);
             }
 
-            Type fromType = obj.GetType();
-            return fromType switch
-            {
-                _ when fromType == toType => obj,
-                _ when (fromType == typeof(ArrayList)) && toType.IsArray =>
-                    ConvertArrayList((ArrayList)obj, toType),
-                _ when (fromType == typeof(Hashtable)) && toType.IsGenericType &&
-                    (toType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) =>
-                    ConvertHashtable((Hashtable)obj, toType),
-                _ => obj
-            };
+            return obj;
         }
 
         private static object ConvertArrayList(ArrayList arrayList, Type type)

--- a/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
+++ b/src/csharp/Microsoft.Spark/Utils/TypeConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Spark.Utils
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <param name="obj">The object to convert</param>
         /// <returns></returns>
-        internal static T Convert<T>(object obj) => (T)Convert(obj, typeof(T));
+        internal static T Convert<T>(object obj) => obj is T t ? t : (T)Convert(obj, typeof(T));
 
         private static object Convert(object obj, Type toType)
         {


### PR DESCRIPTION
Support `ArrayType` and `MapType` usage in `Row`s.

`Pyrolite` unpickles arrays as an `ArrayList`.  An Arraylist is a non-generic collection of objects, which may not be easy to work with.  `Pyrolite` also unpickles dictionaries as `Hashtable`s and this is also a non-generic collection of objects.

This PR allows a user to use `ArrayList` and `Hashtable` or convert them to `Array` and `Dictionary` types.  This conversion, however, will come with a slight performance hit.

ie:
- ArrayList containing strings => string[]
- ArrayList containing ints => int[]
- ArrayList containing Rows => Row[]
- Hashtable containing int keys and int values => Dictionary<int, int>
- etc.



## Benchmark
- Rows: Total number of rows `[100, 1M]`
- BatchSize: Number of rows processed in a batch. `[100]`
- Entries: Number of entries in an ArrayList / Hashtable.  `[100, 1K, 10K]`
  - ArrayList: An ArrayList containing entries 0-99 (100 entries, similar concept for 1000, 10000)
  - ArrayListArrayList:  There are 10 inner ArrayLists and the remaining number of entries is distributed evenly between them (10 entries, 100 entries, 1000 entries for each inner ArrayList).
  - Hashtable: A hashtable containing key value pairs  0 => 0, 1 =>1, ... , 99 => 99 (100 entries, similar concept for 1000, 10000)

#### Convert `ArrayList` and `Hashtable`
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
Intel Xeon CPU E5-2620 v4 2.10GHz, 2 CPU, 32 logical and 16 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT
  Job-CLUMBH : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT

IterationCount=20  LaunchCount=1  WarmupCount=1  

```
|                    Method | BatchSize | Entries |    Rows |             Mean |           Error |          StdDev |
|-------------------------- |---------- |-------- |-------- |-----------------:|----------------:|----------------:|
|          **ConvertArrayList** |       **100** |     **100** |     **100** |         **360.7 μs** |        **17.25 μs** |        **19.86 μs** |
| ConvertArrayListArrayList |       100 |     100 |     100 |         519.3 μs |        45.62 μs |        52.54 μs |
|          ConvertHashtable |       100 |     100 |     100 |         758.8 μs |        33.24 μs |        38.28 μs |
|          **ConvertArrayList** |       **100** |     **100** | **1000000** |   **3,351,057.8 μs** |    **50,874.85 μs** |    **54,435.52 μs** |
| ConvertArrayListArrayList |       100 |     100 | 1000000 |   4,896,935.6 μs |   149,600.75 μs |   160,071.13 μs |
|          ConvertHashtable |       100 |     100 | 1000000 |   7,504,585.4 μs |   134,821.50 μs |   149,853.74 μs |
|          **ConvertArrayList** |       **100** |    **1000** |     **100** |       **3,590.1 μs** |       **262.25 μs** |       **302.01 μs** |
| ConvertArrayListArrayList |       100 |    1000 |     100 |       3,668.2 μs |       251.27 μs |       279.29 μs |
|          ConvertHashtable |       100 |    1000 |     100 |       6,344.8 μs |       377.69 μs |       419.80 μs |
|          **ConvertArrayList** |       **100** |    **1000** | **1000000** |  **33,311,316.2 μs** | **1,115,618.61 μs** | **1,284,748.05 μs** |
| ConvertArrayListArrayList |       100 |    1000 | 1000000 |  34,964,962.9 μs |   526,089.36 μs |   562,909.72 μs |
|          ConvertHashtable |       100 |    1000 | 1000000 |  63,106,269.4 μs | 3,958,972.67 μs | 4,559,158.81 μs |
|          **ConvertArrayList** |       **100** |   **10000** |     **100** |      **33,126.2 μs** |       **746.65 μs** |       **798.90 μs** |
| ConvertArrayListArrayList |       100 |   10000 |     100 |      32,147.6 μs |       360.40 μs |       385.62 μs |
|          ConvertHashtable |       100 |   10000 |     100 |      66,345.6 μs |     1,460.37 μs |     1,434.28 μs |
|          **ConvertArrayList** |       **100** |   **10000** | **1000000** | **317,183,890.6 μs** |   **708,351.07 μs** |   **815,738.15 μs** |
| ConvertArrayListArrayList |       100 |   10000 | 1000000 | 394,499,638.9 μs |   708,773.27 μs |   787,799.61 μs |
|          ConvertHashtable |       100 |   10000 | 1000000 | 825,564,088.2 μs | 3,111,733.97 μs | 3,329,520.49 μs |


#### No conversion
Calling `TypeConverter.Convert<int>(obj)` vs `(int)obj`
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
Intel Xeon CPU E5-2620 v4 2.10GHz, 2 CPU, 32 logical and 16 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT
  Job-UVXNFK : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT

IterationCount=5  LaunchCount=1  WarmupCount=1  

```
|     Method | BatchSize | Entries |     Rows |              Mean |             Error |           StdDev |
|----------- |---------- |-------- |--------- |------------------:|------------------:|-----------------:|
| **ConvertInt** |       **100** |     **100** |      **100** |          **41.06 μs** |          **3.912 μs** |         **1.016 μs** |
|    CastInt |       100 |     100 |      100 |          23.49 μs |          5.606 μs |         0.867 μs |
| **ConvertInt** |       **100** |     **100** |  **1000000** |     **396,551.98 μs** |     **34,748.328 μs** |     **9,024.030 μs** |
|    CastInt |       100 |     100 |  1000000 |     247,219.10 μs |    141,801.483 μs |    36,825.395 μs |
| **ConvertInt** |       **100** |     **100** | **10000000** |   **4,035,195.86 μs** |    **139,054.542 μs** |    **36,112.023 μs** |
|    CastInt |       100 |     100 | 10000000 |   2,352,191.76 μs |    389,791.373 μs |   101,227.582 μs |
| **ConvertInt** |       **100** |    **1000** |      **100** |         **410.80 μs** |         **51.857 μs** |        **13.467 μs** |
|    CastInt |       100 |    1000 |      100 |         228.52 μs |         46.352 μs |        12.038 μs |
| **ConvertInt** |       **100** |    **1000** |  **1000000** |   **4,368,132.10 μs** |  **1,103,291.684 μs** |   **286,521.347 μs** |
|    CastInt |       100 |    1000 |  1000000 |   2,200,200.50 μs |    277,385.442 μs |    42,925.704 μs |
| **ConvertInt** |       **100** |    **1000** | **10000000** |  **41,942,342.14 μs** |  **1,258,969.409 μs** |   **326,950.358 μs** |
|    CastInt |       100 |    1000 | 10000000 |  21,470,283.10 μs |    507,310.372 μs |    78,506.842 μs |
| **ConvertInt** |       **100** |   **10000** |      **100** |       **4,051.71 μs** |        **151.726 μs** |        **39.403 μs** |
|    CastInt |       100 |   10000 |      100 |       2,841.25 μs |         75.513 μs |        19.610 μs |
| **ConvertInt** |       **100** |   **10000** |  **1000000** |  **38,662,062.20 μs** |    **469,219.586 μs** |   **121,854.836 μs** |
|    CastInt |       100 |   10000 |  1000000 |  27,471,575.25 μs |    428,995.149 μs |    66,387.474 μs |
| **ConvertInt** |       **100** |   **10000** | **10000000** | **441,093,311.35 μs** | **31,287,220.793 μs** | **4,841,732.051 μs** |
|    CastInt |       100 |   10000 | 10000000 | 282,128,913.54 μs |  2,246,192.614 μs |   583,329.089 μs |
