### PR TITLE
Spark 3.1.0 APIs - DataFrame

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -696,7 +696,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         /// <summary>
-        /// Test signatures for APIs introduced in Spark 3.0.*
+        /// Test signatures for APIs introduced in Spark 3.0.*.
+
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V3_0_0)]
         public void TestSignaturesV3_0_X()

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -668,7 +668,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             _df.CreateGlobalTempView("global_view");
             _df.CreateOrReplaceGlobalTempView("global_view");
 
-            Assert.IsType<string[]>(_df.InputFiles());
+            Assert.IsType<string[]>(_df.InputFiles().ToArray());
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -735,7 +735,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
         /// <summary>
         /// Test signatures for APIs introduced in Spark 3.1.*.
-
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V3_1_0)]
         public void TestSignaturesV3_1_X()

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -732,7 +732,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         /// <summary>
-        /// Test signatures for APIs introduced in Spark 3.1.*
+        /// Test signatures for APIs introduced in Spark 3.1.*.
+
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V3_1_0)]
         public void TestSignaturesV3_1_X()

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -696,10 +696,10 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         /// <summary>
-        /// Test signatures for APIs introduced in Spark 3.*
+        /// Test signatures for APIs introduced in Spark 3.0.*
         /// </summary>
         [SkipIfSparkVersionIsLessThan(Versions.V3_0_0)]
