### PR TITLE
[Build] Separate publish stage from signing stage.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ stages:
         condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
 
       - task: PowerShell@2
-        displayName: Sign artifacts and Package Microsoft.Spark.Worker
+        displayName: Sign artifacts
         inputs:
           filePath: eng\common\build.ps1
           arguments: -restore -sign
@@ -131,6 +131,8 @@ stages:
           pathtoPublish: '$(ArtifactPath)'
           artifactName:  Microsoft.Spark.Binaries
 
+  # The "Publish" stage is separated out from the "Sign" stage because we need to install powershell module
+  # to zip files correctly for macOS; installing the module is not allowed in NetCoreInternal-Pool.
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - job: Publish
       dependsOn:
@@ -143,14 +145,15 @@ stages:
           _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
       steps:
+      # The following module needs to be installed to zip files correctly for macOS.
+      - powershell: Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.5
+      
       - task: DownloadBuildArtifacts@0
-        displayName: Download Build Artifacts
+        displayName: Download Signed Artifacts
         inputs:
           artifactName: Microsoft.Spark.Binaries
           downloadPath: $(Build.ArtifactStagingDirectory)
 
-      - powershell: Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.5
-      
       - task: PowerShell@2
         displayName: Package Microsoft.Spark.Worker
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,8 @@ stages:
       steps:
       # The following module needs to be installed to zip files correctly for macOS.
       - powershell: Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.5
-      
+        displayName: Install Microsoft.PowerShell.Archive
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Signed Artifacts
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,10 +85,10 @@ stages:
         artifactName:  Microsoft.Spark.Binaries
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - job: SignPublish
+    - job: Sign
       dependsOn:
         - Build
-      displayName: Sign and Publish Artifacts
+      displayName: Sign Artifacts
       pool:
         name: NetCoreInternal-Pool
         queue: buildpool.windows.10.amd64.vs2017
@@ -113,17 +113,52 @@ stages:
         env:
           TeamName: $(_TeamName)
         condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
-    
+
       - task: PowerShell@2
         displayName: Sign artifacts and Package Microsoft.Spark.Worker
         inputs:
           filePath: eng\common\build.ps1
-          arguments: -restore -sign -publish
+          arguments: -restore -sign
                      -c $(buildConfiguration)
                      -ci
                      $(_OfficialBuildIdArgs)
                      /p:DotNetSignType=$(_SignType)
                      /p:SparkPackagesDir=$(ArtifactPath)\BuildArtifacts\artifacts\packages
+                     /p:SparkWorkerPublishDir=$(ArtifactPath)\Microsoft.Spark.Worker
+
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(ArtifactPath)'
+          artifactName:  Microsoft.Spark.Binaries
+
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - job: Publish
+      dependsOn:
+        - Sign
+      displayName: Publish Artifacts
+      pool: Hosted VS2017
+
+      variables:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+
+      steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Build Artifacts
+        inputs:
+          artifactName: Microsoft.Spark.Binaries
+          downloadPath: $(Build.ArtifactStagingDirectory)
+
+      - powershell: Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force -AllowClobber -Verbose -MinimumVersion 1.2.5
+      
+      - task: PowerShell@2
+        displayName: Package Microsoft.Spark.Worker
+        inputs:
+          filePath: eng\common\build.ps1
+          arguments: -restore -publish
+                     -c $(buildConfiguration)
+                     -ci
+                     $(_OfficialBuildIdArgs)
                      /p:SparkWorkerPublishDir=$(ArtifactPath)\Microsoft.Spark.Worker
                      /p:SparkWorkerPackageOutputDir=$(ArtifactPath)
 


### PR DESCRIPTION
This fixes #672 

To zip files correctly for macOS, we need to install PowerShell module `Microsoft.PowerShell.Archive` > `1.2.3.0`. Currently zipping happens in the signing stage, which runs in `NetCoreInternal-Pool`. However, installing the module is not allowed in `NetCoreInternal-Pool` and we need to request to `dotnet/core-eng` to get it installed. Since the next release date is coming up soon, we will introduce a new "publish" stage, which runs on a pool that allows installing PowerShell module.