### PR TITLE
Fix flaky CallbackTests.TestCallbackHandlers Test

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/CallbackTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/CallbackTests.cs
@@ -164,6 +164,15 @@ namespace Microsoft.Spark.UnitTest
             {
                 using ISocketWrapper serverSocket = serverListener.Accept();
                 WriteAndReadTestData(serverSocket, callbackHandler, inputToHandler);
+
+                if (callbackHandler.Throws)
+                {
+                    Assert.False(callbackConnection.IsRunning);
+                }
+                else
+                {
+                    Assert.True(callbackConnection.IsRunning);
+                }
             }
         }
 

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/CallbackConnection.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/CallbackConnection.cs
@@ -67,6 +67,8 @@ namespace Microsoft.Spark.Interop.Ipc
 
         internal long ConnectionId { get; }
 
+        internal bool IsRunning => _isRunning;
+
         /// <summary>
         /// Run and start processing the callback connection.
         /// </summary>

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/CallbackConnection.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/CallbackConnection.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Spark.Interop.Ipc
                 $"[{ConnectionId}] Connected with RemoteEndPoint: {socket.RemoteEndPoint}");
         }
 
-        private enum ConnectionStatus
+        internal enum ConnectionStatus
         {
             /// <summary>
             /// Connection is normal.


### PR DESCRIPTION
Instead of checking that reading from the socket throws an exception, check `CallbackConnection` to verify if it is running instead.

Cancelling the `CancellationToken` changes the _isRunning flag on the `CallbackConnection` from true to false.  Testing that this flag has been set correctly is the right thing to verify versus checking communication states/exceptions while trying to read the socket streams.