-        public void TestSignaturesV3_X_X()
+        public void TestSignaturesV3_0_X()
         {
             // Validate ToLocalIterator
             var data = new List<GenericRow>
@@ -728,6 +728,19 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             _df.Explain("codegen");
             _df.Explain("cost");
             _df.Explain("formatted");
+        }
+
+        /// <summary>
+        /// Test signatures for APIs introduced in Spark 3.1.*
+        /// </summary>
+        [SkipIfSparkVersionIsLessThan(Versions.V3_1_0)]
+        public void TestSignaturesV3_1_X()
+        {
+            Assert.IsType<DataFrame>(_df.UnionByName(_df, true));
+
+            Assert.IsType<bool>(_df.SameSemantics(_df));
+
+            Assert.IsType<int>(_df.SemanticHash());
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -667,6 +667,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             _df.CreateGlobalTempView("global_view");
             _df.CreateOrReplaceGlobalTempView("global_view");
+
+            Assert.IsType<string[]>(_df.InputFiles());
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -1032,6 +1032,15 @@ namespace Microsoft.Spark.Sql
             new DataStreamWriter((JvmObjectReference)_jvmObject.Invoke("writeStream"), this);
 
         /// <summary>
+        /// Returns a best-effort snapshot of the files that compose this <see cref="DataFrame"/>.
+        /// This method simply asks each constituent BaseRelation for its respective files and takes
+        /// the union of all results. Depending on the source relations, this may not find all input
+        /// files. Duplicates are removed.
+        /// </summary>
+        /// <returns>Files that compose this DataFrame</returns>
+        public string[] InputFiles() => (string[])_jvmObject.Invoke("inputFiles");
+
+        /// <summary>
         /// Returns `true` when the logical query plans inside both <see cref="DataFrame"/>s are
         /// equal and therefore return same results.
         /// </summary>

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -577,6 +577,18 @@ namespace Microsoft.Spark.Sql
             WrapAsDataFrame(_jvmObject.Invoke("unionByName", other));
 
         /// <summary>
+        /// Returns a new <see cref="DataFrame"/> containing union of rows in this
+        /// <see cref="DataFrame"/> and another <see cref="DataFrame"/>, resolving
+        /// columns by name.
+        /// </summary>
+        /// <param name="other">Other DataFrame</param>
+        /// <param name="allowMissingColumns">Allow missing columns</param>
+        /// <returns>DataFrame object</returns>
+        [Since(Versions.V3_1_0)]
+        public DataFrame UnionByName(DataFrame other, bool allowMissingColumns) =>
+            WrapAsDataFrame(_jvmObject.Invoke("unionByName", other, allowMissingColumns));
+
+        /// <summary>
         /// Returns a new `DataFrame` containing rows only in both this `DataFrame`
         /// and another `DataFrame`.
         /// </summary>
@@ -1018,6 +1030,37 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataStreamWriter object</returns>
         public DataStreamWriter WriteStream() =>
             new DataStreamWriter((JvmObjectReference)_jvmObject.Invoke("writeStream"), this);
+
+        /// <summary>
+        /// Returns `true` when the logical query plans inside both <see cref="DataFrame"/>s are
+        /// equal and therefore return same results.
+        /// </summary>
+        /// <remarks>
+        /// The equality comparison here is simplified by tolerating the cosmetic differences
+        /// such as attribute names.
+        /// 
+        /// This API can compare both <see cref="DataFrame"/>s very fast but can still return `false`
+        /// on the <see cref="DataFrame"/> that return the same results, for instance, from different
+        /// plans. Such false negative semantic can be useful when caching as an example.
+        /// </remarks>
+        /// <param name="other">Other DataFrame</param>
+        /// <returns>
+        /// `true` when the logical query plans inside both <see cref="DataFrame"/>s are
+        /// equal and therefore return same results.
+        /// </returns>
+        public bool SameSemantics(DataFrame other) =>
+            (bool)_jvmObject.Invoke("sameSemantics", other);
+
+        /// <summary>
+        /// Returns a hash code of the logical query plan against this <see cref="DataFrame"/>.
+        /// </summary>
+        /// <remarks>
+        /// Unlike the standard hash code, the hash is calculated against the query plan
+        /// simplified by tolerating the cosmetic differences such as attribute names.
+        /// </remarks>
+        /// <returns>Hash code of the logical query plan</returns>
+        public int SemanticHash() =>
+            (int)_jvmObject.Invoke("semanticHash");
 
         /// <summary>
         /// Returns row objects based on the function (either "toPythonIterator",

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -1038,7 +1038,7 @@ namespace Microsoft.Spark.Sql
         /// files. Duplicates are removed.
         /// </summary>
         /// <returns>Files that compose this DataFrame</returns>
-        public string[] InputFiles() => (string[])_jvmObject.Invoke("inputFiles");
+        public IEnumerable<string> InputFiles() => (string[])_jvmObject.Invoke("inputFiles");
 
         /// <summary>
         /// Returns `true` when the logical query plans inside both <see cref="DataFrame"/>s are

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -1048,6 +1048,7 @@ namespace Microsoft.Spark.Sql
         /// `true` when the logical query plans inside both <see cref="DataFrame"/>s are
         /// equal and therefore return same results.
         /// </returns>
+        [Since(Versions.V3_1_0)]
         public bool SameSemantics(DataFrame other) =>
             (bool)_jvmObject.Invoke("sameSemantics", other);
 
@@ -1059,6 +1060,7 @@ namespace Microsoft.Spark.Sql
         /// simplified by tolerating the cosmetic differences such as attribute names.
         /// </remarks>
         /// <returns>Hash code of the logical query plan</returns>
+        [Since(Versions.V3_1_0)]
         public int SemanticHash() =>
             (int)_jvmObject.Invoke("semanticHash");
 

--- a/src/csharp/Microsoft.Spark/Versions.cs
+++ b/src/csharp/Microsoft.Spark/Versions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Spark
         internal const string V2_4_0 = "2.4.0";
         internal const string V2_4_2 = "2.4.2";
         internal const string V3_0_0 = "3.0.0";
+        internal const string V3_1_0 = "3.1.0";
         internal const string V3_1_1 = "3.1.1";
     }
 }


### PR DESCRIPTION
PR adds support for the following APIs added in Spark 3.1.0:

**DataFrame**
```scala
def unionByName(other: Dataset[T], allowMissingColumns: Boolean): Dataset[T]
def sameSemantics(other: Dataset[T]): Boolean
def semanticHash(): Int
```

Added into scala in Spark 2.0.0, but added into pySpark in Spark 3.1.0
```scala
def inputFiles: Array[String]
```