### PR TITLE
Fix DaemonWorkerTests.TestsDaemonWorkerTaskRunners and CallbackTests.TestCallbackServer

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/CallbackTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/CallbackTests.cs
@@ -61,11 +61,13 @@ namespace Microsoft.Spark.UnitTest
             using ISocketWrapper callbackSocket = SocketFactory.CreateSocket();
             callbackServer.Run(callbackSocket);
 
-            int connectionNumber = 10;
+            int connectionNumber = 2;
+            var clientSockets = new ISocketWrapper[connectionNumber];
             for (int i = 0; i < connectionNumber; ++i)
             {
                 var ipEndpoint = (IPEndPoint)callbackSocket.LocalEndPoint;
                 ISocketWrapper clientSocket = SocketFactory.CreateSocket();
+                clientSockets[i] = clientSocket;
                 clientSocket.Connect(ipEndpoint.Address, ipEndpoint.Port);
 
                 WriteAndReadTestData(clientSocket, callbackHandler, i, new CancellationToken());

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
@@ -14,12 +14,13 @@ namespace Microsoft.Spark.Worker.UnitTest
     [Collection("Spark Unit Tests")]
     public class DaemonWorkerTests : IDisposable
     {
+        private const string ReuseWorkerEnvVariable = "SPARK_REUSE_WORKER";
         private readonly string _reuseWorker;
 
         public DaemonWorkerTests()
         {
-            _reuseWorker = Environment.GetEnvironmentVariable("SPARK_REUSE_WORKER");
-            Environment.SetEnvironmentVariable("SPARK_REUSE_WORKER", "1");
+            _reuseWorker = Environment.GetEnvironmentVariable(ReuseWorkerEnvVariable);
+            Environment.SetEnvironmentVariable(ReuseWorkerEnvVariable, "1");
         }
 
         [Theory]
@@ -75,7 +76,7 @@ namespace Microsoft.Spark.Worker.UnitTest
 
         public void Dispose()
         {
-            Environment.SetEnvironmentVariable("SPARK_REUSE_WORKER", _reuseWorker);
+            Environment.SetEnvironmentVariable(ReuseWorkerEnvVariable, _reuseWorker);
         }
     }
 }


### PR DESCRIPTION
Keep references to the client sockets during test execution to prevent garbage collection of the client sockets.

Fixes #685 