### PR TITLE
Split E2E test build pipeline

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -10,9 +10,9 @@ steps:
 - ${{ each version in parameters.versions }}:
   - task: BatchScript@1
     displayName: 'Download Spark Distro ${{ version }}'
-      inputs:
-        filename: script\download-spark-distros.cmd
-        arguments: $(Build.BinariesDirectory) ${{ version }}
+    inputs:
+      filename: script\download-spark-distros.cmd
+      arguments: $(Build.BinariesDirectory) ${{ version }}
 
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark ${{ version }}'

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -8,6 +8,12 @@ parameters:
 
 steps:
 - ${{ each version in parameters.versions }}:
+  - task: BatchScript@1
+    displayName: 'Download Spark Distro ${{ version }}'
+      inputs:
+        filename: script\download-spark-distros.cmd
+        arguments: $(Build.BinariesDirectory) ${{ version }}
+
   - task: DotNetCoreCLI@2
     displayName: 'E2E tests for Spark ${{ version }}'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ stages:
           pathtoPublish: '$(ArtifactPath)'
           artifactName:  Microsoft.Spark.Binaries
 
-- stage: Test
+- stage: E2E Tests for Spark 2.3
   displayName: E2E Tests for Spark 2.3
   dependsOn: Build
   jobs:
@@ -213,7 +213,7 @@ stages:
         - '2.3.3'
         - '2.3.4'
 
-- stage: Test
+- stage: E2E Tests for Spark 2.4
   displayName: E2E Tests for Spark 2.4
   dependsOn: Build
   jobs:
@@ -257,7 +257,7 @@ stages:
         - '2.4.6'
         - '2.4.7'
 
-- stage: Test
+- stage: E2E Tests for Spark 3.0
   displayName: E2E Tests for Spark 3.0
   dependsOn: Build
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ stages:
           pathtoPublish: '$(ArtifactPath)'
           artifactName:  Microsoft.Spark.Binaries
 
-- stage: E2E Tests for Spark 2.3
+- stage: E2E_Tests_2_3
   displayName: E2E Tests for Spark 2.3
   dependsOn: Build
   jobs:
@@ -213,7 +213,7 @@ stages:
         - '2.3.3'
         - '2.3.4'
 
-- stage: E2E Tests for Spark 2.4
+- stage: E2E_Tests_2_4
   displayName: E2E Tests for Spark 2.4
   dependsOn: Build
   jobs:
@@ -257,7 +257,7 @@ stages:
         - '2.4.6'
         - '2.4.7'
 
-- stage: E2E Tests for Spark 3.0
+- stage: E2E_Tests_3_0
   displayName: E2E Tests for Spark 3.0
   dependsOn: Build
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
           artifactName:  Microsoft.Spark.Binaries
 
 - stage: Test
-  displayName: E2E Tests
+  displayName: E2E Tests for Spark 2.3
   dependsOn: Build
   jobs:
   - job: Run
@@ -199,9 +199,9 @@ stages:
         targetFolder: $(Build.SourcesDirectory)/src/scala
 
     - task: BatchScript@1
-      displayName: Download Spark Distros & Winutils.exe
+      displayName: Download Winutils.exe
       inputs:
-        filename: script\download-spark-distros.cmd
+        filename: script\download-hadoop-utils.cmd
         arguments: $(Build.BinariesDirectory)
 
     - template: azure-pipelines-e2e-tests-template.yml
@@ -212,6 +212,43 @@ stages:
         - '2.3.2'
         - '2.3.3'
         - '2.3.4'
+
+- stage: Test
+  displayName: E2E Tests for Spark 2.4
+  dependsOn: Build
+  jobs:
+  - job: Run
+    pool: Hosted VS2017
+
+    variables:
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
+      DOTNET_WORKER_DIR: $(CurrentDotnetWorkerDir)
+
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: Microsoft.Spark.Binaries
+        downloadPath: $(Build.ArtifactStagingDirectory)
+
+    - task: CopyFiles@2
+      displayName: Copy jars
+      inputs:
+        sourceFolder: $(ArtifactPath)/Jars
+        contents: '**/*.jar'
+        targetFolder: $(Build.SourcesDirectory)/src/scala
+
+    - task: BatchScript@1
+      displayName: Download Winutils.exe
+      inputs:
+        filename: script\download-hadoop-utils.cmd
+        arguments: $(Build.BinariesDirectory)
+
+    - template: azure-pipelines-e2e-tests-template.yml
+      parameters:
+        versions:
         - '2.4.0'
         - '2.4.1'
         - '2.4.3'
@@ -219,5 +256,42 @@ stages:
         - '2.4.5'
         - '2.4.6'
         - '2.4.7'
