### PR TITLE
Support for Delta Lake 0.8.0

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             string deltaVersion = sparkVersion.Major switch
             {
                 2 => "delta-core_2.11:0.6.1",
-                3 => "delta-core_2.12:0.7.0",
+                3 => "delta-core_2.12:0.8.0",
                 _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
             };
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             {
                 ("spark.databricks.delta.snapshotPartitions", "2"),
                 ("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5"),
-                ("spark.databricks.delta.minReaderVersion", "1"),
+                // Set the writer protocol version for testing UpgradeTableProtocol().
                 ("spark.databricks.delta.minWriterVersion", "2")
             };
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
                 ("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5"),
                 ("spark.databricks.delta.minReaderVersion", "1"),
                 ("spark.databricks.delta.minWriterVersion", "2")
-        };
+            };
 
             (string, string)[] extraConf = sparkVersion.Major switch
             {

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaFixture.cs
@@ -26,8 +26,10 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             (string, string)[] conf = new[]
             {
                 ("spark.databricks.delta.snapshotPartitions", "2"),
-                ("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
-            };
+                ("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5"),
+                ("spark.databricks.delta.minReaderVersion", "1"),
+                ("spark.databricks.delta.minWriterVersion", "2")
+        };
 
             (string, string)[] extraConf = sparkVersion.Major switch
             {

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -337,7 +337,9 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             _spark.Range(15).Write().Format("delta").SaveAsTable(tableName);
 
             Assert.IsType<DeltaTable>(DeltaTable.ForName(tableName));
-            Assert.IsType<DeltaTable>(DeltaTable.ForName(_spark, tableName));
+            DeltaTable table = Assert.IsType<DeltaTable>(DeltaTable.ForName(_spark, tableName));
+
+            table.UpgradeTableProtocol(2, 2);
         }
 
         /// <summary>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Spark.E2ETest;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Extensions.Delta.Tables;
 using Microsoft.Spark.Sql;

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             Assert.IsType<DeltaTable>(DeltaTable.ForName(tableName));
             DeltaTable table = Assert.IsType<DeltaTable>(DeltaTable.ForName(_spark, tableName));
 
-            table.UpgradeTableProtocol(2, 2);
+            table.UpgradeTableProtocol(1, 3);
         }
 
         /// <summary>

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta.E2ETest/DeltaTableTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Spark.Extensions.Delta.E2ETest
             _spark.Range(15).Write().Format("delta").SaveAsTable(tableName);
 
             Assert.IsType<DeltaTable>(DeltaTable.ForName(tableName));
-            DeltaTable table = Assert.IsType<DeltaTable>(DeltaTable.ForName(_spark, tableName));
+            DeltaTable table = DeltaTable.ForName(_spark, tableName);
 
             table.UpgradeTableProtocol(1, 3);
         }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/DeltaLakeVersions.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Spark.Extensions.Delta
         internal const string V0_6_0 = "0.6.0";
         internal const string V0_6_1 = "0.6.1";
         internal const string V0_7_0 = "0.7.0";
+        internal const string V0_8_0 = "0.8.0";
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -501,5 +501,21 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
                 "merge",
                 source,
                 condition));
+
+        /// <summary>
+        /// Updates the protocol version of the table to leverage new features. Upgrading the reader version
+        /// will prevent all clients that have an older version of Delta Lake from accessing this table.
+        /// Upgrading the writer version will prevent older versions of Delta Lake to write to this table.
+        /// The reader or writer version cannot be downgraded.
+        /// 
+        /// See online documentation and Delta's protocol specification at
+        /// <see href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">PROTOCOL.md</see> for more
+        /// details.
+        /// </summary>
+        /// <param name="readerVersion">Version of the Delta read protocol.</param>
+        /// <param name="writerVersion">Version of the Delta write protocol.</param>
+        [DeltaLakeSince(DeltaLakeVersions.V0_8_0)]
+        public void UpgradeTableProtocol(int readerVersion, int writerVersion) =>
+            _jvmObject.Invoke("upgradeTableProtocol", readerVersion, writerVersion);
     }
 }


### PR DESCRIPTION
This small PR adds support for Delta Lake 0.8.0.  This includes a new API `DeltaTable.UpgradeTableProtocol()`.