### PR TITLE
Added the exists method to the FileSystem.

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
@@ -54,26 +54,28 @@ namespace Microsoft.Spark.E2ETest.Hadoop
             Assert.False(Directory.Exists(path));
         }
 
+        /// <summary>
+        /// Tests that Exists() returns true if the file exist.
+        /// Tests that Exists() returns false if the file doesn't exist.
+        /// </summary>
         [Fact]
         public void TestExists()
         {
             using FileSystem fs = FileSystem.Get(_spark.SparkContext.HadoopConfiguration());
 
             using var tempDirectory = new TemporaryDirectory();
+
             string path = Path.Combine(tempDirectory.Path, "temp-table");
 
-            _spark
-                .Range(25)
-                .Coalesce(1)
-                .Write()
-                .Csv(path);
+            Assert.False(fs.Exists(path));
+
+            _spark.Range(25).Coalesce(1).Write().Csv(path);
 
             Assert.True(fs.Exists(path));
 
             var dataFile = Directory.GetFiles(path, "*.csv").FirstOrDefault();
 
             Assert.NotNull(dataFile);
-
             Assert.True(fs.Exists(dataFile));
         }
     }

--- a/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using Microsoft.Spark.Hadoop.Fs;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.UnitTest.TestUtils;
@@ -51,6 +52,29 @@ namespace Microsoft.Spark.E2ETest.Hadoop
             Assert.False(fs.Delete(path, true));
 
             Assert.False(Directory.Exists(path));
+        }
+
+        [Fact]
+        public void TestExists()
+        {
+            using FileSystem fs = FileSystem.Get(_spark.SparkContext.HadoopConfiguration());
+
+            using var tempDirectory = new TemporaryDirectory();
+            string path = Path.Combine(tempDirectory.Path, "temp-table");
+
+            _spark
+                .Range(25)
+                .Coalesce(1)
+                .Write()
+                .Csv(path);
+
+            Assert.True(fs.Exists(path));
+
+            var dataFile = Directory.GetFiles(path, "*.csv").FirstOrDefault();
+
+            Assert.NotNull(dataFile);
+
+            Assert.True(fs.Exists(dataFile));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Hadoop/FileSystemTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Spark.E2ETest.Hadoop
 
             Assert.True(fs.Exists(path));
 
-            var dataFile = Directory.GetFiles(path, "*.csv").FirstOrDefault();
+            string dataFile = Directory.GetFiles(path, "*.csv").FirstOrDefault();
 
             Assert.NotNull(dataFile);
             Assert.True(fs.Exists(dataFile));

--- a/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
+++ b/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
@@ -55,6 +55,14 @@ namespace Microsoft.Spark.Hadoop.Fs
             return (bool)_jvmObject.Invoke("delete", pathObject, recursive);
         }
 
+        public bool Exists(string path)
+        {
+            JvmObjectReference pathObject =
+                SparkEnvironment.JvmBridge.CallConstructor("org.apache.hadoop.fs.Path", path);
+
+            return (bool)_jvmObject.Invoke("exists", pathObject);
+        }
+
         public void Dispose() => _jvmObject.Invoke("close");
     }
 }

--- a/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
+++ b/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Spark.Hadoop.Fs
             return (bool)_jvmObject.Invoke("delete", pathObject, recursive);
         }
 
+        /// <summary>
+        /// Check if a path exists.
+        /// </summary>
+        /// <param name="path">Source path</param>
+        /// <returns>True if the path exists else false.</returns>
         public bool Exists(string path)
         {
             JvmObjectReference pathObject =


### PR DESCRIPTION
This PR adds the exists(string filePath) api to the FileSystem, which will allow the users to check whether a given folder or file exists in the file system or not.

I'll be adding more methods once I know, that I have done this work correctly.

**Example: Check for an existing file**

```cs
SparkSession spark = ....
FileSystem fs = FileSystem.Get(spark.SparkContext.HadoopConfiguration());
bool fileExists = fs.Exists("abfss://container@datalake.dfs.core.windows.net/myfolder/file.csv");
```

This PR relates to #328 

