### PR TITLE
Shutdown the JVM thread pool to fix the hanging issue while exiting.

### DIFF
--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -84,6 +84,9 @@ class DotnetBackend extends Logging {
 
     // Send close to .NET callback server.
     DotnetBackend.shutdownCallbackClient()
+
+    // Shutdown the thread pool whose executors could still be running.
+    ThreadPool.shutdown()
   }
 }
 

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
@@ -53,6 +53,14 @@ object ThreadPool {
   }
 
   /**
+   * Shutdown any running ExecutorServices.
+   */
+  def shutdown(): Unit = synchronized {
+    executors.foreach(_._2.shutdown())
+    executors.clear()
+  }
+
+  /**
    * Get the executor if it exists, otherwise create a new one.
    *
    * @param id Integer id of the thread.

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -16,7 +16,7 @@ import java.util.concurrent.{Semaphore, TimeUnit}
 import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark
-import org.apache.spark.api.dotnet.{DotnetBackend, ThreadPool}
+import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
@@ -143,11 +143,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
-        // Shutdown the thread pool whose executors could still be running,
-        // blocking the JVM process to exit. Since .NET process has already exited,
-        // the thread pool will never be cleaned up by the .NET process.
-        ThreadPool.shutdown()
 
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -196,8 +196,7 @@ object DotnetRunner extends Logging {
         case Some(path) => path.toAbsolutePath.toString
         case None =>
           throw new IllegalArgumentException(
-            s"Failed to find $dotnetExecutable under" +
-              s" ${dir.getAbsolutePath}")
+            s"Failed to find $dotnetExecutable under ${dir.getAbsolutePath}")
       }
     }
 

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -143,7 +143,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,
         // (reason: Shutdown hook called before final status was reported.)

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -84,6 +84,9 @@ class DotnetBackend extends Logging {
 
     // Send close to .NET callback server.
     DotnetBackend.shutdownCallbackClient()
+
+    // Shutdown the thread pool whose executors could still be running.
+    ThreadPool.shutdown()
   }
 }
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
@@ -53,6 +53,14 @@ object ThreadPool {
   }
 
   /**
+   * Shutdown any running ExecutorServices.
+   */
+  def shutdown(): Unit = synchronized {
+    executors.foreach(_._2.shutdown())
+    executors.clear()
+  }
+
+  /**
    * Get the executor if it exists, otherwise create a new one.
    *
    * @param id Integer id of the thread.

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -144,7 +144,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,
         // (reason: Shutdown hook called before final status was reported.)

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -197,8 +197,7 @@ object DotnetRunner extends Logging {
         case Some(path) => path.toAbsolutePath.toString
         case None =>
           throw new IllegalArgumentException(
-            s"Failed to find $dotnetExecutable under" +
-              s" ${dir.getAbsolutePath}")
+            s"Failed to find $dotnetExecutable under ${dir.getAbsolutePath}")
       }
     }
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -16,7 +16,7 @@ import java.util.concurrent.{Semaphore, TimeUnit}
 import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark
-import org.apache.spark.api.dotnet.{DotnetBackend, ThreadPool}
+import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
@@ -144,11 +144,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
-        // Shutdown the thread pool whose executors could still be running,
-        // blocking the JVM process to exit. Since .NET process has already exited,
-        // the thread pool will never be cleaned up by the .NET process.
-        ThreadPool.shutdown()
 
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -84,6 +84,9 @@ class DotnetBackend extends Logging {
 
     // Send close to .NET callback server.
     DotnetBackend.shutdownCallbackClient()
+
+    // Shutdown the thread pool whose executors could still be running.
+    ThreadPool.shutdown()
   }
 }
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/ThreadPool.scala
@@ -53,6 +53,14 @@ object ThreadPool {
   }
 
   /**
+   * Shutdown any running ExecutorServices.
+   */
+  def shutdown(): Unit = synchronized {
+    executors.foreach(_._2.shutdown())
+    executors.clear()
+  }
+
+  /**
    * Get the executor if it exists, otherwise create a new one.
    *
    * @param id Integer id of the thread.

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -16,7 +16,7 @@ import java.util.concurrent.{Semaphore, TimeUnit}
 import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark
-import org.apache.spark.api.dotnet.{DotnetBackend, ThreadPool}
+import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
@@ -143,11 +143,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
-        // Shutdown the thread pool whose executors could still be running,
-        // blocking the JVM process to exit. Since .NET process has already exited,
-        // the thread pool will never be cleaned up by the .NET process.
-        ThreadPool.shutdown()
 
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -196,8 +196,7 @@ object DotnetRunner extends Logging {
         case Some(path) => path.toAbsolutePath.toString
         case None =>
           throw new IllegalArgumentException(
-            s"Failed to find $dotnetExecutable under" +
-              s" ${dir.getAbsolutePath}")
+            s"Failed to find $dotnetExecutable under ${dir.getAbsolutePath}")
       }
     }
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -143,7 +143,6 @@ object DotnetRunner extends Logging {
         } else {
           logInfo(s".NET application exited successfully")
         }
-
         // TODO: The following is causing the following error:
         // INFO ApplicationMaster: Final app status: FAILED, exitCode: 16,
         // (reason: Shutdown hook called before final status was reported.)


### PR DESCRIPTION
The JVM thread is not properly cleaned up, so there could be executor services still running when the JVM process tries to exit.

If there are executors running, this will prevent the JVM process to exit (behavior only under Ubuntu), leading to a hanging behavior at the end of the run.

This PR proposes to fix this issue by shutting down the thread pool.