### PR TITLE
JvmBridge/Netty blocking connection deadlock mitigation

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Streaming/DataStreamWriterTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Streaming/DataStreamWriterTests.cs
@@ -68,9 +68,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Assert.IsType<DataStreamWriter>(dsw.Trigger(Trigger.Once()));
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped.
-        [Fact(Skip = "Skipping flaky test. Root cause is being investigated.")]
-#pragma warning restore xUnit1004
+        [SkipIfSparkVersionIsLessThan(Versions.V2_4_0)]
         public void TestForeachBatch()
         {
             // Temporary folder to put our test stream input.

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -54,17 +54,17 @@ namespace Microsoft.Spark.Interop.Ipc
             _jvmThreadPoolGC = new JvmThreadPoolGC(
                 _logger, this, SparkEnvironment.ConfigurationService.JvmThreadGCInterval);
 
-            int backendThreads = SparkEnvironment.ConfigurationService.GetBackendThreads();
-            int maxSockets = backendThreads;
-            if (backendThreads >= (2 * SocketBufferThreshold))
+            int numBackendThreads = SparkEnvironment.ConfigurationService.GetNumBackendThreads();
+            int maxNumSockets = numBackendThreads;
+            if (numBackendThreads >= (2 * SocketBufferThreshold))
             {
                 // Set the max number of concurrent sockets to be less than the number of
                 // JVM backend threads to allow some buffer.
-                maxSockets -= SocketBufferThreshold;
+                maxNumSockets -= SocketBufferThreshold;
             }
-            _logger.LogInfo($"JVM backend threads is {backendThreads}. JvMBridge max " +
-                $"concurrent sockets is set to {maxSockets}.");
-            _socketSemaphore = new SemaphoreSlim(maxSockets, maxSockets);
+            _logger.LogInfo($"The number of JVM backend thread is set to {numBackendThreads}. " +
+                $"The max number of concurrent sockets in JvmBridge is set to {maxNumSockets}.");
+            _socketSemaphore = new SemaphoreSlim(maxNumSockets, maxNumSockets);
         }
 
         private ISocketWrapper GetConnection()

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Spark.Interop.Ipc
         {
             // Limit the number of connections to the JVM backend. Netty is configured
             // to use a set number of threads to process incoming connections. Each
-            // new connection is delegated to these threads and in a round robin fashion.
-            // A deadlock can occur if a new connection is scheduled on a blocking thread.
+            // new connection is delegated to these threads in a round robin fashion.
+            // A deadlock can occur if a new connection is scheduled on a blocked thread.
             _socketSemaphore.Wait();
             if (!_sockets.TryDequeue(out ISocketWrapper socket))
             {

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -247,8 +247,8 @@ namespace Microsoft.Spark.Interop.Ipc
                 _logger.LogException(e);
 
                 // In rare cases we may hit the Netty connection thread deadlock.
-                // Say if max backend threads is 10. If we are currently using 10
-                // connections (0 in the _sockets queue) and when we hit this exception,
+                // If max backend threads is 10 and we are currently using 10 active
+                // connections (0 in the _sockets queue). When we hit this exception,
                 // the socket?.Dispose() will not requeue this socket and we will release
                 // the semaphore. Then in the next thread (assuming the other 9 connections
                 // are still busy), a new connection will be made to the backend and this

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Spark.Interop.Ipc
 
                 if (e.InnerException is JvmException)
                 {
-                    // DotnetHandler caught JVM exception and passed back to dotnet.
+                    // DotnetBackendHandler caught JVM exception and passed back to dotnet.
                     // We can reuse this connection.
                     _sockets.Enqueue(socket);
                 }

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Spark.Services
         private const string DotnetBackendPortEnvVarName = "DOTNETBACKEND_PORT";
         private const int DotnetBackendDebugPort = 5567;
 
+        private const string DotnetBackendThreadsEnvVarName = "DOTNET_SPARK_BACKEND_THREADS";
+
         private static readonly string s_procBaseFileName = "Microsoft.Spark.Worker";
         private static readonly string s_procFileName =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
@@ -61,6 +63,21 @@ namespace Microsoft.Spark.Services
             _logger.LogInfo($"Using port {portNumber} for connection.");
 
             return portNumber;
+        }
+
+        /// <summary>
+        /// Returns the max number of threads for socket communication between JVM and CLR.
+        /// </summary>
+        public int GetBackendThreads()
+        {
+            if (!int.TryParse(
+                Environment.GetEnvironmentVariable(DotnetBackendThreadsEnvVarName),
+                out int numThreads))
+            {
+                numThreads = 10;
+            }
+
+            return numThreads;
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Spark.Services
         private const string DotnetBackendPortEnvVarName = "DOTNETBACKEND_PORT";
         private const int DotnetBackendDebugPort = 5567;
 
-        private const string DotnetBackendThreadsEnvVarName = "DOTNET_SPARK_BACKEND_THREADS";
-        private const int DotnetBackendThreadsDefault = 10;
+        private const string DotnetNumBackendThreadsEnvVarName = "DOTNET_SPARK_NUM_BACKEND_THREADS";
+        private const int DotnetNumBackendThreadsDefault = 10;
 
         private static readonly string s_procBaseFileName = "Microsoft.Spark.Worker";
         private static readonly string s_procFileName =
@@ -69,13 +69,13 @@ namespace Microsoft.Spark.Services
         /// <summary>
         /// Returns the max number of threads for socket communication between JVM and CLR.
         /// </summary>
-        public int GetBackendThreads()
+        public int GetNumBackendThreads()
         {
             if (!int.TryParse(
-                Environment.GetEnvironmentVariable(DotnetBackendThreadsEnvVarName),
+                Environment.GetEnvironmentVariable(DotnetNumBackendThreadsEnvVarName),
                 out int numThreads))
             {
-                numThreads = DotnetBackendThreadsDefault;
+                numThreads = DotnetNumBackendThreadsDefault;
             }
 
             return numThreads;

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Spark.Services
         private const int DotnetBackendDebugPort = 5567;
 
         private const string DotnetBackendThreadsEnvVarName = "DOTNET_SPARK_BACKEND_THREADS";
+        private const int DotnetBackendThreadsDefault = 10;
 
         private static readonly string s_procBaseFileName = "Microsoft.Spark.Worker";
         private static readonly string s_procFileName =
@@ -74,7 +75,7 @@ namespace Microsoft.Spark.Services
                 Environment.GetEnvironmentVariable(DotnetBackendThreadsEnvVarName),
                 out int numThreads))
             {
-                numThreads = 10;
+                numThreads = DotnetBackendThreadsDefault;
             }
 
             return numThreads;

--- a/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Spark.Services
         /// <summary>
         /// Returns the max number of threads for socket communication between JVM and CLR.
         /// </summary>
-        int GetBackendThreads();
+        int GetNumBackendThreads();
 
         /// <summary>
         /// The full path to the .NET worker executable.

--- a/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Spark.Services
         int GetBackendPortNumber();
 
         /// <summary>
+        /// Returns the max number of threads for socket communication between JVM and CLR.
+        /// </summary>
+        int GetBackendThreads();
+
+        /// <summary>
         /// The full path to the .NET worker executable.
         /// </summary>
         string GetWorkerExePath();

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -33,7 +33,9 @@ class DotnetBackend extends Logging {
 
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
+    val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
+    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,6 +17,8 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.Dotnet.DOTNET_NUM_BACKEND_THREADS
+import org.apache.spark.{SparkConf, SparkEnv}
 
 /**
  * Netty server that invokes JVM calls based upon receiving messages from .NET.
@@ -30,8 +32,8 @@ class DotnetBackend extends Logging {
   private[this] var bossGroup: EventLoopGroup = _
 
   def init(portNumber: Int): Int = {
-    // need at least 3 threads, use 10 here for safety
-    bossGroup = new NioEventLoopGroup(10)
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -34,7 +34,7 @@ class DotnetBackend extends Logging {
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
     val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
-    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    logInfo(s"The number of DotnetBackend threads is set to $numBackendThreads.")
     bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 

--- a/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
+++ b/src/scala/microsoft-spark-2.3.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
@@ -1,0 +1,12 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.internal.config
+
+private[spark] object Dotnet {
+  val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
+    .createWithDefault(10)
+}

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -33,7 +33,9 @@ class DotnetBackend extends Logging {
 
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
+    val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
+    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,6 +17,8 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.Dotnet.DOTNET_NUM_BACKEND_THREADS
+import org.apache.spark.{SparkConf, SparkEnv}
 
 /**
  * Netty server that invokes JVM calls based upon receiving messages from .NET.
@@ -30,8 +32,8 @@ class DotnetBackend extends Logging {
   private[this] var bossGroup: EventLoopGroup = _
 
   def init(portNumber: Int): Int = {
-    // need at least 3 threads, use 10 here for safety
-    bossGroup = new NioEventLoopGroup(10)
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -34,7 +34,7 @@ class DotnetBackend extends Logging {
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
     val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
-    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    logInfo(s"The number of DotnetBackend threads is set to $numBackendThreads.")
     bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 

--- a/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
+++ b/src/scala/microsoft-spark-2.4.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
@@ -1,0 +1,12 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.internal.config
+
+private[spark] object Dotnet {
+  val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
+    .createWithDefault(10)
+}

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -33,7 +33,9 @@ class DotnetBackend extends Logging {
 
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
+    val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
+    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -34,7 +34,7 @@ class DotnetBackend extends Logging {
   def init(portNumber: Int): Int = {
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
     val numBackendThreads = conf.get(DOTNET_NUM_BACKEND_THREADS)
-    logInfo(s"Backend threads set to ${DOTNET_NUM_BACKEND_THREADS.key}=$numBackendThreads")
+    logInfo(s"The number of DotnetBackend threads is set to $numBackendThreads.")
     bossGroup = new NioEventLoopGroup(numBackendThreads)
     val workerGroup = bossGroup
 

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,6 +17,8 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.Dotnet._
+import org.apache.spark.{SparkConf, SparkEnv}
 
 /**
  * Netty server that invokes JVM calls based upon receiving messages from .NET.
@@ -30,8 +32,8 @@ class DotnetBackend extends Logging {
   private[this] var bossGroup: EventLoopGroup = _
 
   def init(portNumber: Int): Int = {
-    // need at least 3 threads, use 10 here for safety
-    bossGroup = new NioEventLoopGroup(10)
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    bossGroup = new NioEventLoopGroup(conf.get(DOTNET_NUM_BACKEND_THREADS))
     val workerGroup = bossGroup
 
     bootstrap = new ServerBootstrap()

--- a/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
+++ b/src/scala/microsoft-spark-3.0.x/src/main/scala/org/apache/spark/internal/config/Dotnet.scala
@@ -1,0 +1,12 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.internal.config
+
+private[spark] object Dotnet {
+  val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
+    .createWithDefault(10)
+}


### PR DESCRIPTION
This PR attempts to limit the number of connections to the JVM backend. Netty is configured to use a set number of threads to process incoming connections. Each new connection is delegated to these threads in a round robin fashion. A deadlock can occur if a new connection is scheduled on a blocked thread.


Fixes #701
