### PR TITLE
Add DOTNET_WORKER_<ver>_DIR environment variable

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Spark.E2ETest
             /// <summary>
             /// This environment variable specifies the path where the DotNet worker is installed.
             /// </summary>
-            public const string WorkerDir = Services.ConfigurationService.WorkerDirEnvVarName;
+            public const string WorkerDir = Services.ConfigurationService.DefaultWorkerDirEnvVarName;
         }
 
         private readonly Process _process = new Process();

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -48,7 +48,9 @@ namespace Microsoft.Spark.UnitTest
             Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, workerDir);
 
             // Only ConfigurationService.WorkerDirEnvVarName is set, WorkerExePath will be built using it.
-            Assert.Equal(Path.Combine(workerDir, ConfigurationService.ProcFileName), configService.GetWorkerExePath());
+            Assert.Equal(
+                Path.Combine(workerDir, ConfigurationService.ProcFileName),
+                configService.GetWorkerExePath());
         }
 
         [Fact]
@@ -63,7 +65,9 @@ namespace Microsoft.Spark.UnitTest
             // ConfigurationService.WorkerDirEnvVarName and ConfigurationService.WorkerVerDirEnvVarName
             // environment variables are set. ConfigurationService.WorkerVerDirEnvVarName will take
             // precedence.
