### PR TITLE
Prep 1.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     <tbody align="center">
         <tr>
             <td >2.3</td>
-            <td rowspan=3><a href="https://github.com/dotnet/spark/releases/tag/v1.1.0">v1.1.0</a></td>
+            <td rowspan=3><a href="https://github.com/dotnet/spark/releases/tag/v1.1.1">v1.1.1</a></td>
         </tr>
         <tr>
             <td>2.4*</td>

--- a/benchmark/scala/pom.xml
+++ b/benchmark/scala/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.spark</groupId>
   <artifactId>microsoft-spark-benchmark</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <inceptionYear>2019</inceptionYear>
   <properties>
     <encoding>UTF-8</encoding>

--- a/docs/release-notes/1.1.1/release-1.1.1.md
+++ b/docs/release-notes/1.1.1/release-1.1.1.md
@@ -1,6 +1,6 @@
 # .NET for Apache Spark 1.1.1 Release Notes
 
-* Note that there was a breaking forward compatibility change ([#871](https://github.com/dotnet/spark/pull/871)) that went into the 1.1.0 release. This is the re-release of 1.1.0 after reverting the change. If you happend to be using the 1.1.0 release, it is strongly encouraged to upgrade to 1.1.1.
+* Note that there was a breaking forward compatibility change ([#871](https://github.com/dotnet/spark/pull/871)) that went into the 1.1.0 release. This is the re-release of 1.1.0 after reverting the change. If you happen to be using the 1.1.0 release, it is strongly encouraged to upgrade to 1.1.1.
 
 ### Deprecation notice for Spark 2.3
 

--- a/docs/release-notes/1.1.1/release-1.1.1.md
+++ b/docs/release-notes/1.1.1/release-1.1.1.md
@@ -1,6 +1,6 @@
 # .NET for Apache Spark 1.1.1 Release Notes
 
-* Note that there was a breaking forward compatibility change that went into 1.1.0 release. This release reverts the change
+* Note that there was a breaking forward compatibility change ([#871](https://github.com/dotnet/spark/pull/871)) that went into the 1.1.0 release. This is the re-release of 1.1.0 after reverting the change. If you happend to be using the 1.1.0 release, it is strongly encouraged to upgrade to 1.1.1.
 
 ### Deprecation notice for Spark 2.3
 

--- a/docs/release-notes/1.1.1/release-1.1.1.md
+++ b/docs/release-notes/1.1.1/release-1.1.1.md
@@ -1,6 +1,6 @@
 # .NET for Apache Spark 1.1.1 Release Notes
 
-* Note that there was a breaking forward compatibility change ([#871](https://github.com/dotnet/spark/pull/871)) that went into the 1.1.0 release. This is the re-release of 1.1.0 after reverting the change. If you happen to be using the 1.1.0 release, it is strongly encouraged to upgrade to 1.1.1.
+* Note that there was a breaking forward compatibility change ([#871](https://github.com/dotnet/spark/pull/871)) that went into the 1.1.0 release. This is the re-release of 1.1.0 after reverting the change. If you are using the 1.1.0 release, it is strongly encouraged to upgrade to 1.1.1.
 
 ### Deprecation notice for Spark 2.3
 

--- a/docs/release-notes/1.1.1/release-1.1.1.md
+++ b/docs/release-notes/1.1.1/release-1.1.1.md
@@ -1,4 +1,6 @@
-# .NET for Apache Spark 1.1 Release Notes
+# .NET for Apache Spark 1.1.1 Release Notes
+
+* Note that there was a breaking forward compatibility change that went into 1.1.0 release. This release reverts the change
 
 ### Deprecation notice for Spark 2.3
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/src/scala/pom.xml
+++ b/src/scala/pom.xml
@@ -7,7 +7,7 @@
   <version>${microsoft-spark.version}</version>
   <properties>
     <encoding>UTF-8</encoding>
-    <microsoft-spark.version>1.1.0</microsoft-spark.version>
+    <microsoft-spark.version>1.1.1</microsoft-spark.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This PR prepares 1.1.1 release, re-release of 1.1.0 after reverting forward compatibility breaking change: #871.