### PR TITLE
Fix package-worker.ps1 to handle output path with ":"

### DIFF
--- a/script/package-worker.ps1
+++ b/script/package-worker.ps1
@@ -17,7 +17,7 @@ foreach ($framework in $frameworks)
         # Generate additional tar.gz worker files only for linux-x64.
         if ($runtime.Name.ToLower().Equals("linux-x64"))
         {
-            tar czf "$output_dir/$filename.tar.gz" $worker_version_dir
+            tar czf "$output_dir/$filename.tar.gz" $worker_version_dir --force-local
         }
         
         Compress-Archive -DestinationPath "$output_dir/$filename.zip" -Path $worker_version_dir -CompressionLevel Optimal


### PR DESCRIPTION
`tar` treats `:` as remote storage, the current `tar` fails with:
```
tar (child): Cannot connect to D: resolve failed
```
Specifying `--force-local` fixes the issue.