### PR TITLE
Isolate all dotnet-interactive statements to use the same jvm thread

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
 
         private bool TryGetSparkSession(out SparkSession sparkSession)
         {
-            sparkSession = SparkSession.GetDefaultSession();
+            sparkSession = SparkSession.GetActiveSession();
             return sparkSession != null;
         }
 

--- a/src/csharp/Microsoft.Spark.Worker/Utils/AssemblyLoaderHelper.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Utils/AssemblyLoaderHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using Microsoft.Spark.Interop;
 using Microsoft.Spark.Services;
 using Microsoft.Spark.Utils;
 
@@ -23,8 +24,7 @@ namespace Microsoft.Spark.Worker.Utils
         private static readonly ConcurrentDictionary<string, Lazy<DependencyProvider>>
             s_dependencyProviders = new ConcurrentDictionary<string, Lazy<DependencyProvider>>();
 
-        private static readonly bool s_runningREPL =
-            EnvironmentUtils.GetEnvironmentVariableAsBool(Constants.RunningREPLEnvVar);
+        private static readonly bool s_runningREPL = SparkEnvironment.ConfigurationService.IsRunningRepl();
 
         /// <summary>
         /// Register the AssemblyLoader.ResolveAssembly handler to handle the

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using Microsoft.Spark.Network;
 using Microsoft.Spark.Services;
-using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Interop.Ipc
 {
@@ -33,6 +32,7 @@ namespace Microsoft.Spark.Interop.Ipc
         private static MemoryStream s_payloadMemoryStream;
 
         private const int SocketBufferThreshold = 3;
+        private const int ThreadIdForRepl = 1;
 
         private readonly SemaphoreSlim _socketSemaphore;
         private readonly ConcurrentQueue<ISocketWrapper> _sockets =
@@ -208,7 +208,7 @@ namespace Microsoft.Spark.Interop.Ipc
                 PayloadHelper.BuildPayload(
                     payloadMemoryStream,
                     isStatic,
-                    thread == null ? 1 : thread.ManagedThreadId,
+                    thread == null ? ThreadIdForRepl : thread.ManagedThreadId,
                     classNameOrJvmObjectReference,
                     methodName,
                     args);

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Spark.Interop.Ipc
 
                 if (thread != null)
                 {
-                    _jvmThreadPoolGC.TryAddThread(Thread.CurrentThread);
+                    _jvmThreadPoolGC.TryAddThread(thread);
                 }
 
                 Stream inputStream = socket.InputStream;

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Services
 {
@@ -107,5 +108,11 @@ namespace Microsoft.Spark.Services
             _workerPath = s_procFileName;
             return _workerPath;
         }
+
+        /// <summary>
+        /// Flag indicating whether running in REPL.
+        /// </summary>
+        public bool IsRunningRepl() =>
+            EnvironmentUtils.GetEnvironmentVariableAsBool(Constants.RunningREPLEnvVar);
     }
 }

--- a/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/IConfigurationService.cs
@@ -30,5 +30,10 @@ namespace Microsoft.Spark.Services
         /// The full path to the .NET worker executable.
         /// </summary>
         string GetWorkerExePath();
+
+        /// <summary>
+        /// Flag indicating whether running in REPL.
+        /// </summary>
+        bool IsRunningRepl();
     }
 }

--- a/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfUtils.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Spark.Utils
                 "DOTNET_WORKER_SPARK_VERSION",
                 SparkEnvironment.SparkVersion.ToString());
 
-            if (EnvironmentUtils.GetEnvironmentVariableAsBool(Constants.RunningREPLEnvVar))
+            if (SparkEnvironment.ConfigurationService.IsRunningRepl())
             {
                 environmentVars.Put(Constants.RunningREPLEnvVar, "true");
             }


### PR DESCRIPTION
Each code submission processed by `dotnet-interactive` run on an available thread in its thread pool.  This means that if two separate code submissions were submitted, each may run on a different thread in the CLR, which in turn be processed on a different thread in the JVM.

This PR prevents this from occurring by forcing the same JVM thread to process all incoming requests from the CLR when running a `dotnet-interactive` repl session.
