### PR TITLE
Enable more E2E tests for Delta running under Spark 3.0.

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Microsoft.Spark.E2ETest;
 using Xunit;
 
@@ -22,11 +23,35 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
             };
 
+            Tuple<string, string>[] conf = new[]
+            {
+                new Tuple<string, string>(
+                    "spark.databricks.delta.snapshotPartitions", "2"),
+                new Tuple<string, string>(
+                    "spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
+            };
+
+            Tuple<string, string>[] extraConf= sparkVersion.Major switch
+            {
+                2 => Array.Empty<Tuple<string, string>>(),
+                3 => new[]
+                {
+                    new Tuple<string, string>(
+                        "spark.sql.extensions",
+                        "io.delta.sql.DeltaSparkSessionExtension"),
+                    new Tuple<string, string>(
+                        "spark.sql.catalog.spark_catalog",
+                        "org.apache.spark.sql.delta.catalog.DeltaCatalog"),
+                },
+                _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
+            };
+
+            string confStr =
+                string.Join(" ", conf.Concat(extraConf).Select(c => $"--conf {c.Item1}={c.Item2}"));
+
             Environment.SetEnvironmentVariable(
                 SparkFixture.EnvironmentVariableNames.ExtraSparkSubmitArgs,
-                $"--packages io.delta:{deltaVersion} " +
-                "--conf spark.databricks.delta.snapshotPartitions=2 " +
-                "--conf spark.sql.sources.parallelPartitionDiscovery.parallelism=5");
+                $"--packages io.delta:{deltaVersion} {confStr}");
             SparkFixture = new SparkFixture();
         }
     }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -23,24 +23,20 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
             };
 
-            Tuple<string, string>[] conf = new[]
+            (string, string)[] conf = new[]
             {
-                new Tuple<string, string>(
-                    "spark.databricks.delta.snapshotPartitions", "2"),
-                new Tuple<string, string>(
-                    "spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
+                ("spark.databricks.delta.snapshotPartitions", "2"),
+                ("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
             };
 
-            Tuple<string, string>[] extraConf= sparkVersion.Major switch
+            (string, string)[] extraConf = sparkVersion.Major switch
             {
-                2 => Array.Empty<Tuple<string, string>>(),
+                2 => Array.Empty<(string, string)>(),
                 3 => new[]
                 {
-                    new Tuple<string, string>(
-                        "spark.sql.extensions",
+                    ("spark.sql.extensions",
                         "io.delta.sql.DeltaSparkSessionExtension"),
-                    new Tuple<string, string>(
-                        "spark.sql.catalog.spark_catalog",
+                    ("spark.sql.catalog.spark_catalog",
                         "org.apache.spark.sql.delta.catalog.DeltaCatalog"),
                 },
                 _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 2 => Array.Empty<(string, string)>(),
                 3 => new[]
                 {
-                    ("spark.sql.extensions",
-                        "io.delta.sql.DeltaSparkSessionExtension"),
+                    ("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"),
                     ("spark.sql.catalog.spark_catalog",
                         "org.apache.spark.sql.delta.catalog.DeltaCatalog"),
                 },

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         /// Run the end-to-end scenario from the Delta Quickstart tutorial.
         /// </summary>
         /// <see cref="https://docs.delta.io/latest/quick-start.html"/>
-        [SkipIfSparkVersionIsNotInRange(Versions.V2_4_2, Versions.V3_0_0)]
+        [SkipIfSparkVersionIsLessThan(Versions.V2_4_2)]
         public void TestTutorialScenario()
         {
             using var tempDirectory = new TemporaryDirectory();
@@ -223,7 +223,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
         /// <summary>
         /// Test that methods return the expected signature.
         /// </summary>
-        [SkipIfSparkVersionIsNotInRange(Versions.V2_4_2, Versions.V3_0_0)]
+        [SkipIfSparkVersionIsLessThan(Versions.V2_4_2)]
         public void TestSignatures()
         {
             using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
This PR proposes to add coverage for Delta E2E tests running under Spark 3.0, by setting few options mentioned in #657:
```
   .Option("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
   .Option("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
```