+
+- stage: Test
+  displayName: E2E Tests for Spark 3.0
+  dependsOn: Build
+  jobs:
+  - job: Run
+    pool: Hosted VS2017
+
+    variables:
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      HADOOP_HOME: $(Build.BinariesDirectory)\hadoop
+      DOTNET_WORKER_DIR: $(CurrentDotnetWorkerDir)
+
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: Microsoft.Spark.Binaries
+        downloadPath: $(Build.ArtifactStagingDirectory)
+
+    - task: CopyFiles@2
+      displayName: Copy jars
+      inputs:
+        sourceFolder: $(ArtifactPath)/Jars
+        contents: '**/*.jar'
+        targetFolder: $(Build.SourcesDirectory)/src/scala
+
+    - task: BatchScript@1
+      displayName: Download Winutils.exe
+      inputs:
+        filename: script\download-hadoop-utils.cmd
+        arguments: $(Build.BinariesDirectory)
+
+    - template: azure-pipelines-e2e-tests-template.yml
+      parameters:
+        versions:
         - '3.0.0'
         - '3.0.1'

--- a/script/download-hadoop-utils.cmd
+++ b/script/download-hadoop-utils.cmd
@@ -1,0 +1,14 @@
+@echo off
+
+setlocal
+
+set OutputDir=%1
+cd %OutputDir%
+
+echo "Download Hadoop utils for Windows."
+curl -k -L -o hadoop.zip https://github.com/steveloughran/winutils/releases/download/tag_2017-08-29-hadoop-2.8.1-native/hadoop-2.8.1.zip
+unzip hadoop.zip
+mkdir -p hadoop\bin
+cp hadoop-2.8.1\winutils.exe hadoop\bin
+
+endlocal

--- a/script/download-spark-distros.cmd
+++ b/script/download-spark-distros.cmd
@@ -3,29 +3,12 @@
 setlocal
 
 set OutputDir=%1
-cd %OutputDir%
+set SparkVersion=%2
 
-echo "Download Hadoop binaries for Windows."
-curl -k -L -o hadoop.zip https://github.com/steveloughran/winutils/releases/download/tag_2017-08-29-hadoop-2.8.1-native/hadoop-2.8.1.zip
-unzip hadoop.zip
-mkdir -p hadoop\bin
-cp hadoop-2.8.1\winutils.exe hadoop\bin
+cd %OutputDir%
 
 echo "Downloading Spark distros."
 
-curl -k -L -o spark-2.3.0.tgz https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz && tar xzvf spark-2.3.0.tgz
-curl -k -L -o spark-2.3.1.tgz https://archive.apache.org/dist/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && tar xzvf spark-2.3.1.tgz
-curl -k -L -o spark-2.3.2.tgz https://archive.apache.org/dist/spark/spark-2.3.2/spark-2.3.2-bin-hadoop2.7.tgz && tar xzvf spark-2.3.2.tgz
-curl -k -L -o spark-2.3.3.tgz https://archive.apache.org/dist/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz && tar xzvf spark-2.3.3.tgz
-curl -k -L -o spark-2.3.4.tgz https://archive.apache.org/dist/spark/spark-2.3.4/spark-2.3.4-bin-hadoop2.7.tgz && tar xzvf spark-2.3.4.tgz
-curl -k -L -o spark-2.4.0.tgz https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && tar xzvf spark-2.4.0.tgz
-curl -k -L -o spark-2.4.1.tgz https://archive.apache.org/dist/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz && tar xzvf spark-2.4.1.tgz
-curl -k -L -o spark-2.4.3.tgz https://archive.apache.org/dist/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz && tar xzvf spark-2.4.3.tgz
-curl -k -L -o spark-2.4.4.tgz https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && tar xzvf spark-2.4.4.tgz
-curl -k -L -o spark-2.4.5.tgz https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz && tar xzvf spark-2.4.5.tgz
-curl -k -L -o spark-2.4.6.tgz https://archive.apache.org/dist/spark/spark-2.4.6/spark-2.4.6-bin-hadoop2.7.tgz && tar xzvf spark-2.4.6.tgz
-curl -k -L -o spark-2.4.7.tgz https://archive.apache.org/dist/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz && tar xzvf spark-2.4.7.tgz
-curl -k -L -o spark-3.0.0.tgz https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz && tar xzvf spark-3.0.0.tgz
-curl -k -L -o spark-3.0.1.tgz https://archive.apache.org/dist/spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz && tar xzvf spark-3.0.1.tgz
+curl -k -L -o spark-%SparkVersion%.tgz https://archive.apache.org/dist/spark/spark-%SparkVersion%/spark-%SparkVersion%-bin-hadoop2.7.tgz && tar xzvf spark-%SparkVersion%.tgz
 
 endlocal


### PR DESCRIPTION
I see occasional timeouts in build due to E2E tests taking longer than one hour if they are run on a SKU that's slow.

This PR splits E2E tests based on Spark versions (2.3, 2.4, 3.0, for example).

I didn't attempt to create a template for this because we cannot reuse it when compatibility tests are brought back. We need to revisit creating a template with compatibility tests in mind.