### PR TITLE
Check whether file is found before trying to dereference it

### DIFF
--- a/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
@@ -262,34 +262,18 @@ namespace Microsoft.Spark.Utils
                 typeData,
                 td =>
                 {
-                    Assembly assembly = AssemblyLoader.LoadAssembly(
+                    Type type = AssemblyLoader.LoadAssembly(
                         td.AssemblyName,
-                        td.AssemblyFileName);
-                    if (assembly == null)
-                    {
-                        string searchPath =
-                            Environment.GetEnvironmentVariable("DOTNET_ASSEMBLY_SEARCH_PATHS");
-                        
-                        if (String.IsNullOrEmpty(searchPath))
-                        {
-                            searchPath = "Empty";
-                        }
-                        
-                        throw new FileNotFoundException(
-                            string.Format(
-                                "Assembly '{0}' file not found '{1}'. " 
-                                + "Current DOTNET_ASSEMBLY_SEARCH_PATHS '{2}'",
-                                td.AssemblyName,
-                                td.AssemblyFileName,
-                                searchPath));
-                    }
-
-                    Type type = assembly.GetType(td.Name);
+                        td.AssemblyFileName)?.GetType(td.Name);
                     if (type == null)
                     {
-                        throw new TypeLoadException(
-                            string.Format("Unable to load Type '{0}' from Assembly '{1}'"));
+                        throw new FileNotFoundException(
+                            string.Format(
+                                "Assembly '{0}' file not found '{1}'",
+                                td.AssemblyName,
+                                td.AssemblyFileName));
                     }
+
                     return type;
                 });
     }

--- a/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
@@ -262,18 +262,34 @@ namespace Microsoft.Spark.Utils
                 typeData,
                 td =>
                 {
-                    Type type = AssemblyLoader.LoadAssembly(
+                    Assembly assembly = AssemblyLoader.LoadAssembly(
                         td.AssemblyName,
-                        td.AssemblyFileName).GetType(td.Name);
-                    if (type == null)
+                        td.AssemblyFileName);
+                    if (assembly == null)
                     {
+                        string searchPath =
+                            Environment.GetEnvironmentVariable("DOTNET_ASSEMBLY_SEARCH_PATHS");
+                        
+                        if (String.IsNullOrEmpty(searchPath))
+                        {
+                            searchPath = "Empty";
+                        }
+                        
                         throw new FileNotFoundException(
                             string.Format(
-                                "Assembly '{0}' file not found '{1}'",
+                                "Assembly '{0}' file not found '{1}'. " 
+                                + "Current DOTNET_ASSEMBLY_SEARCH_PATHS '{2}'",
                                 td.AssemblyName,
-                                td.AssemblyFileName));
+                                td.AssemblyFileName,
+                                searchPath));
                     }
 
+                    Type type = assembly.GetType(td.Name);
+                    if (type == null)
+                    {
+                        throw new TypeLoadException(
+                            string.Format("Unable to load Type '{0}' from Assembly '{1}'"));
+                    }
                     return type;
                 });
     }

--- a/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Spark.Utils
                 {
                     Type type = AssemblyLoader.LoadAssembly(
                         td.AssemblyName,
-                        td.AssemblyFileName)?.GetType(td.Name);
+                        td.AssemblyFileName)?.GetType(td.Name, true);
                     if (type == null)
                     {
                         throw new FileNotFoundException(


### PR DESCRIPTION
Fixes #758 

The current code causes a NullReferenceException when the assembly cannot be found so this switches the logic slightly and also adds some additional detail to describe how the DOTNET_ASSEMBLY_SEARCH_PATHS environment variable is set to help users understand why their dll's are not being loaded.

I wasn't sure on writing a test for this, if it needs a test let me know, I did think about adding a check for a FileNotFoundException for a file that doesn't exist and call `UdfSerDe.Deserialize(UdfData udfData)`.

I was also unsure what to throw if the assembly had been loaded but the type couldn't for some reason, I went with TypeLoadException but let me know if you think something else is more appropriate.

The point of this really is that I have seen this pop up a few times and the NullReferenceException hides a genuinely useful FileNotFoundException.

Ed