-            Assert.Equal(Path.Combine(workerVerDir, ConfigurationService.ProcFileName), configService.GetWorkerExePath());
+            Assert.Equal(
+                Path.Combine(workerVerDir, ConfigurationService.ProcFileName),
+                configService.GetWorkerExePath());
         }
 
         public void Dispose()

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Spark.UnitTest
                 Assert.True(
                     string.IsNullOrWhiteSpace(
                         Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
                 Assert.Equal(
                     ConfigurationService.DefaultWorkerDirEnvVarName, configService.WorkerDirEnvVarName);
             }
@@ -94,6 +97,9 @@ namespace Microsoft.Spark.UnitTest
                 Assert.False(
                     string.IsNullOrWhiteSpace(
                         Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
                 Assert.Equal(_workerDirEnvVars.WorkerMajorDir.Name, configService.WorkerDirEnvVarName);
             }
 
@@ -112,6 +118,9 @@ namespace Microsoft.Spark.UnitTest
                 Assert.False(
                     string.IsNullOrWhiteSpace(
                         Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
                 Assert.Equal(_workerDirEnvVars.WorkerMajorMinorDir.Name, configService.WorkerDirEnvVarName);
             }
 
@@ -129,6 +138,9 @@ namespace Microsoft.Spark.UnitTest
                 Assert.False(
                     string.IsNullOrWhiteSpace(
                         Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
                 Assert.Equal(
                     _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, configService.WorkerDirEnvVarName);
             }

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Spark.UnitTest
             Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
             Assert.True(_workerDirEnvVars.WorkerDir.IsSet());
 
-            // Only ConfigurationService.WorkerDirEnvVarName is set, WorkerExePath will be built using it.
+            // Only WorkerDir is set, WorkerExePath will be built using it.
             Assert.Equal(
                 Path.Combine(workerDir, ConfigurationService.ProcFileName),
                 configService.GetWorkerExePath());

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Spark.Services;
+using Microsoft.Spark.Utils;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    public class ConfigurationServiceTests : IDisposable
+    {
+        private readonly string _workerDir =
+            Environment.GetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName);
+        private readonly string _workerVerDir =
+            Environment.GetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName);
+
+        public ConfigurationServiceTests()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, "");
+            Environment.SetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName, "");
+        }
+
+        [Fact]
+        public void TestWorkerVerEnvName()
+        {
+            string expected = string.Format(
+                ConfigurationService.WorkerVerDirEnvVarNameFormat,
+                new Version(AssemblyInfoProvider.MicrosoftSparkAssemblyInfo().AssemblyVersion).Major);
+            Assert.Equal(expected, ConfigurationService.WorkerVerDirEnvVarName);
+        }
+
+        [Fact]
+        public void TestWorkerExePathWithNoEnvVars()
+        {
+            var configService = new ConfigurationService();
+            // Environment variables not set, only Microsoft.Spark.Worker filename should be returned.
+            Assert.Equal(ConfigurationService.ProcFileName, configService.GetWorkerExePath());
+        }
+
+        [Fact]
+        public void TestWorkerExePathWithWorkerDirEnvVar()
+        {
+            var configService = new ConfigurationService();
+            var workerDir = "workerDir";
+            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, workerDir);
+
+            // Only ConfigurationService.WorkerDirEnvVarName is set, WorkerExePath will be built using it.
+            Assert.Equal(Path.Combine(workerDir, ConfigurationService.ProcFileName), configService.GetWorkerExePath());
+        }
+
+        [Fact]
+        public void TestWorkerExePathWithEnvVarPrecedence()
+        {
+            var configService = new ConfigurationService();
+            var workerDir = "workerDir";
+            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, workerDir);
+            var workerVerDir = "workerVerDir";
+            Environment.SetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName, workerVerDir);
+
+            // ConfigurationService.WorkerDirEnvVarName and ConfigurationService.WorkerVerDirEnvVarName
+            // environment variables are set. ConfigurationService.WorkerVerDirEnvVarName will take
+            // precedence.
+            Assert.Equal(Path.Combine(workerVerDir, ConfigurationService.ProcFileName), configService.GetWorkerExePath());
+        }
+
+        public void Dispose()
+        {
+            if (!string.IsNullOrWhiteSpace(_workerDir))
+            {
+                Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, _workerDir);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_workerVerDir))
+            {
+                Environment.SetEnvironmentVariable(
+                    ConfigurationService.WorkerVerDirEnvVarName, _workerVerDir);
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -19,39 +19,17 @@ namespace Microsoft.Spark.UnitTest
             var version = new Version(AssemblyInfoProvider.MicrosoftSparkAssemblyInfo().AssemblyVersion);
             _workerDirEnvVars = new WorkerDirEnvVars
             {
-                WorkerDir = new EnvVar {
-                    Name = ConfigurationService.DefaultWorkerDirEnvVarName,
-                    Value = Environment.GetEnvironmentVariable(
-                        ConfigurationService.DefaultWorkerDirEnvVarName)
-                },
-                WorkerMajorMinorBuildDir = new EnvVar
-                {
-                    Name = string.Format(
+                WorkerDir = new EnvVar(ConfigurationService.DefaultWorkerDirEnvVarName),
+                WorkerMajorMinorBuildDir = new EnvVar(
+                    string.Format(
                         ConfigurationService.WorkerVerDirEnvVarNameFormat,
-                        $"{version.Major}_{version.Minor}_{version.Build}"),
-                    Value = Environment.GetEnvironmentVariable(
-                        string.Format(
-                            ConfigurationService.WorkerVerDirEnvVarNameFormat,
-                            $"{version.Major}_{version.Minor}_{version.Build}"))
-                },
-                WorkerMajorMinorDir = new EnvVar
-                {
-                    Name = string.Format(
+                        $"{version.Major}_{version.Minor}_{version.Build}")),
+                WorkerMajorMinorDir = new EnvVar(
+                    string.Format(
                         ConfigurationService.WorkerVerDirEnvVarNameFormat,
-                        $"{version.Major}_{version.Minor}"),
-                    Value = Environment.GetEnvironmentVariable(
-                        string.Format(
-                            ConfigurationService.WorkerVerDirEnvVarNameFormat,
-                            $"{version.Major}_{version.Minor}"))
-                },
-                WorkerMajorDir = new EnvVar
-                {
-                    Name = string.Format(
-                        ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major),
-                    Value = Environment.GetEnvironmentVariable(
-                        string.Format(
-                            ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major))
-                }
+                        $"{version.Major}_{version.Minor}")),
+                WorkerMajorDir = new EnvVar(
+                    string.Format(ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major))
             };
 
             Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, "");
