### PR TITLE
Support for Hyperspace 0.4.0

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace.E2ETest/HyperspaceFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace.E2ETest/HyperspaceFixture.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Spark.Extensions.Hyperspace.E2ETest
             Version sparkVersion = SparkSettings.Version;
             string hyperspaceVersion = sparkVersion.Major switch
             {
-                2 => "hyperspace-core_2.11:0.2.0",
-                3 => "hyperspace-core_2.12:0.2.0",
+                2 => "hyperspace-core_2.11:0.4.0",
+                3 => "hyperspace-core_2.12:0.4.0",
                 _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
             };
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace.E2ETest/HyperspaceTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace.E2ETest/HyperspaceTests.cs
@@ -66,6 +66,14 @@ namespace Microsoft.Spark.Extensions.Hyperspace.E2ETest
 
             // Refresh API.
             _hyperspace.RefreshIndex(_sampleIndexName);
+            _hyperspace.RefreshIndex(_sampleIndexName, "incremental");
+
+            // Optimize API.
+            _hyperspace.OptimizeIndex(_sampleIndexName);
+            _hyperspace.OptimizeIndex(_sampleIndexName, "quick");
+
+            // Index metadata API.
+            Assert.IsType<DataFrame>(_hyperspace.Index(_sampleIndexName));
 
             // Cancel API.
             Assert.Throws<Exception>(() => _hyperspace.Cancel(_sampleIndexName));

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// modes as listed below.
         /// </summary>
         /// <param name="indexName">Name of the index to refresh.</param>
-        /// <param name="mode">Refresh mode. Currently supported modes are "incremental" and "full".</param>
+        /// <param name="mode">Refresh mode. Currently supported modes are <c>incremental</c> and
+        /// <c>full</c>.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public void RefreshIndex(string indexName, string mode = "full") =>
             _jvmObject.Invoke("refreshIndex", indexName, mode);
@@ -82,19 +83,21 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <summary>
         /// Optimize index by changing the underlying index data layout (e.g., compaction).
         ///
-        /// Note: This API does NOT refresh (i.e.update) the index if the underlying data changes. It only
+        /// Note: This API does NOT refresh (i.e. update) the index if the underlying data changes. It only
         /// rearranges the index data into a better layout, by compacting small index files. The index files
         /// larger than a threshold remain untouched to avoid rewriting large contents.
         /// 
+        /// <c>quick</c> optimize mode is used by default.
+        /// 
         /// Available modes:
-        /// `Quick` mode: This mode allows for fast optimization. Files smaller than a predefined threshold'
-        /// "spark.hyperspace.index.optimize.fileSizeThreshold" will be picked for compaction.
+        /// <c>quick</c> mode: This mode allows for fast optimization. Files smaller than a predefined threshold
+        /// <c>spark.hyperspace.index.optimize.fileSizeThreshold</c> will be picked for compaction.
         ///
-        /// `Full` mode: This allows for slow but complete optimization. ALL index files are picked for
+        /// <c>full</c> mode: This allows for slow but complete optimization. ALL index files are picked for
         /// compaction.
         /// </summary>
         /// <param name="indexName">Name of the index to optimize.</param>
-        /// <param name="mode">Optimize mode "quick" or "full".</param>
+        /// <param name="mode">Optimize mode <c>quick</c> or <c>full</c>.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_3)]
         public void OptimizeIndex(string indexName, string mode = "quick") =>
             _jvmObject.Invoke("optimizeIndex", indexName, mode);

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -90,8 +90,8 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <c>quick</c> optimize mode is used by default.
         /// 
         /// Available modes:
-        /// <c>quick</c> mode: This mode allows for fast optimization. Files smaller than a predefined threshold
-        /// <c>spark.hyperspace.index.optimize.fileSizeThreshold</c> will be picked for compaction.
+        /// <c>quick</c> mode: This mode allows for fast optimization. Files smaller than a predefined
+        /// threshold <c>spark.hyperspace.index.optimize.fileSizeThreshold</c> will be picked for compaction.
         ///
         /// <c>full</c> mode: This allows for slow but complete optimization. ALL index files are picked for
         /// compaction.

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -70,14 +70,21 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         public void VacuumIndex(string indexName) => _jvmObject.Invoke("vacuumIndex", indexName);
 
         /// <summary>
