### PR TITLE
Update README for v1.1.1 for jars

### DIFF
--- a/docs/release-notes/1.1.1/release-1.1.1.md
+++ b/docs/release-notes/1.1.1/release-1.1.1.md
@@ -106,11 +106,11 @@ The following table outlines the supported Spark versions along with the microso
     <tbody align="center">
         <tr>
             <td>2.3.*</td>
-            <td>microsoft-spark-2-3_2.11-1.1.0.jar</td>
+            <td>microsoft-spark-2-3_2.11-1.1.1.jar</td>
         </tr>
         <tr>
             <td>2.4.0</td>
-            <td rowspan=7>microsoft-spark-2-4_2.11-1.1.0.jar</td>
+            <td rowspan=7>microsoft-spark-2-4_2.11-1.1.1.jar</td>
         </tr>
         <tr>
             <td>2.4.1</td>
@@ -136,7 +136,7 @@ The following table outlines the supported Spark versions along with the microso
         </tr>
         <tr>
             <td>3.0.0</td>
-            <td rowspan=3>microsoft-spark-3-0_2.12-1.1.0.jar</td>
+            <td rowspan=3>microsoft-spark-3-0_2.12-1.1.1.jar</td>
         </tr>
         <tr>
             <td>3.0.1</td>
@@ -161,7 +161,7 @@ The following table outlines the supported Delta versions along with the Microso
     <tbody align="center">
         <tr>
             <td>0.1.0</td>
-            <td rowspan=9>1.1.0</td>
+            <td rowspan=9>1.1.1</td>
         </tr>
         <tr>
             <td>0.2.0</td>
@@ -204,7 +204,7 @@ The following table outlines the supported Hyperspace versions along with the Mi
     <tbody align="center">
         <tr>
             <td>0.1.0</td>
-            <td rowspan=4>1.1.0</td>
+            <td rowspan=4>1.1.1</td>
         </tr>
         <tr>
             <td>0.2.0</td>


### PR DESCRIPTION
The v1.1.1 README has typo for jar versions.