### PR TITLE
Spark 3.1.0 APIs - Catalog

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/CatalogTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/CatalogTests.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Spark.E2ETest.Utils;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Catalog;
+using Microsoft.Spark.Sql.Types;
+using Xunit;
+using static Microsoft.Spark.E2ETest.Utils.SQLUtils;
+
+namespace Microsoft.Spark.E2ETest.IpcTests
+{
+    [Collection("Spark E2E Tests")]
+    public class CatalogTests
+    {
+        private readonly SparkSession _spark;
+
+        public CatalogTests(SparkFixture fixture)
+        {
+            _spark = fixture.Spark;
+        }
+
+        /// <summary>
+        /// Test signatures for APIs up to Spark 2.3.*.
+        /// </summary>
+        [Fact]
+        public void TestSignaturesV2_3_X()
+        {
+            WithTable(_spark, new string[] { "users", "users2", "users3", "users4", "usersp" }, () =>
+            {
+                Catalog catalog = _spark.Catalog;
+
+                Assert.IsType<DataFrame>(catalog.ListDatabases());
+                Assert.IsType<DataFrame>(catalog.ListFunctions());
+                Assert.IsType<DataFrame>(catalog.ListFunctions("default"));
+
+                string usersFilePath = Path.Combine(TestEnvironment.ResourceDirectory, "users.parquet");
+                var usersSchema = new StructType(new[]
+                {
+                    new StructField("name", new StringType()),
+                    new StructField("favorite_color", new StringType()),
+                });
+                var tableOptions = new Dictionary<string, string>() { { "path", usersFilePath } };
+                Assert.IsType<DataFrame>(catalog.CreateTable("users", usersFilePath));
+                Assert.IsType<DataFrame>(catalog.CreateTable("users2", usersFilePath, "parquet"));
+                Assert.IsType<DataFrame>(catalog.CreateTable("users3", "parquet", tableOptions));
+                Assert.IsType<DataFrame>(
+                    catalog.CreateTable("users4", "parquet", usersSchema, tableOptions));
+
+                Assert.IsType<string>(catalog.CurrentDatabase());
+                Assert.IsType<bool>(catalog.DatabaseExists("default"));
+
+                Assert.IsType<bool>(catalog.DropGlobalTempView("no-view"));
+                Assert.IsType<bool>(catalog.DropTempView("no-view"));
+                Assert.IsType<bool>(catalog.FunctionExists("default", "functionname"));
+                Assert.IsType<bool>(catalog.FunctionExists("functionname"));
+                Assert.IsType<Database>(catalog.GetDatabase("default"));
+                Assert.IsType<Function>(catalog.GetFunction("abs"));
+                Assert.IsType<Function>(catalog.GetFunction(null, "abs"));
+                Assert.IsType<Table>(catalog.GetTable("users"));
+                Assert.IsType<Table>(catalog.GetTable("default", "users"));
+                Assert.IsType<bool>(catalog.IsCached("users"));
+                Assert.IsType<DataFrame>(catalog.ListColumns("users"));
+                Assert.IsType<DataFrame>(catalog.ListColumns("default", "users"));
+                Assert.IsType<DataFrame>(catalog.ListDatabases());
+                Assert.IsType<DataFrame>(catalog.ListFunctions());
+                Assert.IsType<DataFrame>(catalog.ListFunctions("default"));
+                Assert.IsType<DataFrame>(catalog.ListTables());
+                Assert.IsType<DataFrame>(catalog.ListTables("default"));
+
+                catalog.RefreshByPath("/");
+                catalog.RefreshTable("users");
+                catalog.SetCurrentDatabase("default");
+                catalog.CacheTable("users");
+                catalog.UncacheTable("users");
+                catalog.ClearCache();
+
+                Assert.IsType<bool>(catalog.TableExists("users"));
+                Assert.IsType<bool>(catalog.TableExists("default", "users"));
+
+                _spark.Sql(@"CREATE TABLE IF NOT EXISTS usersp USING PARQUET PARTITIONED BY (name)  
+                            AS SELECT * FROM users");
+                catalog.RecoverPartitions("usersp");
+            });
+        }
+
+        /// <summary>
+        /// Test signatures for APIs introduced in Spark 3.1.*.
+        /// </summary>
+        [SkipIfSparkVersionIsLessThan(Versions.V3_1_0)]
+        public void TestSignaturesV3_1_X()
+        {
+            WithTable(_spark, new string[] { "users1", "users2" }, () =>
+            {
+                Catalog catalog = _spark.Catalog;
+
+                string usersFilePath = Path.Combine(TestEnvironment.ResourceDirectory, "users.parquet");
+                var usersSchema = new StructType(new[]
+                {
+                    new StructField("name", new StringType()),
+                    new StructField("favorite_color", new StringType()),
+                });
+                var tableOptions = new Dictionary<string, string>() { { "path", usersFilePath } };
+                Assert.IsType<DataFrame>(
+                    catalog.CreateTable("users1", "parquet", "description", tableOptions));
+                Assert.IsType<DataFrame>(
+                    catalog.CreateTable("users2", "parquet", usersSchema, "description", tableOptions));
+            });
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/FunctionsTests.cs
@@ -4,10 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Sql;
-using Microsoft.Spark.Sql.Catalog;
 using Microsoft.Spark.Sql.Types;
 using Xunit;
 using static Microsoft.Spark.Sql.Functions;
@@ -666,56 +664,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                 (arg) => new Dictionary<string, string> { { arg, arg } });
             Udf<string, IDictionary<string, string[]>>(
                 (arg) => new Dictionary<string, string[]> { { arg, new[] { arg } } });
-        }
-
-        [Fact]
-        /// Tests for the Catclog Functions - returned from SparkSession.Catalog
-        public void CatalogFunctions()
-        {
-            Catalog catalog = _spark.Catalog;
-
-            Assert.IsType<DataFrame>(catalog.ListDatabases());
-            Assert.IsType<DataFrame>(catalog.ListFunctions());
-            Assert.IsType<DataFrame>(catalog.ListFunctions("default"));
-
-            DataFrame table = catalog.CreateTable("users",
-                Path.Combine(TestEnvironment.ResourceDirectory, "users.parquet"));
-            Assert.IsType<DataFrame>(table);
-
-            Assert.IsType<string>(catalog.CurrentDatabase());
-            Assert.IsType<bool>(catalog.DatabaseExists("default"));
-
-            Assert.IsType<bool>(catalog.DropGlobalTempView("no-view"));
-            Assert.IsType<bool>(catalog.DropTempView("no-view"));
-            Assert.IsType<bool>(catalog.FunctionExists("default", "functionname"));
-            Assert.IsType<bool>(catalog.FunctionExists("functionname"));
-            Assert.IsType<Database>(catalog.GetDatabase("default"));
-            Assert.IsType<Function>(catalog.GetFunction("abs"));
-            Assert.IsType<Function>(catalog.GetFunction(null, "abs"));
-            Assert.IsType<Table>(catalog.GetTable("users"));
-            Assert.IsType<Table>(catalog.GetTable("default", "users"));
-            Assert.IsType<bool>(catalog.IsCached("users"));
-            Assert.IsType<DataFrame>(catalog.ListColumns("users"));
-            Assert.IsType<DataFrame>(catalog.ListColumns("default", "users"));
-            Assert.IsType<DataFrame>(catalog.ListDatabases());
-            Assert.IsType<DataFrame>(catalog.ListFunctions());
-            Assert.IsType<DataFrame>(catalog.ListFunctions("default"));
-            Assert.IsType<DataFrame>(catalog.ListTables());
-            Assert.IsType<DataFrame>(catalog.ListTables("default"));
-
-            catalog.RefreshByPath("/");
-            catalog.RefreshTable("users");
-            catalog.SetCurrentDatabase("default");
-            catalog.CacheTable("users");
-            catalog.UncacheTable("users");
-            catalog.ClearCache();
-
-            Assert.IsType<bool>(catalog.TableExists("users"));
-            Assert.IsType<bool>(catalog.TableExists("default", "users"));
-
-            _spark.Sql(@"CREATE TABLE IF NOT EXISTS usersp USING PARQUET PARTITIONED BY (name)  
-                            AS SELECT * FROM users");
-            catalog.RecoverPartitions("usersp");
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/Sql/Catalog/Catalog.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Catalog/Catalog.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.Sql.Catalog
 {
@@ -73,6 +75,100 @@ namespace Microsoft.Spark.Sql.Catalog
                 (JvmObjectReference)_jvmObject.Invoke("createTable", tableName, path, source));
 
         /// <summary>
+        /// Creates a table based on the dataset in a data source and a set of options.
+        /// </summary>
+        /// <param name="tableName">
+        /// Is either a qualified or unqualified name that designates a table. If no database
+        /// identifier is provided, it refers to a table in the current database.
+        /// </param>
+        /// <param name="source">
+        /// Data source to use to create the table such as parquet, csv, etc.
+        /// </param>
+        /// <param name="options">Options used to table</param>
+        /// <returns>The corresponding DataFrame</returns>
+        public DataFrame CreateTable(string tableName, string source, IDictionary<string, string> options) =>
+            new DataFrame((JvmObjectReference)_jvmObject.Invoke("createTable", tableName, source, options));
+
+        /// <summary>
+        /// Creates a table based on the dataset in a data source and a set of options.
+        /// </summary>
+        /// <param name="tableName">
+        /// Is either a qualified or unqualified name that designates a table. If no database
+        /// identifier is provided, it refers to a table in the current database.
+        /// </param>
+        /// <param name="source">
+        /// Data source to use to create the table such as parquet, csv, etc.
+        /// </param>
+        /// <param name="description">Description of the table</param>
+        /// <param name="options">Options used to table</param>
+        /// <returns>The corresponding DataFrame</returns>
+        [Since(Versions.V3_1_0)]
+        public DataFrame CreateTable(
+            string tableName,
+            string source,
+            string description,
+            IDictionary<string, string> options) =>
+            new DataFrame(
+                (JvmObjectReference)_jvmObject.Invoke(
+                    "createTable", tableName, source, description, options));
+
+        /// <summary>
+        /// Create a table based on the dataset in a data source, a schema and a set of options.
+        /// </summary>
+        /// <param name="tableName">
+        /// Is either a qualified or unqualified name that designates a table. If no database
+        /// identifier is provided, it refers to a table in the current database.
+        /// </param>
+        /// <param name="source">
+        /// Data source to use to create the table such as parquet, csv, etc.
+        /// </param>
+        /// <param name="schema">Schema of the table</param>
+        /// <param name="options">Options used to table</param>
+        /// <returns>The corresponding DataFrame</returns>
+        public DataFrame CreateTable(
+            string tableName,
+            string source,
+            StructType schema,
+            IDictionary<string, string> options) =>
+            new DataFrame(
+                (JvmObjectReference)_jvmObject.Invoke(
+                    "createTable",
+                    tableName,
+                    source,
+                    DataType.FromJson(_jvmObject.Jvm, schema.Json),
+                    options));
+
+        /// <summary>
+        /// Create a table based on the dataset in a data source, a schema and a set of options.
+        /// </summary>
+        /// <param name="tableName">
+        /// Is either a qualified or unqualified name that designates a table. If no database
+        /// identifier is provided, it refers to a table in the current database.
+        /// </param>
+        /// <param name="source">
+        /// Data source to use to create the table such as parquet, csv, etc.
+        /// </param>
+        /// <param name="schema">Schema of the table</param>
+        /// <param name="description">Description of the table</param>
+        /// <param name="options">Options used to table</param>
+        /// <returns>The corresponding DataFrame</returns>
+        [Since(Versions.V3_1_0)]
+        public DataFrame CreateTable(
+            string tableName,
+            string source,
+            StructType schema,
+            string description,
+            IDictionary<string, string> options) =>
+            new DataFrame(
+                (JvmObjectReference)_jvmObject.Invoke(
+                    "createTable",
+                    tableName,
+                    source,
+                    DataType.FromJson(_jvmObject.Jvm, schema.Json),
+                    description,
+                    options));
+
+        /// <summary>
         /// Returns the current database in this session. By default your session will be
         /// connected to the "default" database (named "default") and to change database
         /// either use `SetCurrentDatabase("databaseName")` or
@@ -115,7 +211,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="viewName">The unqualified name of the temporary view to be dropped.
         /// </param>
         /// <returns>bool, true if the view was dropped and false if it was not dropped.</returns>
-        public bool DropTempView(string viewName) => 
+        public bool DropTempView(string viewName) =>
             (bool)_jvmObject.Invoke("dropTempView", viewName);
 
         /// <summary>
@@ -203,7 +299,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// whether the table is temporary or not.</returns>
         public Table GetTable(string dbName, string tableName) =>
             new Table((JvmObjectReference)_jvmObject.Invoke("getTable", dbName, tableName));
-        
+
         /// <summary>
         /// Returns true if the table is currently cached in-memory. If the table is cached then it
         /// will consume memory. To remove the table from cache use `UncacheTable` or `ClearCache`
@@ -321,7 +417,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// table. If no database identifier is provided, it refers to a table in the current
         /// database.</param>
         public void RefreshTable(string tableName) => _jvmObject.Invoke("refreshTable", tableName);
-        
+
         /// <summary>
         /// Sets the current default database in this session.
         /// </summary>
@@ -347,7 +443,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="tableName">Is an unqualified name that designates a table.</param>
         /// <returns>bool, true if the table exists in the specified database and false if it does
         /// not exist</returns>
-        public bool TableExists(string dbName, string tableName) => 
+        public bool TableExists(string dbName, string tableName) =>
             (bool)_jvmObject.Invoke("tableExists", dbName, tableName);
 
         /// <summary>


### PR DESCRIPTION
PR adds support for the following APIs added in Spark 3.1.0 and adds missing `createTable` APIs:

**Catalog**
Introduced in Spark 3.1.0
```scala
def createTable(tableName: String, source: String, description: String, options: Map[String, String]): DataFrame
def createTable(tableName: String, source: String, schema: StructType, description: String, options: Map[String, String]): DataFrame
```

Missing createTable APIs
```scala
def createTable(tableName: String, source: String, options: Map[String, String]): DataFrame
def createTable(tableName: String, source: String, schema: StructType, options: Map[String, String]): DataFrame
```