+        /// Update indexes for the latest version of the data.
+        /// </summary>
+        /// <param name="indexName">Name of the index to refresh.</param>
+        [HyperspaceSince(HyperspaceVersions.V0_0_1)]
+        public void RefreshIndex(string indexName) => _jvmObject.Invoke("refreshIndex", indexName);
+
+        /// <summary>
         /// Update indexes for the latest version of the data. This API provides a few supported refresh
         /// modes as listed below.
         /// </summary>
         /// <param name="indexName">Name of the index to refresh.</param>
         /// <param name="mode">Refresh mode. Currently supported modes are <c>incremental</c> and
         /// <c>full</c>.</param>
-        [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void RefreshIndex(string indexName, string mode = "full") =>
+        [HyperspaceSince(HyperspaceVersions.V0_0_3)]
+        public void RefreshIndex(string indexName, string mode) =>
             _jvmObject.Invoke("refreshIndex", indexName, mode);
 
         /// <summary>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -70,11 +70,34 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         public void VacuumIndex(string indexName) => _jvmObject.Invoke("vacuumIndex", indexName);
 
         /// <summary>
-        /// Update indexes for the latest version of the data.
+        /// Update indexes for the latest version of the data. This API provides a few supported refresh
+        /// modes as listed below.
         /// </summary>
         /// <param name="indexName">Name of the index to refresh.</param>
+        /// <param name="mode">Refresh mode. Currently supported modes are "incremental" and "full".</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void RefreshIndex(string indexName) => _jvmObject.Invoke("refreshIndex", indexName);
+        public void RefreshIndex(string indexName, string mode = "full") =>
+            _jvmObject.Invoke("refreshIndex", indexName, mode);
+
+        /// <summary>
+        /// Optimize index by changing the underlying index data layout (e.g., compaction).
+        ///
+        /// Note: This API does NOT refresh (i.e.update) the index if the underlying data changes. It only
+        /// rearranges the index data into a better layout, by compacting small index files. The index files
+        /// larger than a threshold remain untouched to avoid rewriting large contents.
+        /// 
+        /// Available modes:
+        /// `Quick` mode: This mode allows for fast optimization. Files smaller than a predefined threshold'
+        /// "spark.hyperspace.index.optimize.fileSizeThreshold" will be picked for compaction.
+        ///
+        /// `Full` mode: This allows for slow but complete optimization. ALL index files are picked for
+        /// compaction.
+        /// </summary>
+        /// <param name="indexName">Name of the index to optimize.</param>
+        /// <param name="mode">Optimize mode "quick" or "full".</param>
+        [HyperspaceSince(HyperspaceVersions.V0_0_3)]
+        public void OptimizeIndex(string indexName, string mode = "quick") =>
+            _jvmObject.Invoke("optimizeIndex", indexName, mode);
 
         /// <summary>
         /// Cancel api to bring back index from an inconsistent state to the last known stable
@@ -120,5 +143,14 @@ namespace Microsoft.Spark.Extensions.Hyperspace
                 verbose);
             redirectFunc(explainString);
         }
+
+        /// <summary>
+        /// Get index metadata and detailed index statistics for a given index.
+        /// </summary>
+        /// <param name="indexName">Name of the index to get stats for.</param>
+        /// <returns>Index metadata and statistics as a <see cref="DataFrame"/>.</returns>
+        [HyperspaceSince(HyperspaceVersions.V0_0_4)]
+        public DataFrame Index(string indexName) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("index", indexName));
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/HyperspaceVersions.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/HyperspaceVersions.cs
@@ -7,5 +7,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
     internal static class HyperspaceVersions
     {
         internal const string V0_0_1 = "0.0.1";
+        internal const string V0_0_3 = "0.0.3";
+        internal const string V0_0_4 = "0.0.4";
     }
 }


### PR DESCRIPTION
This PR adds full support for [Hyperspace 0.4.0](https://github.com/microsoft/hyperspace/releases/tag/v0.4.0).  This includes new APIs `optimizeIndex()` and `index()` introduced in Hyperspace 0.3.0 and 0.4.0, respectively.