@@ -66,19 +44,10 @@ namespace Microsoft.Spark.UnitTest
             {
                 var configService = new ConfigurationService();
 
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(
-                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
                 Assert.Equal(
                     ConfigurationService.DefaultWorkerDirEnvVarName, configService.WorkerDirEnvVarName);
             }
@@ -87,19 +56,10 @@ namespace Microsoft.Spark.UnitTest
                 var configService = new ConfigurationService();
                 Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, "workerMajorDir");
 
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(
-                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
                 Assert.Equal(_workerDirEnvVars.WorkerMajorDir.Name, configService.WorkerDirEnvVarName);
             }
 
@@ -108,19 +68,10 @@ namespace Microsoft.Spark.UnitTest
                 Environment.SetEnvironmentVariable(
                     _workerDirEnvVars.WorkerMajorMinorDir.Name, "workerMajorMinorDir");
 
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(
-                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+                Assert.True(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
                 Assert.Equal(_workerDirEnvVars.WorkerMajorMinorDir.Name, configService.WorkerDirEnvVarName);
             }
 
@@ -128,19 +79,11 @@ namespace Microsoft.Spark.UnitTest
                 var configService = new ConfigurationService();
                 Environment.SetEnvironmentVariable(
                     _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "workerMajorMinorBuildDir");
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(
-                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-                Assert.False(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-                Assert.True(
-                    string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+
+                Assert.True(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+                Assert.True(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
+                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
                 Assert.Equal(
                     _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, configService.WorkerDirEnvVarName);
             }
@@ -151,18 +94,10 @@ namespace Microsoft.Spark.UnitTest
         {
             var configService = new ConfigurationService();
 
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
 
             // Environment variables not set, only Microsoft.Spark.Worker filename should be returned.
             Assert.Equal(ConfigurationService.ProcFileName, configService.GetWorkerExePath());
@@ -175,18 +110,10 @@ namespace Microsoft.Spark.UnitTest
             var workerDir = "workerDir";
             Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
 
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-            Assert.False(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
+            Assert.True(_workerDirEnvVars.WorkerDir.IsSet());
 
             // Only ConfigurationService.WorkerDirEnvVarName is set, WorkerExePath will be built using it.
             Assert.Equal(
@@ -203,23 +130,14 @@ namespace Microsoft.Spark.UnitTest
             var workerMajorDir = "workerMajorDir";
             Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, workerMajorDir);
 
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
-            Assert.True(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
-            Assert.False(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
-            Assert.False(
-                string.IsNullOrWhiteSpace(
-                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
+            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
+            Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
+            Assert.True(_workerDirEnvVars.WorkerDir.IsSet());
 
-
-            // DOTNET_WORKER_DIR and DOTNET_WORKER_{MAJOR}_DIR environment variables are set.
-            // Ensure that the environment variable constructed with the assembly version takes
-            // precedence.
+            // WorkerDir and WorkerMajorDir environment variables are set.
+            // Ensure that the environment variable constructed with the
+            // assembly version takes precedence.
             Assert.Equal(
                 Path.Combine(workerMajorDir, ConfigurationService.ProcFileName),
                 configService.GetWorkerExePath());
@@ -251,8 +169,16 @@ namespace Microsoft.Spark.UnitTest
 
         private class EnvVar
         {
-            public string Name { get; set; }
-            public string Value { get; set; }
+            public string Name { get; }
+            public string Value { get; }
+
+            public EnvVar(string name)
+            {
+                Name = name;
+                Value = Environment.GetEnvironmentVariable(name);
+            }
+
+            public bool IsSet() => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Name));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Spark.UnitTest
             {
                 WorkerDir = new EnvVar {
                     Name = ConfigurationService.DefaultWorkerDirEnvVarName,
-                    Value = Environment.GetEnvironmentVariable(ConfigurationService.DefaultWorkerDirEnvVarName)
+                    Value = Environment.GetEnvironmentVariable(
+                        ConfigurationService.DefaultWorkerDirEnvVarName)
                 },
                 WorkerMajorMinorBuildDir = new EnvVar
                 {
@@ -120,7 +121,8 @@ namespace Microsoft.Spark.UnitTest
                     _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "workerMajorMinorBuildDir");
                 Assert.False(
                     string.IsNullOrWhiteSpace(
-                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+                        Environment.GetEnvironmentVariable(
+                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
                 Assert.False(
                     string.IsNullOrWhiteSpace(
                         Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -32,61 +32,10 @@ namespace Microsoft.Spark.UnitTest
                     string.Format(ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major))
             };
 
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, "");
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "");
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name, "");
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, "");
-        }
-
-        [Fact]
-        public void TestWorkerEnvName()
-        {
-            {
-                var configService = new ConfigurationService();
-
-                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
-                Assert.Equal(
-                    ConfigurationService.DefaultWorkerDirEnvVarName, configService.WorkerDirEnvVarName);
-            }
-
-            {
-                var configService = new ConfigurationService();
-                Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, "workerMajorDir");
-
-                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
-                Assert.Equal(_workerDirEnvVars.WorkerMajorDir.Name, configService.WorkerDirEnvVarName);
-            }
-
-            {
-                var configService = new ConfigurationService();
-                Environment.SetEnvironmentVariable(
-                    _workerDirEnvVars.WorkerMajorMinorDir.Name, "workerMajorMinorDir");
-
-                Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-                Assert.True(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
-                Assert.Equal(_workerDirEnvVars.WorkerMajorMinorDir.Name, configService.WorkerDirEnvVarName);
-            }
-
-            {
-                var configService = new ConfigurationService();
-                Environment.SetEnvironmentVariable(
-                    _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "workerMajorMinorBuildDir");
-
-                Assert.True(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-                Assert.True(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-                Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
-                Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
-                Assert.Equal(
-                    _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, configService.WorkerDirEnvVarName);
-            }
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, null);
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name, null);
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name, null);
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, null);
         }
 
         [Fact]
@@ -94,10 +43,10 @@ namespace Microsoft.Spark.UnitTest
         {
             var configService = new ConfigurationService();
 
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerDir.IsSet());
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
 
             // Environment variables not set, only Microsoft.Spark.Worker filename should be returned.
             Assert.Equal(ConfigurationService.ProcFileName, configService.GetWorkerExePath());
@@ -107,13 +56,13 @@ namespace Microsoft.Spark.UnitTest
         public void TestWorkerExePathWithWorkerDirEnvVar()
         {
             var configService = new ConfigurationService();
-            var workerDir = "workerDir";
+            string workerDir = "workerDir";
             Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
 
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerMajorDir.IsSet());
-            Assert.True(_workerDirEnvVars.WorkerDir.IsSet());
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+            Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+            Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
 
             // Only WorkerDir is set, WorkerExePath will be built using it.
             Assert.Equal(
@@ -124,23 +73,63 @@ namespace Microsoft.Spark.UnitTest
         [Fact]
         public void TestWorkerExePathWithEnvVarPrecedence()
         {
-            var configService = new ConfigurationService();
-            var workerDir = "workerDir";
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
-            var workerMajorDir = "workerMajorDir";
-            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, workerMajorDir);
+            {
+                var configService = new ConfigurationService();
+                string workerDir = "workerDir";
+                Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
 
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorBuildDir.IsSet());
-            Assert.False(_workerDirEnvVars.WorkerMajorMinorDir.IsSet());
-            Assert.True(_workerDirEnvVars.WorkerMajorDir.IsSet());
-            Assert.True(_workerDirEnvVars.WorkerDir.IsSet());
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
+                Assert.Equal(
+                    Path.Combine(workerDir, ConfigurationService.ProcFileName),
+                    configService.GetWorkerExePath());
+            }
 
-            // WorkerDir and WorkerMajorDir environment variables are set.
-            // Ensure that the environment variable constructed with the
-            // assembly version takes precedence.
-            Assert.Equal(
-                Path.Combine(workerMajorDir, ConfigurationService.ProcFileName),
-                configService.GetWorkerExePath());
+            {
+                var configService = new ConfigurationService();
+                string workerMajorDir = "workerMajorDir";
+                Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, workerMajorDir);
+
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
+                Assert.Equal(
+                    Path.Combine(workerMajorDir, ConfigurationService.ProcFileName),
+                    configService.GetWorkerExePath());
+            }
+
+            {
+                var configService = new ConfigurationService();
+                string workerMajorMinorDir = "workerMajorMinorDir";
+                Environment.SetEnvironmentVariable(
+                    _workerDirEnvVars.WorkerMajorMinorDir.Name, workerMajorMinorDir);
+
+                Assert.False(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
+                Assert.Equal(
+                    Path.Combine(workerMajorMinorDir, ConfigurationService.ProcFileName),
+                    configService.GetWorkerExePath());
+            }
+
+            {
+                var configService = new ConfigurationService();
+                string workerMajorMinorBuildDir = "workerMajorMinorBuildDir";
+                Environment.SetEnvironmentVariable(
+                    _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, workerMajorMinorBuildDir);
+
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorMinorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerMajorDir.Name));
+                Assert.True(IsEnvVarSet(_workerDirEnvVars.WorkerDir.Name));
+                Assert.Equal(
+                    Path.Combine(workerMajorMinorBuildDir, ConfigurationService.ProcFileName),
+                    configService.GetWorkerExePath());
+            }
         }
 
         public void Dispose()
@@ -158,6 +147,9 @@ namespace Microsoft.Spark.UnitTest
                 _workerDirEnvVars.WorkerMajorDir.Name,
                 _workerDirEnvVars.WorkerMajorDir.Value);
         }
+
+        public bool IsEnvVarSet(string name) =>
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name));
 
         private class WorkerDirEnvVars
         {
@@ -178,7 +170,6 @@ namespace Microsoft.Spark.UnitTest
                 Value = Environment.GetEnvironmentVariable(name);
             }
 
