### PR TITLE
Fix issues where extension e2e tests are not being run

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -18,7 +18,7 @@ steps:
     displayName: 'E2E tests for Spark ${{ version }}'
     inputs:
       command: test
-      projects: '**/Microsoft.Spark.E2ETest/*.csproj'
+      projects: '**/Microsoft.Spark*.E2ETest/*.csproj'
       arguments: '--configuration $(buildConfiguration) ${{ parameters.testOptions }}'
     env:
       SPARK_HOME: $(Build.BinariesDirectory)\spark-${{ version }}-bin-hadoop2.7


### PR DESCRIPTION
#697 introduced a bug where e2e extension tests are not being run.

This PR addresses the issue to enable e2e tests for extensions.