### PR TITLE
CallbackClient - add connection back to pool

### DIFF
--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
@@ -25,13 +25,12 @@ class CallbackClient(address: String, port: Int) extends Logging {
 
   private[this] var isShutdown: Boolean = false
 
-  final def send(
-      callbackId: Int,
-      writeBody: DataOutputStream => Unit): Unit =
+  final def send(callbackId: Int, writeBody: DataOutputStream => Unit): Unit =
     getOrCreateConnection() match {
       case Some(connection) =>
         try {
           connection.send(callbackId, writeBody)
+          addConnection(connection)
         } catch {
           case e: Exception =>
             logError(s"Error calling callback [callback id = $callbackId].", e)

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
@@ -25,13 +25,12 @@ class CallbackClient(address: String, port: Int) extends Logging {
 
   private[this] var isShutdown: Boolean = false
 
-  final def send(
-      callbackId: Int,
-      writeBody: DataOutputStream => Unit): Unit =
+  final def send(callbackId: Int, writeBody: DataOutputStream => Unit): Unit =
     getOrCreateConnection() match {
       case Some(connection) =>
         try {
           connection.send(callbackId, writeBody)
+          addConnection(connection)
         } catch {
           case e: Exception =>
             logError(s"Error calling callback [callback id = $callbackId].", e)

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/CallbackClient.scala
@@ -25,13 +25,12 @@ class CallbackClient(address: String, port: Int) extends Logging {
 
   private[this] var isShutdown: Boolean = false
 
-  final def send(
-      callbackId: Int,
-      writeBody: DataOutputStream => Unit): Unit =
+  final def send(callbackId: Int, writeBody: DataOutputStream => Unit): Unit =
     getOrCreateConnection() match {
       case Some(connection) =>
         try {
           connection.send(callbackId, writeBody)
+          addConnection(connection)
         } catch {
           case e: Exception =>
             logError(s"Error calling callback [callback id = $callbackId].", e)


### PR DESCRIPTION
Add connection back to connection pool after successfully calling callback.  Was accidently removed in commit https://github.com/dotnet/spark/pull/549/commits/95fe7dbe0e0e8a47c4803845fab81871bc3dc29e