-            public bool IsSet() => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Name));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/ConfigurationServiceTests.cs
@@ -12,30 +12,144 @@ namespace Microsoft.Spark.UnitTest
 {
     public class ConfigurationServiceTests : IDisposable
     {
-        private readonly string _workerDir =
-            Environment.GetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName);
-        private readonly string _workerVerDir =
-            Environment.GetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName);
+        private readonly WorkerDirEnvVars _workerDirEnvVars;
 
         public ConfigurationServiceTests()
         {
-            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, "");
-            Environment.SetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName, "");
+            var version = new Version(AssemblyInfoProvider.MicrosoftSparkAssemblyInfo().AssemblyVersion);
+            _workerDirEnvVars = new WorkerDirEnvVars
+            {
+                WorkerDir = new EnvVar {
+                    Name = ConfigurationService.DefaultWorkerDirEnvVarName,
+                    Value = Environment.GetEnvironmentVariable(ConfigurationService.DefaultWorkerDirEnvVarName)
+                },
+                WorkerMajorMinorBuildDir = new EnvVar
+                {
+                    Name = string.Format(
+                        ConfigurationService.WorkerVerDirEnvVarNameFormat,
+                        $"{version.Major}_{version.Minor}_{version.Build}"),
+                    Value = Environment.GetEnvironmentVariable(
+                        string.Format(
+                            ConfigurationService.WorkerVerDirEnvVarNameFormat,
+                            $"{version.Major}_{version.Minor}_{version.Build}"))
+                },
+                WorkerMajorMinorDir = new EnvVar
+                {
+                    Name = string.Format(
+                        ConfigurationService.WorkerVerDirEnvVarNameFormat,
+                        $"{version.Major}_{version.Minor}"),
+                    Value = Environment.GetEnvironmentVariable(
+                        string.Format(
+                            ConfigurationService.WorkerVerDirEnvVarNameFormat,
+                            $"{version.Major}_{version.Minor}"))
+                },
+                WorkerMajorDir = new EnvVar
+                {
+                    Name = string.Format(
+                        ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major),
+                    Value = Environment.GetEnvironmentVariable(
+                        string.Format(
+                            ConfigurationService.WorkerVerDirEnvVarNameFormat, version.Major))
+                }
+            };
+
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, "");
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "");
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name, "");
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, "");
         }
 
         [Fact]
