### PR TITLE
Spark 3.1.0 APIs - DataStreamReader and DataStreamWriter 

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/Utils/SQLUtils.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Utils/SQLUtils.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Spark.Sql;
+
+namespace Microsoft.Spark.E2ETest.Utils
+{
+    internal static class SQLUtils
+    {
+        /// <summary>
+        /// Drops tables in <paramref name="tableNames"/> after calling <paramref name="action"/>.
+        /// </summary>
+        /// <param name="spark">The <see cref="SparkSession"/></param>
+        /// <param name="tableNames">Names of the tables to drop</param>
+        /// <param name="action"><see cref="Action"/> to execute.</param>
+        public static void WithTable(SparkSession spark, IEnumerable<string> tableNames, Action action)
+        {
+            try
+            {
+                action();
+            }
+            finally
+            {
+                tableNames.ToList().ForEach(name => spark.Sql($"DROP TABLE IF EXISTS {name}"));
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
@@ -167,6 +167,16 @@ namespace Microsoft.Spark.Sql.Streaming
         public DataFrame Parquet(string path) => LoadSource("parquet", path);
 
         /// <summary>
+        /// Define a Streaming DataFrame on a Table. The DataSource corresponding to the table should
+        /// support streaming mode.
+        /// </summary>
+        /// <param name="tableName">Name of the table</param>
+        /// <returns>DataFrame object</returns>
+        [Since(Versions.V3_1_0)]
+        public DataFrame Table(string tableName) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
+
+        /// <summary>
         /// Loads text files and returns a <see cref="DataFrame"/> whose schema starts
         /// with a string column named "value", and followed by partitioned columns
         /// if there are any.

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamWriter.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamWriter.cs
@@ -179,6 +179,30 @@ namespace Microsoft.Spark.Sql.Streaming
         }
 
         /// <summary>
+        /// Starts the execution of the streaming query, which will continually output results to the
+        /// given table as new data arrives. The returned <see cref="StreamingQuery"/> object can be
+        /// used to interact with the stream.
+        /// </summary>
+        /// <remarks>
+        /// For v1 table, partitioning columns provided by <see cref="PartitionBy(string[])"/> will be
+        /// respected no matter the table exists or not. A new table will be created if the table not
+        /// exists.
+        ///
+        /// For v2 table, <see cref="PartitionBy(string[])"/> will be ignored if the table already exists.
+        /// <see cref="PartitionBy(string[])"/> will be respected only if the v2 table does not exist.
+        /// Besides, the v2 table created by this API lacks some functionalities (e.g., customized
+        /// properties, options, and serde info). If you need them, please create the v2 table manually
+        /// before the execution to avoid creating a table with incomplete information.
+        /// </remarks>
+        /// <param name="tableName">Name of the table</param>
+        /// <returns>StreamingQuery object</returns>
+        [Since(Versions.V3_1_0)]
+        public StreamingQuery ToTable(string tableName)
+        {
+            return new StreamingQuery((JvmObjectReference)_jvmObject.Invoke("toTable", tableName));
+        }
+
+        /// <summary>
         /// Sets the output of the streaming query to be processed using the provided
         /// writer object. See <see cref="IForeachWriter"/> for more details on the
         /// lifecycle and semantics.

--- a/src/csharp/Microsoft.Spark/Versions.cs
+++ b/src/csharp/Microsoft.Spark/Versions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Spark
         internal const string V2_4_0 = "2.4.0";
         internal const string V2_4_2 = "2.4.2";
         internal const string V3_0_0 = "3.0.0";
+        internal const string V3_1_0 = "3.1.0";
         internal const string V3_1_1 = "3.1.1";
     }
 }


### PR DESCRIPTION
PR adds support for the following APIs added in Spark 3.1.0:

**DataStreamReader**
```scala
def table(tableName: String): DataFrame
```

**DataStreamWriter**
```scala
def toTable(tableName: String): StreamingQuery
```