### PR TITLE
Microsoft.Spark.Extensions.DotNet.Interactive - conform to Microsoft.Dotnet.Interactive 1.0.0-beta.20480.3 API changes.

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.20319.1" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.20480.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/PackageResolverTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/PackageResolverTests.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive.Utility;
+using Microsoft.DotNet.Interactive;
 using Microsoft.Spark.UnitTest.TestUtils;
 using Microsoft.Spark.Utils;
 using Moq;
@@ -33,12 +33,12 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest
             {
             }
             
-            var assemblyPaths = new List<FileInfo>
+            var assemblyPaths = new string[]
             {
-                new FileInfo(Path.Combine(packageFrameworkPath, "1.dll")),
-                new FileInfo(Path.Combine(packageFrameworkPath, "2.dll"))
+                Path.Combine(packageFrameworkPath, "1.dll"),
+                Path.Combine(packageFrameworkPath, "2.dll")
             };
-            var probingPaths = new List<DirectoryInfo> { new DirectoryInfo(packageRootPath) };
+            var probingPaths = new string[] { packageRootPath };
 
             var mockSupportNugetWrapper = new Mock<SupportNugetWrapper>();
             mockSupportNugetWrapper
@@ -49,7 +49,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest
                         packageName,
                         packageVersion,
                         assemblyPaths,
-                        new DirectoryInfo(packageRootPath),
+                        packageRootPath,
                         probingPaths) 
                 });
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
@@ -34,16 +34,16 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
         /// </summary>
         /// <param name="kernel">The kernel calling this method.</param>
         /// <returns><see cref="Task.CompletedTask"/> when extension is loaded.</returns>
-        public Task OnLoadAsync(IKernel kernel)
+        public Task OnLoadAsync(Kernel kernel)
         {
-            if (kernel is CompositeKernel kernelBase)
+            if (kernel is CompositeKernel compositeKernel)
             {
                 Environment.SetEnvironmentVariable(Constants.RunningREPLEnvVar, "true");
 
                 DirectoryInfo tempDir = CreateTempDirectory();
-                kernelBase.RegisterForDisposal(new DisposableDirectory(tempDir));
+                compositeKernel.RegisterForDisposal(new DisposableDirectory(tempDir));
 
-                kernelBase.AddMiddleware(async (command, context, next) =>
+                compositeKernel.AddMiddleware(async (command, context, next) =>
                 {
                     await next(command, context);
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/Microsoft.Spark.Extensions.DotNet.Interactive.csproj
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/Microsoft.Spark.Extensions.DotNet.Interactive.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.20319.1">
+    <PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.20480.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/PackageResolver.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/PackageResolver.cs
@@ -6,7 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using Microsoft.DotNet.Interactive.Utility;
+using Microsoft.DotNet.Interactive;
 using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Extensions.DotNet.Interactive
@@ -47,9 +47,9 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
             {
                 ResolvedPackageReference resolvedPackage = package.ResolvedPackage;
 
-                foreach (FileInfo asmPath in resolvedPackage.AssemblyPaths)
+                foreach (string asmPath in resolvedPackage.AssemblyPaths)
                 {
-                    // asmPath.FullName
+                    // asmPath
                     //   /path/to/packages/package.name/package.version/lib/framework/1.dll
                     // resolvedPackage.PackageRoot
                     //   /path/to/packages/package.name/package.version/
@@ -57,13 +57,13 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                     //   package.name/package.version/lib/framework/1.dll
                     assemblyProbingPaths.Add(
                         GetPathRelativeToPackages(
-                            asmPath.FullName,
-                            resolvedPackage.PackageRoot));
+                            asmPath,
+                            package.PackageRootDirectory));
                 }
 
-                foreach (DirectoryInfo probePath in resolvedPackage.ProbingPaths)
+                foreach (string probePath in resolvedPackage.ProbingPaths)
                 {
-                    // probePath.FullName
+                    // probePath
                     //   /path/to/packages/package.name/package.version/
                     // resolvedPackage.PackageRoot
                     //   /path/to/packages/package.name/package.version/
@@ -71,8 +71,8 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                     //   package.name/package.version
                     nativeProbingPaths.Add(
                         GetPathRelativeToPackages(
-                            probePath.FullName,
-                            resolvedPackage.PackageRoot));
+                            probePath,
+                            package.PackageRootDirectory));
                 }
 
                 nugetMetadata.Add(
@@ -115,8 +115,9 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                 _supportNugetWrapper.ResolvedPackageReferences;
             foreach (ResolvedPackageReference package in packages)
             {
+                var packageRootDirectory = new DirectoryInfo(package.PackageRoot);
                 IEnumerable<FileInfo> files =
-                    package.PackageRoot.EnumerateFiles("*.nupkg", SearchOption.AllDirectories);
+                    packageRootDirectory.EnumerateFiles("*.nupkg", SearchOption.AllDirectories);
 
                 foreach (FileInfo file in files)
                 {
@@ -125,6 +126,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                         yield return new ResolvedNuGetPackage
                         {
                             ResolvedPackage = package,
+                            PackageRootDirectory = packageRootDirectory,
                             NuGetFile = file
                         };
                     }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/ResolvedNugetPackage.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/ResolvedNugetPackage.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using Microsoft.DotNet.Interactive.Utility;
+using Microsoft.DotNet.Interactive;
 
 namespace Microsoft.Spark.Extensions.DotNet.Interactive
 {
     internal class ResolvedNuGetPackage
     {
         public ResolvedPackageReference ResolvedPackage { get; set; }
+        public DirectoryInfo PackageRootDirectory { get; set; }
         public FileInfo NuGetFile { get; set; }
     }
 }


### PR DESCRIPTION
Update the `Microsoft.Spark.Extensions.DotNet.Interactive` to be compatible with the updated APIs in `Microsoft.Dotnet.Interactive` `1.0.0-beta.20480.3`