-        public void TestWorkerVerEnvName()
+        public void TestWorkerEnvName()
         {
-            string expected = string.Format(
-                ConfigurationService.WorkerVerDirEnvVarNameFormat,
-                new Version(AssemblyInfoProvider.MicrosoftSparkAssemblyInfo().AssemblyVersion).Major);
-            Assert.Equal(expected, ConfigurationService.WorkerVerDirEnvVarName);
+            {
+                var configService = new ConfigurationService();
+
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(
+                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.Equal(
+                    ConfigurationService.DefaultWorkerDirEnvVarName, configService.WorkerDirEnvVarName);
+            }
+
+            {
+                var configService = new ConfigurationService();
+                Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, "workerMajorDir");
+
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(
+                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.Equal(_workerDirEnvVars.WorkerMajorDir.Name, configService.WorkerDirEnvVarName);
+            }
+
+            {
+                var configService = new ConfigurationService();
+                Environment.SetEnvironmentVariable(
+                    _workerDirEnvVars.WorkerMajorMinorDir.Name, "workerMajorMinorDir");
+
+                Assert.True(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(
+                            _workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.Equal(_workerDirEnvVars.WorkerMajorMinorDir.Name, configService.WorkerDirEnvVarName);
+            }
+
+            {
+                var configService = new ConfigurationService();
+                Environment.SetEnvironmentVariable(
+                    _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, "workerMajorMinorBuildDir");
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+                Assert.False(
+                    string.IsNullOrWhiteSpace(
+                        Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+                Assert.Equal(
+                    _workerDirEnvVars.WorkerMajorMinorBuildDir.Name, configService.WorkerDirEnvVarName);
+            }
         }
 
         [Fact]
         public void TestWorkerExePathWithNoEnvVars()
         {
             var configService = new ConfigurationService();
+
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+
             // Environment variables not set, only Microsoft.Spark.Worker filename should be returned.
             Assert.Equal(ConfigurationService.ProcFileName, configService.GetWorkerExePath());
         }
@@ -45,7 +159,20 @@ namespace Microsoft.Spark.UnitTest
         {
             var configService = new ConfigurationService();
             var workerDir = "workerDir";
-            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, workerDir);
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
+
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+            Assert.False(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
 
             // Only ConfigurationService.WorkerDirEnvVarName is set, WorkerExePath will be built using it.
             Assert.Equal(
@@ -58,30 +185,60 @@ namespace Microsoft.Spark.UnitTest
         {
             var configService = new ConfigurationService();
             var workerDir = "workerDir";
-            Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, workerDir);
-            var workerVerDir = "workerVerDir";
-            Environment.SetEnvironmentVariable(ConfigurationService.WorkerVerDirEnvVarName, workerVerDir);
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name, workerDir);
+            var workerMajorDir = "workerMajorDir";
+            Environment.SetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name, workerMajorDir);
 
-            // ConfigurationService.WorkerDirEnvVarName and ConfigurationService.WorkerVerDirEnvVarName
-            // environment variables are set. ConfigurationService.WorkerVerDirEnvVarName will take
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorBuildDir.Name)));
+            Assert.True(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorMinorDir.Name)));
+            Assert.False(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerMajorDir.Name)));
+            Assert.False(
+                string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(_workerDirEnvVars.WorkerDir.Name)));
+
+
+            // DOTNET_WORKER_DIR and DOTNET_WORKER_{MAJOR}_DIR environment variables are set.
+            // Ensure that the environment variable constructed with the assembly version takes
             // precedence.
             Assert.Equal(
-                Path.Combine(workerVerDir, ConfigurationService.ProcFileName),
+                Path.Combine(workerMajorDir, ConfigurationService.ProcFileName),
                 configService.GetWorkerExePath());
         }
 
         public void Dispose()
         {
-            if (!string.IsNullOrWhiteSpace(_workerDir))
-            {
-                Environment.SetEnvironmentVariable(ConfigurationService.WorkerDirEnvVarName, _workerDir);
-            }
+            Environment.SetEnvironmentVariable(
+                _workerDirEnvVars.WorkerDir.Name,
+                _workerDirEnvVars.WorkerDir.Value);
+            Environment.SetEnvironmentVariable(
+                _workerDirEnvVars.WorkerMajorMinorBuildDir.Name,
+                _workerDirEnvVars.WorkerMajorMinorBuildDir.Value);
+            Environment.SetEnvironmentVariable(
+                _workerDirEnvVars.WorkerMajorMinorDir.Name,
+                _workerDirEnvVars.WorkerMajorMinorDir.Value);
+            Environment.SetEnvironmentVariable(
+                _workerDirEnvVars.WorkerMajorDir.Name,
+                _workerDirEnvVars.WorkerMajorDir.Value);
+        }
 
