### PR TITLE
Add spark.dotnet.ignoreSparkPatchVersionCheck conf to ignore patch version in DotnetRunner

### DIFF
--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val sparkMajorMinorVersionPrefix = "2.3."
+  private val supportedSparkMajorMinorVersionPrefix = "2.3"
   private val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -48,7 +48,7 @@ object DotnetRunner extends Logging {
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
       SPARK_VERSION,
-      sparkMajorMinorVersionPrefix,
+      supportedSparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 
     val settings = initializeSettings(args)

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -34,6 +35,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
+  private val supportedSparkMajorMinorVersion = List("2", "3")
   private val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -43,7 +45,8 @@ object DotnetRunner extends Logging {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    validateSparkVersions
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    validateSparkVersions(conf)
 
     val settings = initializeSettings(args)
 
@@ -164,12 +167,18 @@ object DotnetRunner extends Logging {
     }
   }
 
-  private def validateSparkVersions: Unit = {
-    if (!supportedSparkVersions(SPARK_VERSION)) {
+  private def validateSparkVersions(conf: SparkConf): Unit = {
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
+    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported spark major.minor version: $majorMinorVersion")
+    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: ${SPARK_VERSION}." +
-          s" Supported versions: ${supportedVersions}")
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -37,6 +37,8 @@ object DotnetRunner extends Logging {
   private val sparkMajorMinorVersionPrefix = "2.3."
   private val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
+  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
+
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
@@ -45,6 +47,7 @@ object DotnetRunner extends Logging {
     DotnetUtils.validateSparkVersions(
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
+      SPARK_VERSION,
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -45,7 +46,11 @@ object DotnetRunner extends Logging {
     }
 
     DotnetUtils.validateSparkVersions(
-      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      sys.props
+        .getOrElse(
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.key,
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.defaultValue.get.toString)
+        .toBoolean,
       spark.SPARK_VERSION,
       SPARK_VERSION,
       supportedSparkMajorMinorVersionPrefix,

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -11,4 +11,8 @@ import org.apache.spark.internal.config.ConfigBuilder
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
     .createWithDefault(10)
+
+  val DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK =
+    ConfigBuilder("spark.dotnet.ignoreSparkPatchVersionCheck").booleanConf
+      .createWithDefault(false)
 }

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -202,27 +202,27 @@ object Utils extends Logging {
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
-   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
       normalizedSparkVersion: String,
-      sparkMajorMinorVersionPrefix: String,
+      supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
-    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+    if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
         s"Unsupported spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
     } else if (ignorePatchVersion) {
       logWarning(
         s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -196,39 +196,37 @@ object Utils extends Logging {
   /**
    * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
-   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *   - If ignoreSparkPatchVersion is
    *     - true: valid
    *     - false: check if the spark version is in supportedSparkVersions.
-   * @param conf Spark conf.
+   * @param ignoreSparkPatchVersion Ignore spark patch version.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
    * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
-      conf: SparkConf,
+      ignoreSparkPatchVersion: Boolean,
       sparkVersion: String,
       normalizedSparkVersion: String,
       supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-
     if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
-    } else if (ignorePatchVersion) {
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported spark major.minor version: '$supportedSparkMajorMinorVersionPrefix'.")
+    } else if (ignoreSparkPatchVersion) {
       logWarning(
-        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
+        s"Ignoring spark patch version. Spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Spark major.minor prefix used: '$supportedSparkMajorMinorVersionPrefix'.")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported versions: $supportedVersions")
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported versions: '$supportedVersions'.")
     }
   }
 

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -201,15 +201,16 @@ object Utils extends Logging {
    *     - false: check if the spark version is in supportedSparkVersions.
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
+   * @param normalizedSparkVersion: The normalized spark version.
    * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
+      normalizedSparkVersion: String,
       sparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
     if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -194,7 +194,7 @@ object Utils extends Logging {
   }
 
   /**
-   * Validates the spark version by verifying:
+   * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
    *   - If ignoreSparkPatchVersionCheck spark conf is
    *     - true: valid

--- a/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -17,15 +17,12 @@ class UtilsTest {
 
   @Test
   def shouldIgnorePatchVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
-
     val sparkVersion = "2.3.5"
     val sparkMajorMinorVersionPrefix = "2.3"
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
     Utils.validateSparkVersions(
-      conf,
+      true,
       sparkVersion,
       Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
@@ -34,9 +31,6 @@ class UtilsTest {
 
   @Test
   def shouldThrowForUnsupportedVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "2.3.5"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.3"
@@ -47,7 +41,7 @@ class UtilsTest {
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
-            conf,
+            false,
             sparkVersion,
             normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
@@ -56,17 +50,14 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported versions: '${supportedSparkVersions.toSeq.sorted.mkString(", ")}'.",
       exception.getMessage)
   }
 
   @Test
   def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.3"
@@ -77,7 +68,7 @@ class UtilsTest {
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
-            conf,
+            false,
             sparkVersion,
             normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
@@ -86,9 +77,9 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported spark major.minor version: '$sparkMajorMinorVersionPrefix'.",
       exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -27,6 +27,7 @@ class UtilsTest {
     Utils.validateSparkVersions(
       conf,
       sparkVersion,
+      Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
   }
@@ -47,6 +48,7 @@ class UtilsTest {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
+            Utils.normalizeSparkVersion(sparkVersion),
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
@@ -69,6 +71,7 @@ class UtilsTest {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
+            Utils.normalizeSparkVersion(sparkVersion),
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }

--- a/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -8,7 +8,7 @@ package org.apache.spark.util.dotnet
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
-import org.junit.Assert.assertThrows
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 import org.junit.function.ThrowingRunnable
 
@@ -38,21 +38,28 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "2.3.5"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.3."
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
-            Utils.normalizeSparkVersion(sparkVersion),
+            normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      exception.getMessage)
   }
 
   @Test
@@ -61,20 +68,27 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "2.4.4"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.3."
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
-            Utils.normalizeSparkVersion(sparkVersion),
+            normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -21,7 +21,7 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
 
     val sparkVersion = "2.3.5"
-    val sparkMajorMinorVersionPrefix = "2.3."
+    val sparkMajorMinorVersionPrefix = "2.3"
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
     Utils.validateSparkVersions(
@@ -39,7 +39,7 @@ class UtilsTest {
 
     val sparkVersion = "2.3.5"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "2.3."
+    val sparkMajorMinorVersionPrefix = "2.3"
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
     val exception = assertThrows(
@@ -69,7 +69,7 @@ class UtilsTest {
 
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "2.3."
+    val sparkMajorMinorVersionPrefix = "2.3"
     val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
 
     val exception = assertThrows(

--- a/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-3/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.util.dotnet
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.function.ThrowingRunnable
+
+@Test
+class UtilsTest {
+
+  @Test
+  def shouldIgnorePatchVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
+
+    val sparkVersion = "2.3.5"
+    val sparkMajorMinorVersionPrefix = "2.3."
+    val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
+
+    Utils.validateSparkVersions(
+      conf,
+      sparkVersion,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
+  }
+
+  @Test
+  def shouldThrowForUnsupportedVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "2.3.5"
+    val sparkMajorMinorVersionPrefix = "2.3."
+    val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new ThrowingRunnable {
+        override def run(): Unit = {
+          Utils.validateSparkVersions(
+            conf,
+            sparkVersion,
+            sparkMajorMinorVersionPrefix,
+            supportedSparkVersions)
+        }
+      })
+  }
+
+  @Test
+  def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "2.4.4"
+    val sparkMajorMinorVersionPrefix = "2.3."
+    val supportedSparkVersions = Set[String]("2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4")
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new ThrowingRunnable {
+        override def run(): Unit = {
+          Utils.validateSparkVersions(
+            conf,
+            sparkVersion,
+            sparkMajorMinorVersionPrefix,
+            supportedSparkVersions)
+        }
+      })
+  }
+}

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -34,6 +35,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
+  private val supportedSparkMajorMinorVersion = List("2", "4")
   private val supportedSparkVersions =
     Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
@@ -44,7 +46,8 @@ object DotnetRunner extends Logging {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    validateSparkVersions
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    validateSparkVersions(conf)
 
     val settings = initializeSettings(args)
 
@@ -165,12 +168,18 @@ object DotnetRunner extends Logging {
     }
   }
 
-  private def validateSparkVersions: Unit = {
-    if (!supportedSparkVersions(SPARK_VERSION)) {
+  private def validateSparkVersions(conf: SparkConf): Unit = {
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
+    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported spark major.minor version: $majorMinorVersion")
+    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: ${SPARK_VERSION}." +
-          s" Supported versions: ${supportedVersions}")
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -46,7 +47,11 @@ object DotnetRunner extends Logging {
     }
 
     DotnetUtils.validateSparkVersions(
-      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      sys.props
+        .getOrElse(
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.key,
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.defaultValue.get.toString)
+        .toBoolean,
       spark.SPARK_VERSION,
       SPARK_VERSION,
       supportedSparkMajorMinorVersionPrefix,

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -38,6 +38,8 @@ object DotnetRunner extends Logging {
   private val supportedSparkVersions =
     Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
+  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
+
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
@@ -46,6 +48,7 @@ object DotnetRunner extends Logging {
     DotnetUtils.validateSparkVersions(
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
+      SPARK_VERSION,
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,7 +19,6 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
@@ -35,19 +34,20 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val supportedSparkMajorMinorVersion = List("2", "4")
+  private val sparkMajorMinorVersionPrefix = "2.4."
   private val supportedSparkVersions =
     Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
-
-  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    validateSparkVersions(conf)
+    DotnetUtils.validateSparkVersions(
+      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      spark.SPARK_VERSION,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
 
     val settings = initializeSettings(args)
 
@@ -165,21 +165,6 @@ object DotnetRunner extends Logging {
     } else {
       logError(s"DotnetBackend did not initialize in $backendTimeout seconds")
       DotnetUtils.exit(-1)
-    }
-  }
-
-  private def validateSparkVersions(conf: SparkConf): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
-    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported spark major.minor version: $majorMinorVersion")
-    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
-      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val sparkMajorMinorVersionPrefix = "2.4."
+  private val supportedSparkMajorMinorVersionPrefix = "2.4"
   private val supportedSparkVersions =
     Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
@@ -49,7 +49,7 @@ object DotnetRunner extends Logging {
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
       SPARK_VERSION,
-      sparkMajorMinorVersionPrefix,
+      supportedSparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 
     val settings = initializeSettings(args)

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -11,4 +11,8 @@ import org.apache.spark.internal.config.ConfigBuilder
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
     .createWithDefault(10)
+
+  val DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK =
+    ConfigBuilder("spark.dotnet.ignoreSparkPatchVersionCheck").booleanConf
+      .createWithDefault(false)
 }

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -193,7 +193,7 @@ object Utils extends Logging {
   }
 
   /**
-   * Validates the spark version by verifying:
+   * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
    *   - If ignoreSparkPatchVersionCheck spark conf is
    *     - true: valid

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -201,27 +201,27 @@ object Utils extends Logging {
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
-   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
       normalizedSparkVersion: String,
-      sparkMajorMinorVersionPrefix: String,
+      supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
-    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+    if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
         s"Unsupported spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
     } else if (ignorePatchVersion) {
       logWarning(
         s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -195,39 +195,37 @@ object Utils extends Logging {
   /**
    * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
-   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *   - If ignoreSparkPatchVersion is
    *     - true: valid
    *     - false: check if the spark version is in supportedSparkVersions.
-   * @param conf Spark conf.
+   * @param ignoreSparkPatchVersion Ignore spark patch version.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
    * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
-      conf: SparkConf,
+      ignoreSparkPatchVersion: Boolean,
       sparkVersion: String,
       normalizedSparkVersion: String,
       supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-
     if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
-    } else if (ignorePatchVersion) {
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported spark major.minor version: '$supportedSparkMajorMinorVersionPrefix'.")
+    } else if (ignoreSparkPatchVersion) {
       logWarning(
-        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
+        s"Ignoring spark patch version. Spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Spark major.minor prefix used: '$supportedSparkMajorMinorVersionPrefix'.")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported versions: $supportedVersions")
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported versions: '$supportedVersions'.")
     }
   }
 

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -14,7 +14,9 @@ import java.util.{Timer, TimerTask}
 
 import org.apache.commons.compress.archivers.zip.{ZipArchiveEntry, ZipArchiveOutputStream, ZipFile}
 import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 
 import scala.collection.JavaConverters._
 import scala.collection.Set
@@ -188,6 +190,44 @@ object Utils extends Logging {
         }
       })
       .mkString(".")
+  }
+
+  /**
+   * Validates the spark version by verifying:
+   *   - Spark version starts with sparkMajorMinorVersionPrefix.
+   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *     - true: valid
+   *     - false: check if the spark version is in supportedSparkVersions.
+   * @param conf Spark conf.
+   * @param sparkVersion The spark version.
+   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkVersions The set of supported spark versions.
+   */
+  def validateSparkVersions(
+      conf: SparkConf,
+      sparkVersion: String,
+      sparkMajorMinorVersionPrefix: String,
+      supportedSparkVersions: Set[String]): Unit = {
+    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+
+    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+    } else if (ignorePatchVersion) {
+      logWarning(
+        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+    } else if (!supportedSparkVersions(normalizedSparkVersion)) {
+      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported versions: $supportedVersions")
+    }
   }
 
   private[spark] def listZipFileEntries(file: File): Array[String] = {

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -200,15 +200,16 @@ object Utils extends Logging {
    *     - false: check if the spark version is in supportedSparkVersions.
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
+   * @param normalizedSparkVersion: The normalized spark version.
    * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
+      normalizedSparkVersion: String,
       sparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
     if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {

--- a/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.util.dotnet
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.function.ThrowingRunnable
+
+@Test
+class UtilsTest {
+
+  @Test
+  def shouldIgnorePatchVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
+
+    val sparkVersion = "2.4.8"
+    val sparkMajorMinorVersionPrefix = "2.4."
+    val supportedSparkVersions =
+      Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
+
+    Utils.validateSparkVersions(
+      conf,
+      sparkVersion,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
+  }
+
+  @Test
+  def shouldThrowForUnsupportedVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "2.4.8"
+    val sparkMajorMinorVersionPrefix = "2.4."
+    val supportedSparkVersions =
+      Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new ThrowingRunnable {
+        override def run(): Unit = {
+          Utils.validateSparkVersions(
+            conf,
+            sparkVersion,
+            sparkMajorMinorVersionPrefix,
+            supportedSparkVersions)
+        }
+      })
+  }
+
+  @Test
+  def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "3.0.2"
+    val sparkMajorMinorVersionPrefix = "2.4."
+    val supportedSparkVersions =
+      Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new ThrowingRunnable {
+        override def run(): Unit = {
+          Utils.validateSparkVersions(
+            conf,
+            sparkVersion,
+            sparkMajorMinorVersionPrefix,
+            supportedSparkVersions)
+        }
+      })
+  }
+}

--- a/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -8,7 +8,7 @@ package org.apache.spark.util.dotnet
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
-import org.junit.Assert.assertThrows
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 import org.junit.function.ThrowingRunnable
 
@@ -39,22 +39,29 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "2.4.8"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.4."
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
-            Utils.normalizeSparkVersion(sparkVersion),
+            normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      exception.getMessage)
   }
 
   @Test
@@ -63,21 +70,28 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "3.0.2"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.4."
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
-            Utils.normalizeSparkVersion(sparkVersion),
+            normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -28,6 +28,7 @@ class UtilsTest {
     Utils.validateSparkVersions(
       conf,
       sparkVersion,
+      Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
   }
@@ -49,6 +50,7 @@ class UtilsTest {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
+            Utils.normalizeSparkVersion(sparkVersion),
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }
@@ -72,6 +74,7 @@ class UtilsTest {
           Utils.validateSparkVersions(
             conf,
             sparkVersion,
+            Utils.normalizeSparkVersion(sparkVersion),
             sparkMajorMinorVersionPrefix,
             supportedSparkVersions)
         }

--- a/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -17,16 +17,13 @@ class UtilsTest {
 
   @Test
   def shouldIgnorePatchVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
-
     val sparkVersion = "2.4.8"
     val sparkMajorMinorVersionPrefix = "2.4"
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
     Utils.validateSparkVersions(
-      conf,
+      true,
       sparkVersion,
       Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
@@ -35,9 +32,6 @@ class UtilsTest {
 
   @Test
   def shouldThrowForUnsupportedVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "2.4.8"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.4"
@@ -49,7 +43,7 @@ class UtilsTest {
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
-            conf,
+            false,
             sparkVersion,
             normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
@@ -58,17 +52,14 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported versions: '${supportedSparkVersions.toSeq.sorted.mkString(", ")}'.",
       exception.getMessage)
   }
 
   @Test
   def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "3.0.2"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "2.4"
@@ -80,7 +71,7 @@ class UtilsTest {
       new ThrowingRunnable {
         override def run(): Unit = {
           Utils.validateSparkVersions(
-            conf,
+            false,
             sparkVersion,
             normalizedSparkVersion,
             sparkMajorMinorVersionPrefix,
@@ -89,9 +80,9 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported spark major.minor version: '$sparkMajorMinorVersionPrefix'.",
       exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-2-4/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -21,7 +21,7 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
 
     val sparkVersion = "2.4.8"
-    val sparkMajorMinorVersionPrefix = "2.4."
+    val sparkMajorMinorVersionPrefix = "2.4"
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
@@ -40,7 +40,7 @@ class UtilsTest {
 
     val sparkVersion = "2.4.8"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "2.4."
+    val sparkMajorMinorVersionPrefix = "2.4"
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 
@@ -71,7 +71,7 @@ class UtilsTest {
 
     val sparkVersion = "3.0.2"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "2.4."
+    val sparkMajorMinorVersionPrefix = "2.4"
     val supportedSparkVersions =
       Set[String]("2.4.0", "2.4.1", "2.4.3", "2.4.4", "2.4.5", "2.4.6", "2.4.7")
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -34,6 +35,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
+  private val supportedSparkMajorMinorVersion = List("3", "0")
   private val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -43,7 +45,8 @@ object DotnetRunner extends Logging {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    validateSparkVersions
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    validateSparkVersions(conf)
 
     val settings = initializeSettings(args)
 
@@ -164,12 +167,18 @@ object DotnetRunner extends Logging {
     }
   }
 
-  private def validateSparkVersions: Unit = {
-    if (!supportedSparkVersions(SPARK_VERSION)) {
+  private def validateSparkVersions(conf: SparkConf): Unit = {
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
+    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported spark major.minor version: $majorMinorVersion")
+    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: ${SPARK_VERSION}." +
-          s" Supported versions: ${supportedVersions}")
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -37,6 +37,8 @@ object DotnetRunner extends Logging {
   private val sparkMajorMinorVersionPrefix = "3.0."
   private val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
+  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
+
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
@@ -45,6 +47,7 @@ object DotnetRunner extends Logging {
     DotnetUtils.validateSparkVersions(
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
+      SPARK_VERSION,
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val sparkMajorMinorVersionPrefix = "3.0."
+  private val supportedSparkMajorMinorVersionPrefix = "3.0"
   private val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -48,7 +48,7 @@ object DotnetRunner extends Logging {
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
       SPARK_VERSION,
-      sparkMajorMinorVersionPrefix,
+      supportedSparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 
     val settings = initializeSettings(args)

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -45,7 +46,11 @@ object DotnetRunner extends Logging {
     }
 
     DotnetUtils.validateSparkVersions(
-      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      sys.props
+        .getOrElse(
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.key,
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.defaultValue.get.toString)
+        .toBoolean,
       spark.SPARK_VERSION,
       SPARK_VERSION,
       supportedSparkMajorMinorVersionPrefix,

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,7 +19,6 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
@@ -35,18 +34,19 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val supportedSparkMajorMinorVersion = List("3", "0")
+  private val sparkMajorMinorVersionPrefix = "3.0."
   private val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
-
-  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    validateSparkVersions(conf)
+    DotnetUtils.validateSparkVersions(
+      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      spark.SPARK_VERSION,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
 
     val settings = initializeSettings(args)
 
@@ -164,21 +164,6 @@ object DotnetRunner extends Logging {
     } else {
       logError(s"DotnetBackend did not initialize in $backendTimeout seconds")
       DotnetUtils.exit(-1)
-    }
-  }
-
-  private def validateSparkVersions(conf: SparkConf): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
-    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported spark major.minor version: $majorMinorVersion")
-    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
-      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -11,4 +11,8 @@ import org.apache.spark.internal.config.ConfigBuilder
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
     .createWithDefault(10)
+
+  val DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK =
+    ConfigBuilder("spark.dotnet.ignoreSparkPatchVersionCheck").booleanConf
+      .createWithDefault(false)
 }

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -193,7 +193,7 @@ object Utils extends Logging {
   }
 
   /**
-   * Validates the spark version by verifying:
+   * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
    *   - If ignoreSparkPatchVersionCheck spark conf is
    *     - true: valid

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -201,27 +201,27 @@ object Utils extends Logging {
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
-   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
       normalizedSparkVersion: String,
-      sparkMajorMinorVersionPrefix: String,
+      supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
-    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+    if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
         s"Unsupported spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
     } else if (ignorePatchVersion) {
       logWarning(
         s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -195,39 +195,37 @@ object Utils extends Logging {
   /**
    * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
-   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *   - If ignoreSparkPatchVersion is
    *     - true: valid
    *     - false: check if the spark version is in supportedSparkVersions.
-   * @param conf Spark conf.
+   * @param ignoreSparkPatchVersion Ignore spark patch version.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
    * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
-      conf: SparkConf,
+      ignoreSparkPatchVersion: Boolean,
       sparkVersion: String,
       normalizedSparkVersion: String,
       supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-
     if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
-    } else if (ignorePatchVersion) {
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported spark major.minor version: '$supportedSparkMajorMinorVersionPrefix'.")
+    } else if (ignoreSparkPatchVersion) {
       logWarning(
-        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
+        s"Ignoring spark patch version. Spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Spark major.minor prefix used: '$supportedSparkMajorMinorVersionPrefix'.")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported versions: $supportedVersions")
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported versions: '$supportedVersions'.")
     }
   }
 

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -192,23 +192,24 @@ object Utils extends Logging {
       .mkString(".")
   }
 
-    /**
-     * Validates the spark version by verifying:
-     *   - Spark version starts with sparkMajorMinorVersionPrefix.
-     *   - If ignoreSparkPatchVersionCheck spark conf is
-     *     - true: valid
-     *     - false: check if the spark version is in supportedSparkVersions.
-     * @param conf Spark conf.
-     * @param sparkVersion The spark version.
-     * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
-     * @param supportedSparkVersions The set of supported spark versions.
-     */
+  /**
+   * Validates the spark version by verifying:
+   *   - Spark version starts with sparkMajorMinorVersionPrefix.
+   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *     - true: valid
+   *     - false: check if the spark version is in supportedSparkVersions.
+   * @param conf Spark conf.
+   * @param sparkVersion The spark version.
+   * @param normalizedSparkVersion: The normalized spark version.
+   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkVersions The set of supported spark versions.
+   */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
+      normalizedSparkVersion: String,
       sparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
     if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -14,7 +14,9 @@ import java.util.{Timer, TimerTask}
 
 import org.apache.commons.compress.archivers.zip.{ZipArchiveEntry, ZipArchiveOutputStream, ZipFile}
 import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 
 import scala.collection.JavaConverters._
 import scala.collection.Set
@@ -188,6 +190,44 @@ object Utils extends Logging {
         }
       })
       .mkString(".")
+  }
+
+    /**
+     * Validates the spark version by verifying:
+     *   - Spark version starts with sparkMajorMinorVersionPrefix.
+     *   - If ignoreSparkPatchVersionCheck spark conf is
+     *     - true: valid
+     *     - false: check if the spark version is in supportedSparkVersions.
+     * @param conf Spark conf.
+     * @param sparkVersion The spark version.
+     * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+     * @param supportedSparkVersions The set of supported spark versions.
+     */
+  def validateSparkVersions(
+      conf: SparkConf,
+      sparkVersion: String,
+      sparkMajorMinorVersionPrefix: String,
+      supportedSparkVersions: Set[String]): Unit = {
+    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+
+    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+    } else if (ignorePatchVersion) {
+      logWarning(
+        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+    } else if (!supportedSparkVersions(normalizedSparkVersion)) {
+      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported versions: $supportedVersions")
+    }
   }
 
   private[spark] def listZipFileEntries(file: File): Array[String] = {

--- a/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -26,6 +26,7 @@ class UtilsTest {
     Utils.validateSparkVersions(
       conf,
       sparkVersion,
+      Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
   }
@@ -39,13 +40,16 @@ class UtilsTest {
     val sparkMajorMinorVersionPrefix = "3.0."
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
-    assertThrows(classOf[IllegalArgumentException], () => {
-      Utils.validateSparkVersions(
-        conf,
-        sparkVersion,
-        sparkMajorMinorVersionPrefix,
-        supportedSparkVersions)
-    })
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Utils.validateSparkVersions(
+          conf,
+          sparkVersion,
+          Utils.normalizeSparkVersion(sparkVersion),
+          sparkMajorMinorVersionPrefix,
+          supportedSparkVersions)
+      })
   }
 
   @Test
@@ -57,12 +61,15 @@ class UtilsTest {
     val sparkMajorMinorVersionPrefix = "3.0."
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
-    assertThrows(classOf[IllegalArgumentException], () => {
-      Utils.validateSparkVersions(
-        conf,
-        sparkVersion,
-        sparkMajorMinorVersionPrefix,
-        supportedSparkVersions)
-    })
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Utils.validateSparkVersions(
+          conf,
+          sparkVersion,
+          Utils.normalizeSparkVersion(sparkVersion),
+          sparkMajorMinorVersionPrefix,
+          supportedSparkVersions)
+      })
   }
 }

--- a/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -16,15 +16,12 @@ class UtilsTest {
 
   @Test
   def shouldIgnorePatchVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
-
     val sparkVersion = "3.0.3"
     val sparkMajorMinorVersionPrefix = "3.0"
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
     Utils.validateSparkVersions(
-      conf,
+      true,
       sparkVersion,
       Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
@@ -33,9 +30,6 @@ class UtilsTest {
 
   @Test
   def shouldThrowForUnsupportedVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "3.0.3"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.0"
@@ -45,7 +39,7 @@ class UtilsTest {
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
-          conf,
+          false,
           sparkVersion,
           normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
@@ -53,17 +47,14 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported versions: '${supportedSparkVersions.toSeq.sorted.mkString(", ")}'.",
       exception.getMessage)
   }
 
   @Test
   def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.0"
@@ -73,7 +64,7 @@ class UtilsTest {
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
-          conf,
+          false,
           sparkVersion,
           normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
@@ -81,9 +72,9 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported spark major.minor version: '$sparkMajorMinorVersionPrefix'.",
       exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -20,7 +20,7 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
 
     val sparkVersion = "3.0.3"
-    val sparkMajorMinorVersionPrefix = "3.0."
+    val sparkMajorMinorVersionPrefix = "3.0"
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
     Utils.validateSparkVersions(
@@ -38,7 +38,7 @@ class UtilsTest {
 
     val sparkVersion = "3.0.3"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "3.0."
+    val sparkMajorMinorVersionPrefix = "3.0"
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
     val exception = assertThrows(
@@ -66,7 +66,7 @@ class UtilsTest {
 
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "3.0."
+    val sparkMajorMinorVersionPrefix = "3.0"
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
     val exception = assertThrows(

--- a/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.util.dotnet
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+@Test
+class UtilsTest {
+
+  @Test
+  def shouldIgnorePatchVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
+
+    val sparkVersion = "3.0.3"
+    val sparkMajorMinorVersionPrefix = "3.0."
+    val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
+
+    Utils.validateSparkVersions(
+      conf,
+      sparkVersion,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
+  }
+
+  @Test
+  def shouldThrowForUnsupportedVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "3.0.3"
+    val sparkMajorMinorVersionPrefix = "3.0."
+    val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
+
+    assertThrows(classOf[IllegalArgumentException], () => {
+      Utils.validateSparkVersions(
+        conf,
+        sparkVersion,
+        sparkMajorMinorVersionPrefix,
+        supportedSparkVersions)
+    })
+  }
+
+  @Test
+  def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "2.4.4"
+    val sparkMajorMinorVersionPrefix = "3.0."
+    val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
+
+    assertThrows(classOf[IllegalArgumentException], () => {
+      Utils.validateSparkVersions(
+        conf,
+        sparkVersion,
+        sparkMajorMinorVersionPrefix,
+        supportedSparkVersions)
+    })
+  }
+}

--- a/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-0/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -8,7 +8,7 @@ package org.apache.spark.util.dotnet
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
-import org.junit.Assert.assertThrows
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 
 @Test
@@ -37,19 +37,26 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "3.0.3"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.0."
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
           conf,
           sparkVersion,
-          Utils.normalizeSparkVersion(sparkVersion),
+          normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
           supportedSparkVersions)
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      exception.getMessage)
   }
 
   @Test
@@ -58,18 +65,25 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "2.4.4"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.0."
     val supportedSparkVersions = Set[String]("3.0.0", "3.0.1", "3.0.2")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
           conf,
           sparkVersion,
-          Utils.normalizeSparkVersion(sparkVersion),
+          normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
           supportedSparkVersions)
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -34,6 +35,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
+  private val supportedSparkMajorMinorVersion = List("3", "1")
   private val supportedSparkVersions = Set[String]("3.1.1")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -43,7 +45,8 @@ object DotnetRunner extends Logging {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    validateSparkVersions
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    validateSparkVersions(conf)
 
     val settings = initializeSettings(args)
 
@@ -164,12 +167,18 @@ object DotnetRunner extends Logging {
     }
   }
 
-  private def validateSparkVersions: Unit = {
-    if (!supportedSparkVersions(SPARK_VERSION)) {
+  private def validateSparkVersions(conf: SparkConf): Unit = {
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
+    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported spark major.minor version: $majorMinorVersion")
+    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: ${SPARK_VERSION}." +
-          s" Supported versions: ${supportedVersions}")
+        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
+          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -34,7 +34,7 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val sparkMajorMinorVersionPrefix = "3.1."
+  private val supportedSparkMajorMinorVersionPrefix = "3.1"
   private val supportedSparkVersions = Set[String]("3.1.1")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
@@ -48,7 +48,7 @@ object DotnetRunner extends Logging {
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
       SPARK_VERSION,
-      sparkMajorMinorVersionPrefix,
+      supportedSparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 
     val settings = initializeSettings(args)

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -37,6 +37,8 @@ object DotnetRunner extends Logging {
   private val sparkMajorMinorVersionPrefix = "3.1."
   private val supportedSparkVersions = Set[String]("3.1.1")
 
+  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
+
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
@@ -45,6 +47,7 @@ object DotnetRunner extends Logging {
     DotnetUtils.validateSparkVersions(
       Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
       spark.SPARK_VERSION,
+      SPARK_VERSION,
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
 

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,7 +19,6 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
@@ -35,18 +34,19 @@ import scala.util.Try
  */
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
-  private val supportedSparkMajorMinorVersion = List("3", "1")
+  private val sparkMajorMinorVersionPrefix = "3.1."
   private val supportedSparkVersions = Set[String]("3.1.1")
-
-  val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
       throw new IllegalArgumentException("At least one argument is expected.")
     }
 
-    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    validateSparkVersions(conf)
+    DotnetUtils.validateSparkVersions(
+      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      spark.SPARK_VERSION,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
 
     val settings = initializeSettings(args)
 
@@ -164,21 +164,6 @@ object DotnetRunner extends Logging {
     } else {
       logError(s"DotnetBackend did not initialize in $backendTimeout seconds")
       DotnetUtils.exit(-1)
-    }
-  }
-
-  private def validateSparkVersions(conf: SparkConf): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-    val majorMinorVersion = supportedSparkMajorMinorVersion.mkString("", ".", ".")
-    if (!SPARK_VERSION.startsWith(majorMinorVersion)) {
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported spark major.minor version: $majorMinorVersion")
-    } else if (!ignorePatchVersion && !supportedSparkVersions(SPARK_VERSION)) {
-      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
-      throw new IllegalArgumentException(
-        s"Unsupported spark version used: ${spark.SPARK_VERSION}. Normalized spark version used: $SPARK_VERSION." +
-          s" Supported versions: $supportedVersions")
     }
   }
 

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -19,9 +19,10 @@ import org.apache.spark
 import org.apache.spark.api.dotnet.DotnetBackend
 import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 import org.apache.spark.util.dotnet.{Utils => DotnetUtils}
 import org.apache.spark.util.{RedirectThread, Utils}
-import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkUserAppException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkUserAppException}
 
 import scala.collection.JavaConverters._
 import scala.io.StdIn
@@ -45,7 +46,11 @@ object DotnetRunner extends Logging {
     }
 
     DotnetUtils.validateSparkVersions(
-      Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf()),
+      sys.props
+        .getOrElse(
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.key,
+          DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK.defaultValue.get.toString)
+        .toBoolean,
       spark.SPARK_VERSION,
       SPARK_VERSION,
       supportedSparkMajorMinorVersionPrefix,

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -11,4 +11,8 @@ import org.apache.spark.internal.config.ConfigBuilder
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf
     .createWithDefault(10)
+
+  val DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK =
+    ConfigBuilder("spark.dotnet.ignoreSparkPatchVersionCheck").booleanConf
+      .createWithDefault(false)
 }

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -193,7 +193,7 @@ object Utils extends Logging {
   }
 
   /**
-   * Validates the spark version by verifying:
+   * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
    *   - If ignoreSparkPatchVersionCheck spark conf is
    *     - true: valid

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -201,27 +201,27 @@ object Utils extends Logging {
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
-   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
       normalizedSparkVersion: String,
-      sparkMajorMinorVersionPrefix: String,
+      supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
-    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+    if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
         s"Unsupported spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
     } else if (ignorePatchVersion) {
       logWarning(
         s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
           s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -195,39 +195,37 @@ object Utils extends Logging {
   /**
    * Validates the normalized spark version by verifying:
    *   - Spark version starts with sparkMajorMinorVersionPrefix.
-   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *   - If ignoreSparkPatchVersion is
    *     - true: valid
    *     - false: check if the spark version is in supportedSparkVersions.
-   * @param conf Spark conf.
+   * @param ignoreSparkPatchVersion Ignore spark patch version.
    * @param sparkVersion The spark version.
    * @param normalizedSparkVersion: The normalized spark version.
    * @param supportedSparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
-      conf: SparkConf,
+      ignoreSparkPatchVersion: Boolean,
       sparkVersion: String,
       normalizedSparkVersion: String,
       supportedSparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
-
     if (!normalizedSparkVersion.startsWith(s"$supportedSparkMajorMinorVersionPrefix.")) {
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported spark major.minor version: $supportedSparkMajorMinorVersionPrefix")
-    } else if (ignorePatchVersion) {
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported spark major.minor version: '$supportedSparkMajorMinorVersionPrefix'.")
+    } else if (ignoreSparkPatchVersion) {
       logWarning(
-        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Spark major.minor prefix used: $supportedSparkMajorMinorVersionPrefix")
+        s"Ignoring spark patch version. Spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Spark major.minor prefix used: '$supportedSparkMajorMinorVersionPrefix'.")
     } else if (!supportedSparkVersions(normalizedSparkVersion)) {
       val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
       throw new IllegalArgumentException(
-        s"Unsupported spark version used: $sparkVersion. " +
-          s"Normalized spark version used: $normalizedSparkVersion. " +
-          s"Supported versions: $supportedVersions")
+        s"Unsupported spark version used: '$sparkVersion'. " +
+          s"Normalized spark version used: '$normalizedSparkVersion'. " +
+          s"Supported versions: '$supportedVersions'.")
     }
   }
 

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -14,7 +14,9 @@ import java.util.{Timer, TimerTask}
 
 import org.apache.commons.compress.archivers.zip.{ZipArchiveEntry, ZipArchiveOutputStream, ZipFile}
 import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
 
 import scala.collection.JavaConverters._
 import scala.collection.Set
@@ -188,6 +190,44 @@ object Utils extends Logging {
         }
       })
       .mkString(".")
+  }
+
+  /**
+   * Validates the spark version by verifying:
+   *   - Spark version starts with sparkMajorMinorVersionPrefix.
+   *   - If ignoreSparkPatchVersionCheck spark conf is
+   *     - true: valid
+   *     - false: check if the spark version is in supportedSparkVersions.
+   * @param conf Spark conf.
+   * @param sparkVersion The spark version.
+   * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
+   * @param supportedSparkVersions The set of supported spark versions.
+   */
+  def validateSparkVersions(
+      conf: SparkConf,
+      sparkVersion: String,
+      sparkMajorMinorVersionPrefix: String,
+      supportedSparkVersions: Set[String]): Unit = {
+    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
+    val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
+
+    if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix")
+    } else if (ignorePatchVersion) {
+      logWarning(
+        s"Ignoring spark patch version. Spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Spark major.minor prefix used: $sparkMajorMinorVersionPrefix")
+    } else if (!supportedSparkVersions(normalizedSparkVersion)) {
+      val supportedVersions = supportedSparkVersions.toSeq.sorted.mkString(", ")
+      throw new IllegalArgumentException(
+        s"Unsupported spark version used: $sparkVersion. " +
+          s"Normalized spark version used: $normalizedSparkVersion. " +
+          s"Supported versions: $supportedVersions")
+    }
   }
 
   private[spark] def listZipFileEntries(file: File): Array[String] = {

--- a/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
+++ b/src/scala/microsoft-spark-3-1/src/main/scala/org/apache/spark/util/dotnet/Utils.scala
@@ -200,15 +200,16 @@ object Utils extends Logging {
    *     - false: check if the spark version is in supportedSparkVersions.
    * @param conf Spark conf.
    * @param sparkVersion The spark version.
+   * @param normalizedSparkVersion: The normalized spark version.
    * @param sparkMajorMinorVersionPrefix The spark major and minor version to validate against.
    * @param supportedSparkVersions The set of supported spark versions.
    */
   def validateSparkVersions(
       conf: SparkConf,
       sparkVersion: String,
+      normalizedSparkVersion: String,
       sparkMajorMinorVersionPrefix: String,
       supportedSparkVersions: Set[String]): Unit = {
-    val normalizedSparkVersion = normalizeSparkVersion(sparkVersion)
     val ignorePatchVersion = conf.get(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK)
 
     if (!normalizedSparkVersion.startsWith(sparkMajorMinorVersionPrefix)) {

--- a/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -26,6 +26,7 @@ class UtilsTest {
     Utils.validateSparkVersions(
       conf,
       sparkVersion,
+      Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
       supportedSparkVersions)
   }
@@ -39,13 +40,16 @@ class UtilsTest {
     val sparkMajorMinorVersionPrefix = "3.1."
     val supportedSparkVersions = Set[String]("3.1.1")
 
-    assertThrows(classOf[IllegalArgumentException], () => {
-      Utils.validateSparkVersions(
-        conf,
-        sparkVersion,
-        sparkMajorMinorVersionPrefix,
-        supportedSparkVersions)
-    })
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Utils.validateSparkVersions(
+          conf,
+          sparkVersion,
+          Utils.normalizeSparkVersion(sparkVersion),
+          sparkMajorMinorVersionPrefix,
+          supportedSparkVersions)
+      })
   }
 
   @Test
@@ -57,12 +61,15 @@ class UtilsTest {
     val sparkMajorMinorVersionPrefix = "3.1."
     val supportedSparkVersions = Set[String]("3.1.1")
 
-    assertThrows(classOf[IllegalArgumentException], () => {
-      Utils.validateSparkVersions(
-        conf,
-        sparkVersion,
-        sparkMajorMinorVersionPrefix,
-        supportedSparkVersions)
-    })
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Utils.validateSparkVersions(
+          conf,
+          sparkVersion,
+          Utils.normalizeSparkVersion(sparkVersion),
+          sparkMajorMinorVersionPrefix,
+          supportedSparkVersions)
+      })
   }
 }

--- a/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.apache.spark.util.dotnet
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+@Test
+class UtilsTest {
+
+  @Test
+  def shouldIgnorePatchVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
+
+    val sparkVersion = "3.1.2"
+    val sparkMajorMinorVersionPrefix = "3.1."
+    val supportedSparkVersions = Set[String]("3.1.1")
+
+    Utils.validateSparkVersions(
+      conf,
+      sparkVersion,
+      sparkMajorMinorVersionPrefix,
+      supportedSparkVersions)
+  }
+
+  @Test
+  def shouldThrowForUnsupportedVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "3.1.2"
+    val sparkMajorMinorVersionPrefix = "3.1."
+    val supportedSparkVersions = Set[String]("3.1.1")
+
+    assertThrows(classOf[IllegalArgumentException], () => {
+      Utils.validateSparkVersions(
+        conf,
+        sparkVersion,
+        sparkMajorMinorVersionPrefix,
+        supportedSparkVersions)
+    })
+  }
+
+  @Test
+  def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
+    val conf = new SparkConf()
+    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
+
+    val sparkVersion = "2.4.4"
+    val sparkMajorMinorVersionPrefix = "3.1."
+    val supportedSparkVersions = Set[String]("3.1.1")
+
+    assertThrows(classOf[IllegalArgumentException], () => {
+      Utils.validateSparkVersions(
+        conf,
+        sparkVersion,
+        sparkMajorMinorVersionPrefix,
+        supportedSparkVersions)
+    })
+  }
+}

--- a/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -16,15 +16,12 @@ class UtilsTest {
 
   @Test
   def shouldIgnorePatchVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
-
     val sparkVersion = "3.1.2"
     val sparkMajorMinorVersionPrefix = "3.1"
     val supportedSparkVersions = Set[String]("3.1.1")
 
     Utils.validateSparkVersions(
-      conf,
+      true,
       sparkVersion,
       Utils.normalizeSparkVersion(sparkVersion),
       sparkMajorMinorVersionPrefix,
@@ -33,9 +30,6 @@ class UtilsTest {
 
   @Test
   def shouldThrowForUnsupportedVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "3.1.2"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.1"
@@ -45,7 +39,7 @@ class UtilsTest {
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
-          conf,
+          false,
           sparkVersion,
           normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
@@ -53,17 +47,14 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported versions: '${supportedSparkVersions.toSeq.sorted.mkString(", ")}'.",
       exception.getMessage)
   }
 
   @Test
   def shouldThrowForUnsupportedMajorMinorVersion(): Unit = {
-    val conf = new SparkConf()
-    conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
-
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.1"
@@ -73,7 +64,7 @@ class UtilsTest {
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
-          conf,
+          false,
           sparkVersion,
           normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
@@ -81,9 +72,9 @@ class UtilsTest {
       })
 
     assertEquals(
-      s"Unsupported spark version used: $sparkVersion. " +
-        s"Normalized spark version used: $normalizedSparkVersion. " +
-        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      s"Unsupported spark version used: '$sparkVersion'. " +
+        s"Normalized spark version used: '$normalizedSparkVersion'. " +
+        s"Supported spark major.minor version: '$sparkMajorMinorVersionPrefix'.",
       exception.getMessage)
   }
 }

--- a/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -20,7 +20,7 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, true)
 
     val sparkVersion = "3.1.2"
-    val sparkMajorMinorVersionPrefix = "3.1."
+    val sparkMajorMinorVersionPrefix = "3.1"
     val supportedSparkVersions = Set[String]("3.1.1")
 
     Utils.validateSparkVersions(
@@ -38,7 +38,7 @@ class UtilsTest {
 
     val sparkVersion = "3.1.2"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "3.1."
+    val sparkMajorMinorVersionPrefix = "3.1"
     val supportedSparkVersions = Set[String]("3.1.1")
 
     val exception = assertThrows(
@@ -66,7 +66,7 @@ class UtilsTest {
 
     val sparkVersion = "2.4.4"
     val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
-    val sparkMajorMinorVersionPrefix = "3.1."
+    val sparkMajorMinorVersionPrefix = "3.1"
     val supportedSparkVersions = Set[String]("3.1.1")
 
     val exception = assertThrows(

--- a/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
+++ b/src/scala/microsoft-spark-3-1/src/test/scala/org/apache/spark/util/dotnet/UtilsTest.scala
@@ -8,7 +8,7 @@ package org.apache.spark.util.dotnet
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK
-import org.junit.Assert.assertThrows
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 
 @Test
@@ -37,19 +37,26 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "3.1.2"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.1."
     val supportedSparkVersions = Set[String]("3.1.1")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
           conf,
           sparkVersion,
-          Utils.normalizeSparkVersion(sparkVersion),
+          normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
           supportedSparkVersions)
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported versions: ${supportedSparkVersions.toSeq.sorted.mkString(", ")}",
+      exception.getMessage)
   }
 
   @Test
@@ -58,18 +65,25 @@ class UtilsTest {
     conf.set(DOTNET_IGNORE_SPARK_PATCH_VERSION_CHECK, false)
 
     val sparkVersion = "2.4.4"
+    val normalizedSparkVersion = Utils.normalizeSparkVersion(sparkVersion)
     val sparkMajorMinorVersionPrefix = "3.1."
     val supportedSparkVersions = Set[String]("3.1.1")
 
-    assertThrows(
+    val exception = assertThrows(
       classOf[IllegalArgumentException],
       () => {
         Utils.validateSparkVersions(
           conf,
           sparkVersion,
-          Utils.normalizeSparkVersion(sparkVersion),
+          normalizedSparkVersion,
           sparkMajorMinorVersionPrefix,
           supportedSparkVersions)
       })
+
+    assertEquals(
+      s"Unsupported spark version used: $sparkVersion. " +
+        s"Normalized spark version used: $normalizedSparkVersion. " +
+        s"Supported spark major.minor version: $sparkMajorMinorVersionPrefix",
+      exception.getMessage)
   }
 }


### PR DESCRIPTION
Add a new spark conf, `spark.dotnet.ignoreSparkPatchVersionCheck`.  If set to true, then only check the major.minor `SPARK_VERSION` and ignore patch version.  If set to false, then check the `SPARK_VERSION` against the set of `supportedSparkVersions`