-            if (!string.IsNullOrWhiteSpace(_workerVerDir))
-            {
-                Environment.SetEnvironmentVariable(
-                    ConfigurationService.WorkerVerDirEnvVarName, _workerVerDir);
-            }
+        private class WorkerDirEnvVars
+        {
+            public EnvVar WorkerDir { get; set; }
+            public EnvVar WorkerMajorMinorBuildDir { get; set; }
+            public EnvVar WorkerMajorMinorDir { get; set; }
+            public EnvVar WorkerMajorDir { get; set; }
+        }
+
+        private class EnvVar
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Spark.Services
             {
                 _workerPath = Path.Combine(workerVerDir, ProcFileName);
                 _logger.LogDebug(
-                    "Using the environment variable {0} to construct .NET worker path: {1}.",
+                    "Using the {0} environment variable to construct .NET worker path: {1}.",
                     WorkerVerDirEnvVarName,
                     _workerPath);
                 return _workerPath;
@@ -131,7 +131,7 @@ namespace Microsoft.Spark.Services
             {
                 _workerPath = Path.Combine(workerDir, ProcFileName);
                 _logger.LogDebug(
-                    "Using the environment variable {0} to construct .NET worker path: {1}.",
+                    "Using the {0} environment variable to construct .NET worker path: {1}.",
                     WorkerDirEnvVarName,
                     _workerPath);
                 return _workerPath;

--- a/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
+++ b/src/csharp/Microsoft.Spark/Services/ConfigurationService.cs
@@ -117,7 +117,10 @@ namespace Microsoft.Spark.Services
             if (!string.IsNullOrEmpty(workerVerDir))
             {
                 _workerPath = Path.Combine(workerVerDir, ProcFileName);
-                _logger.LogDebug($"Using the environment variable {WorkerVerDirEnvVarName} to construct .NET worker path: {_workerPath}.");
+                _logger.LogDebug(
+                    "Using the environment variable {0} to construct .NET worker path: {1}.",
+                    WorkerVerDirEnvVarName,
+                    _workerPath);
                 return _workerPath;
             }
 
@@ -127,7 +130,10 @@ namespace Microsoft.Spark.Services
             if (!string.IsNullOrEmpty(workerDir))
             {
                 _workerPath = Path.Combine(workerDir, ProcFileName);
-                _logger.LogDebug($"Using the environment variable {WorkerDirEnvVarName} to construct .NET worker path: {_workerPath}.");
+                _logger.LogDebug(
+                    "Using the environment variable {0} to construct .NET worker path: {1}.",
+                    WorkerDirEnvVarName,
+                    _workerPath);
                 return _workerPath;
             }
 


### PR DESCRIPTION
Update how the `ConfigurationService.GetWorkerExePath` is constructed.

Add a new environment variable, `DOTNET_WORKER_<ver>_DIR` where `ver` can be any of the following (built using the version of the `Microsoft.Spark` assembly):
- major_minor_build
- major_minor
- major

The above listing will take precedence when constructing the worker path (higher item has more precedence).  If it is not set, then fall back to original behavior (use `DOTNET_WORKER_DIR` if it is set, otherwise return the worker process name and expect it to exist in `PATH`).