### PR TITLE
Add public APIs to access JvmBridge, JvmObjectReference, IJvmObjectReferenceProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,6 @@ hs_err_pid*
 
 # F# vs code 
 .ionide/
+
+# Mac dev
+.DS_Store

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeBuilder.cs
@@ -78,14 +78,12 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeBuilder : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DeltaMergeBuilder(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Build the actions to perform when the merge condition was matched. This returns
@@ -96,7 +94,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched() =>
             new DeltaMergeMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenMatched"));
+                (JvmObjectReference)Reference.Invoke("whenMatched"));
 
         /// <summary>
         /// Build the actions to perform when the merge condition was matched and the given
@@ -109,7 +107,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(string condition) =>
             new DeltaMergeMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
+                (JvmObjectReference)Reference.Invoke("whenMatched", condition));
 
         /// <summary>
         /// Build the actions to perform when the merge condition was matched and the given
@@ -122,7 +120,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeMatchedActionBuilder WhenMatched(Column condition) =>
             new DeltaMergeMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenMatched", condition));
+                (JvmObjectReference)Reference.Invoke("whenMatched", condition));
 
         /// <summary>
         /// Build the action to perform when the merge condition was not matched. This returns 
@@ -133,7 +131,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched() =>
             new DeltaMergeNotMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenNotMatched"));
+                (JvmObjectReference)Reference.Invoke("whenNotMatched"));
 
         /// <summary>
         /// Build the actions to perform when the merge condition was not matched and the given
@@ -145,7 +143,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(string condition) =>
             new DeltaMergeNotMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
+                (JvmObjectReference)Reference.Invoke("whenNotMatched", condition));
 
         /// <summary>
         /// Build the actions to perform when the merge condition was not matched and the given
@@ -157,12 +155,12 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeNotMatchedActionBuilder WhenNotMatched(Column condition) =>
             new DeltaMergeNotMatchedActionBuilder(
-                (JvmObjectReference)_jvmObject.Invoke("whenNotMatched", condition));
+                (JvmObjectReference)Reference.Invoke("whenNotMatched", condition));
 
         /// <summary>
         /// Execute the merge operation based on the built matched and not matched actions.
         /// </summary>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public void Execute() => _jvmObject.Invoke("execute");
+        public void Execute() => Reference.Invoke("execute");
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeMatchedActionBuilder.cs
@@ -15,14 +15,12 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeMatchedActionBuilder : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DeltaMergeMatchedActionBuilder(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Update the matched table rows based on the rules defined by <c>set</c>.
@@ -32,7 +30,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Update(Dictionary<string, Column> set) =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("update", set));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("update", set));
 
         /// <summary>
         /// Update the matched table rows based on the rules defined by <c>set</c>.
@@ -42,7 +40,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateExpr(Dictionary<string, string> set) =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateExpr", set));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("updateExpr", set));
 
         /// <summary>
         /// Update all the columns of the matched table row with the values of the corresponding
@@ -51,7 +49,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder UpdateAll() =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("updateAll"));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("updateAll"));
 
         /// <summary>
         /// Delete a matched row from the table.
@@ -59,6 +57,6 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Delete() =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("delete"));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("delete"));
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaMergeNotMatchedActionBuilder.cs
@@ -18,14 +18,12 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaMergeNotMatchedActionBuilder : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DeltaMergeNotMatchedActionBuilder(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Insert a new row to the target table based on the rules defined by <c>values</c>.
@@ -35,7 +33,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Insert(Dictionary<string, Column> values) =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insert", values));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("insert", values));
 
         /// <summary>
         /// Insert a new row to the target table based on the rules defined by <c>values</c>.
@@ -45,7 +43,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertExpr(Dictionary<string, string> values) =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertExpr", values));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("insertExpr", values));
 
         /// <summary>
         /// Insert a new target Delta table row by assigning the target columns to the values of the
@@ -54,6 +52,6 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>DeltaMergeBuilder object.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder InsertAll() =>
-            new DeltaMergeBuilder((JvmObjectReference)_jvmObject.Invoke("insertAll"));
+            new DeltaMergeBuilder((JvmObjectReference)Reference.Invoke("insertAll"));
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Delta/Tables/DeltaTable.cs
@@ -21,16 +21,14 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
     [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
     public class DeltaTable : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         private static readonly string s_deltaTableClassName = "io.delta.tables.DeltaTable";
 
         internal DeltaTable(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Create a DeltaTable from the given parquet table and partition schema.
@@ -243,7 +241,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>Aliased DeltaTable.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable As(string alias) =>
-            new DeltaTable((JvmObjectReference)_jvmObject.Invoke("as", alias));
+            new DeltaTable((JvmObjectReference)Reference.Invoke("as", alias));
 
         /// <summary>
         /// Apply an alias to the DeltaTable. This is similar to <c>Dataset.as(alias)</c>
@@ -253,14 +251,14 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>Aliased DeltaTable.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaTable Alias(string alias) =>
-            new DeltaTable((JvmObjectReference)_jvmObject.Invoke("alias", alias));
+            new DeltaTable((JvmObjectReference)Reference.Invoke("alias", alias));
 
         /// <summary>
         /// Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
         /// </summary>
         /// <returns>DataFrame representation of Delta table.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public DataFrame ToDF() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("toDF"));
+        public DataFrame ToDF() => new DataFrame((JvmObjectReference)Reference.Invoke("toDF"));
 
         /// <summary>
         /// Recursively delete files and directories in the table that are not needed by the table
@@ -273,7 +271,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>Vacuumed DataFrame.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum(double retentionHours) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum", retentionHours));
+            new DataFrame((JvmObjectReference)Reference.Invoke("vacuum", retentionHours));
 
         /// <summary>
         /// Recursively delete files and directories in the table that are not needed by the table
@@ -285,7 +283,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>Vacuumed DataFrame.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame Vacuum() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("vacuum"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("vacuum"));
 
         /// <summary>
         /// Get the information of the latest <c>limit</c> commits on this table as a Spark
@@ -295,7 +293,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>History DataFrame.</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History(int limit) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("history", limit));
+            new DataFrame((JvmObjectReference)Reference.Invoke("history", limit));
 
         /// <summary>
         /// Get the information available commits on this table as a Spark DataFrame. The
@@ -304,7 +302,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <returns>History DataFrame</returns>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DataFrame History() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("history"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("history"));
 
         /// <summary>
         /// Generate a manifest for the given Delta Table.
@@ -315,27 +313,27 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// for Presto and Athena read support.
         /// See the online documentation for more information.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_5_0)]
-        public void Generate(string mode) => _jvmObject.Invoke("generate", mode);
+        public void Generate(string mode) => Reference.Invoke("generate", mode);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public void Delete(string condition) => _jvmObject.Invoke("delete", condition);
+        public void Delete(string condition) => Reference.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table that match the given <c>condition</c>.
         /// </summary>
         /// <param name="condition">Boolean SQL expression.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public void Delete(Column condition) => _jvmObject.Invoke("delete", condition);
+        public void Delete(Column condition) => Reference.Invoke("delete", condition);
 
         /// <summary>
         /// Delete data from the table.
         /// </summary>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public void Delete() => _jvmObject.Invoke("delete");
+        public void Delete() => Reference.Invoke("delete");
 
         /// <summary>
         /// Update rows in the table based on the rules defined by <c>set</c>.
@@ -351,7 +349,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="set">Pules to update a row as a Scala map between target column names
         /// and corresponding update expressions as Column objects.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
-        public void Update(Dictionary<string, Column> set) => _jvmObject.Invoke("update", set);
+        public void Update(Dictionary<string, Column> set) => Reference.Invoke("update", set);
 
         /// <summary>
         /// Update data from the table on the rows that match the given <c>condition</c> based on
@@ -373,7 +371,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// corresponding update expressions as Column objects.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void Update(Column condition, Dictionary<string, Column> set) =>
-            _jvmObject.Invoke("update", condition, set);
+            Reference.Invoke("update", condition, set);
 
         /// <summary>
         /// Update rows in the table based on the rules defined by <c>set</c>.
@@ -391,7 +389,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// corresponding update expressions as SQL formatted strings.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(Dictionary<string, string> set) =>
-            _jvmObject.Invoke("updateExpr", set);
+            Reference.Invoke("updateExpr", set);
 
         /// <summary>
         /// Update data from the table on the rows that match the given <c>condition</c>, which
@@ -413,7 +411,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// corresponding update expressions as SQL formatted strings.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public void UpdateExpr(string condition, Dictionary<string, string> set) =>
-            _jvmObject.Invoke("updateExpr", condition, set);
+            Reference.Invoke("updateExpr", condition, set);
 
         /// <summary>
         /// Merge data from the <c>source</c> DataFrame based on the given merge <c>condition</c>.
@@ -455,7 +453,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, string condition) =>
             new DeltaMergeBuilder(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                 "merge",
                 source,
                 condition));
@@ -497,7 +495,7 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         [DeltaLakeSince(DeltaLakeVersions.V0_3_0)]
         public DeltaMergeBuilder Merge(DataFrame source, Column condition) =>
             new DeltaMergeBuilder(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                 "merge",
                 source,
                 condition));
@@ -516,6 +514,6 @@ namespace Microsoft.Spark.Extensions.Delta.Tables
         /// <param name="writerVersion">Version of the Delta write protocol.</param>
         [DeltaLakeSince(DeltaLakeVersions.V0_8_0)]
         public void UpgradeTableProtocol(int readerVersion, int writerVersion) =>
-            _jvmObject.Invoke("upgradeTableProtocol", readerVersion, writerVersion);
+            Reference.Invoke("upgradeTableProtocol", readerVersion, writerVersion);
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         public Hyperspace(SparkSession spark)
         {
             _spark = spark;
-            _jvmBridge = Reference.Jvm;
+            _jvmBridge = spark.Reference.Jvm;
             Reference = _jvmBridge.CallConstructor(s_hyperspaceClassName, spark);
         }
 

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Hyperspace.cs
@@ -19,17 +19,16 @@ namespace Microsoft.Spark.Extensions.Hyperspace
             "com.microsoft.hyperspace.Hyperspace";
         private readonly SparkSession _spark;
         private readonly IJvmBridge _jvmBridge;
-        private readonly JvmObjectReference _jvmObject;
 
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public Hyperspace(SparkSession spark)
         {
             _spark = spark;
-            _jvmBridge = ((IJvmObjectReferenceProvider)spark).Reference.Jvm;
-            _jvmObject = _jvmBridge.CallConstructor(s_hyperspaceClassName, spark);
+            _jvmBridge = Reference.Jvm;
+            Reference = _jvmBridge.CallConstructor(s_hyperspaceClassName, spark);
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Collect all the index metadata.
@@ -37,7 +36,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <returns>All index metadata as a <see cref="DataFrame"/>.</returns>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public DataFrame Indexes() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("indexes"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("indexes"));
 
         /// <summary>
         /// Create index.
@@ -46,35 +45,35 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <param name="indexConfig">The configuration of index to be created.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public void CreateIndex(DataFrame df, IndexConfig indexConfig) =>
-            _jvmObject.Invoke("createIndex", df, indexConfig);
+            Reference.Invoke("createIndex", df, indexConfig);
 
         /// <summary>
         /// Soft deletes the index with given index name.
         /// </summary>
         /// <param name="indexName">The name of index to delete.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void DeleteIndex(string indexName) => _jvmObject.Invoke("deleteIndex", indexName);
+        public void DeleteIndex(string indexName) => Reference.Invoke("deleteIndex", indexName);
 
         /// <summary>
         /// Restores index with given index name.
         /// </summary>
         /// <param name="indexName">Name of the index to restore.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void RestoreIndex(string indexName) => _jvmObject.Invoke("restoreIndex", indexName);
+        public void RestoreIndex(string indexName) => Reference.Invoke("restoreIndex", indexName);
 
         /// <summary>
         /// Does hard delete of indexes marked as <c>DELETED</c>.
         /// </summary>
         /// <param name="indexName">Name of the index to restore.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void VacuumIndex(string indexName) => _jvmObject.Invoke("vacuumIndex", indexName);
+        public void VacuumIndex(string indexName) => Reference.Invoke("vacuumIndex", indexName);
 
         /// <summary>
         /// Update indexes for the latest version of the data.
         /// </summary>
         /// <param name="indexName">Name of the index to refresh.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void RefreshIndex(string indexName) => _jvmObject.Invoke("refreshIndex", indexName);
+        public void RefreshIndex(string indexName) => Reference.Invoke("refreshIndex", indexName);
 
         /// <summary>
         /// Update indexes for the latest version of the data. This API provides a few supported refresh
@@ -85,7 +84,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <c>full</c>.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_3)]
         public void RefreshIndex(string indexName, string mode) =>
-            _jvmObject.Invoke("refreshIndex", indexName, mode);
+            Reference.Invoke("refreshIndex", indexName, mode);
 
         /// <summary>
         /// Optimize index by changing the underlying index data layout (e.g., compaction).
@@ -107,7 +106,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <param name="mode">Optimize mode <c>quick</c> or <c>full</c>.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_3)]
         public void OptimizeIndex(string indexName, string mode = "quick") =>
-            _jvmObject.Invoke("optimizeIndex", indexName, mode);
+            Reference.Invoke("optimizeIndex", indexName, mode);
 
         /// <summary>
         /// Cancel api to bring back index from an inconsistent state to the last known stable
@@ -124,7 +123,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// </summary>
         /// <param name="indexName">Name of the index to cancel.</param>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public void Cancel(string indexName) => _jvmObject.Invoke("cancel", indexName);
+        public void Cancel(string indexName) => Reference.Invoke("cancel", indexName);
 
         /// <summary>
         /// Explains how indexes will be applied to the given dataframe.
@@ -161,6 +160,6 @@ namespace Microsoft.Spark.Extensions.Hyperspace
         /// <returns>Index metadata and statistics as a <see cref="DataFrame"/>.</returns>
         [HyperspaceSince(HyperspaceVersions.V0_0_4)]
         public DataFrame Index(string indexName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("index", indexName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("index", indexName));
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Index/Builder.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Index/Builder.cs
@@ -12,14 +12,12 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
     [HyperspaceSince(HyperspaceVersions.V0_0_1)]
     public sealed class Builder : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Builder(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Updates index name for <see cref="IndexConfig"/>.
@@ -29,7 +27,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public Builder IndexName(string indexName)
         {
-            _jvmObject.Invoke("indexName", indexName);
+            Reference.Invoke("indexName", indexName);
             return this;
         }
 
@@ -46,7 +44,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public Builder IndexBy(string indexedColumn, params string[] indexedColumns)
         {
-            _jvmObject.Invoke("indexBy", indexedColumn, indexedColumns);
+            Reference.Invoke("indexBy", indexedColumn, indexedColumns);
             return this;
         }
 
@@ -63,7 +61,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public Builder Include(string includedColumn, params string[] includedColumns)
         {
-            _jvmObject.Invoke("include", includedColumn, includedColumns);
+            Reference.Invoke("include", includedColumn, includedColumns);
             return this;
         }
 
@@ -74,6 +72,6 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
         /// <returns>An <see cref="IndexConfig"/> object.</returns>
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public IndexConfig Create() =>
-            new IndexConfig((JvmObjectReference)_jvmObject.Invoke("create"));
+            new IndexConfig((JvmObjectReference)Reference.Invoke("create"));
     }
 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Index/IndexConfig.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.Hyperspace/Index/IndexConfig.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
     public sealed class IndexConfig : IJvmObjectReferenceProvider
     {
         private static readonly string s_className = "com.microsoft.hyperspace.index.IndexConfig";
-        private readonly JvmObjectReference _jvmObject;
 
         /// <summary>
         /// <see cref="IndexConfig"/> specifies the configuration of an index.
@@ -45,7 +44,7 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
             IndexedColumns = new List<string>(indexedColumns);
             IncludedColumns = new List<string>(includedColumns);
 
-            _jvmObject = (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
+            Reference = (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
                 s_className,
                 "apply",
                 IndexName,
@@ -59,15 +58,15 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
         /// <param name="jvmObject">JVM object reference.</param>
         internal IndexConfig(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
-            IndexName = (string)_jvmObject.Invoke("indexName");
+            Reference = jvmObject;
+            IndexName = (string)Reference.Invoke("indexName");
             IndexedColumns = new List<string>(
-                new Seq<string>((JvmObjectReference)_jvmObject.Invoke("indexedColumns")));
+                new Seq<string>((JvmObjectReference)Reference.Invoke("indexedColumns")));
             IncludedColumns = new List<string>(
-                new Seq<string>((JvmObjectReference)_jvmObject.Invoke("includedColumns")));
+                new Seq<string>((JvmObjectReference)Reference.Invoke("includedColumns")));
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
         public string IndexName { get; private set; }
@@ -91,12 +90,12 @@ namespace Microsoft.Spark.Extensions.Hyperspace.Index
                     "builder"));
 
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public override bool Equals(object that) => (bool)_jvmObject.Invoke("equals", that);
+        public override bool Equals(object that) => (bool)Reference.Invoke("equals", that);
 
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public override int GetHashCode() => (int)_jvmObject.Invoke("hashCode");
+        public override int GetHashCode() => (int)Reference.Invoke("hashCode");
 
         [HyperspaceSince(HyperspaceVersions.V0_0_1)]
-        public override string ToString() => (string)_jvmObject.Invoke("toString");
+        public override string ToString() => (string)Reference.Invoke("toString");
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/JvmThreadPoolGCTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/JvmThreadPoolGCTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         {
             _loggerService = LoggerServiceFactory.GetLogger(typeof(JvmThreadPoolGCTests));
             _spark = fixture.Spark;
-            _jvmBridge = ((IJvmObjectReferenceProvider)_spark).Reference.Jvm;
+            _jvmBridge = _spark.Reference.Jvm;
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/SparkContextTests.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Hadoop.Conf;
@@ -53,6 +51,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Assert.IsType<string>(sc.GetCheckpointDir());
 
             Assert.IsType<Configuration>(sc.HadoopConfiguration());
+            
+            Assert.NotNull(sc.Version());
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/SparkSessionTests.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             Assert.IsType<Catalog>(_spark.Catalog);
 
+            Assert.NotNull(_spark.Version());
+        
             Assert.IsType<SparkSession>(SparkSession.Active());
         }
 

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Spark.E2ETest
                 
             Spark.SparkContext.SetLogLevel(DefaultLogLevel);
 
-            Jvm = ((IJvmObjectReferenceProvider)Spark).Reference.Jvm;
+            Jvm = Spark.Reference.Jvm;
         }
 
         public void Dispose()

--- a/src/csharp/Microsoft.Spark.E2ETest/Utils/MemoryStream.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Utils/MemoryStream.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.E2ETest.Utils
                 typeof(T).Name);
         }
 
-        public JvmObjectReference Reference { get; }
+        public JvmObjectReference Reference { get; private set; }
 
         internal DataFrame ToDF() => new DataFrame((JvmObjectReference)Reference.Invoke("toDF"));
 

--- a/src/csharp/Microsoft.Spark.E2ETest/Utils/MemoryStream.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/Utils/MemoryStream.cs
@@ -16,25 +16,21 @@ namespace Microsoft.Spark.E2ETest.Utils
     /// </typeparam>
     internal class MemoryStream<T> : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal MemoryStream(SparkSession sparkSession)
         {
-            JvmObjectReference sparkSessionRef =
-                ((IJvmObjectReferenceProvider)sparkSession).Reference;
-
-            _jvmObject = (JvmObjectReference)sparkSessionRef.Jvm.CallStaticJavaMethod(
+            JvmObjectReference sparkSessionRef = sparkSession.Reference;
+            Reference = (JvmObjectReference)sparkSessionRef.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.sql.test.TestUtils",
                 "createMemoryStream",
                 sparkSessionRef.Invoke("sqlContext"),
                 typeof(T).Name);
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; }
 
-        internal DataFrame ToDF() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("toDF"));
+        internal DataFrame ToDF() => new DataFrame((JvmObjectReference)Reference.Invoke("toDF"));
 
         // TODO: "addData" returns an Offset. Expose class if needed.	
-        internal void AddData(T[] data) => _jvmObject.Invoke("addData", data);
+        internal void AddData(T[] data) => Reference.Invoke("addData", data);
     }
 }

--- a/src/csharp/Microsoft.Spark/Broadcast.cs
+++ b/src/csharp/Microsoft.Spark/Broadcast.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Spark
             _bid = (long)_jvmObject.Invoke("id");
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference => _jvmObject;
 
         /// <summary>
         /// Get the broadcasted value.
@@ -98,8 +98,7 @@ namespace Microsoft.Spark
         /// <returns>Absolute filepath of the created random file</returns>
         private string CreateTempFilePath(SparkConf conf)
         {
-            IJvmBridge jvm = ((IJvmObjectReferenceProvider)conf).Reference.Jvm;
-            var localDir = (string)jvm.CallStaticJavaMethod(
+            var localDir = (string)conf.Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.util.Utils",
                 "getLocalDir",
                 conf);
@@ -116,8 +115,7 @@ namespace Microsoft.Spark
         /// <returns>Returns broadcast variable of type <see cref="JvmObjectReference"/></returns>
         private JvmObjectReference CreateBroadcast(SparkContext sc, T value)
         {
-            IJvmBridge jvm = ((IJvmObjectReferenceProvider)sc).Reference.Jvm;
-            var javaSparkContext = (JvmObjectReference)jvm.CallStaticJavaMethod(
+            var javaSparkContext = (JvmObjectReference)sc.Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.api.java.JavaSparkContext",
                 "fromSparkContext",
                 sc);

--- a/src/csharp/Microsoft.Spark/Hadoop/Conf/Configuration.cs
+++ b/src/csharp/Microsoft.Spark/Hadoop/Conf/Configuration.cs
@@ -11,13 +11,11 @@ namespace Microsoft.Spark.Hadoop.Conf
     /// </summary>
     public class Configuration : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Configuration(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
     }
 }

--- a/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
+++ b/src/csharp/Microsoft.Spark/Hadoop/Fs/FileSystem.cs
@@ -20,14 +20,12 @@ namespace Microsoft.Spark.Hadoop.Fs
     /// </summary>
     public class FileSystem : IJvmObjectReferenceProvider, IDisposable
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal FileSystem(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns the configured <see cref="FileSystem"/>.
@@ -52,7 +50,7 @@ namespace Microsoft.Spark.Hadoop.Fs
             JvmObjectReference pathObject =
                 SparkEnvironment.JvmBridge.CallConstructor("org.apache.hadoop.fs.Path", path);
 
-            return (bool)_jvmObject.Invoke("delete", pathObject, recursive);
+            return (bool)Reference.Invoke("delete", pathObject, recursive);
         }
 
         /// <summary>
@@ -65,9 +63,9 @@ namespace Microsoft.Spark.Hadoop.Fs
             JvmObjectReference pathObject =
                 SparkEnvironment.JvmBridge.CallConstructor("org.apache.hadoop.fs.Path", path);
 
-            return (bool)_jvmObject.Invoke("exists", pathObject);
+            return (bool)Reference.Invoke("exists", pathObject);
         }
 
-        public void Dispose() => _jvmObject.Invoke("close");
+        public void Dispose() => Reference.Invoke("close");
     }
 }

--- a/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/ArrayList.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/ArrayList.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
     /// </summary>
     internal sealed class ArrayList : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
 
         /// <summary>
         /// Create a <c>java.util.ArrayList</c> JVM object
@@ -20,14 +19,14 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
         /// <param name="jvm">JVM bridge to use</param>
         internal ArrayList(IJvmBridge jvm)
         {
-            _jvmObject = jvm.CallConstructor("java.util.ArrayList");
+            Reference = jvm.CallConstructor("java.util.ArrayList");
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         internal void Add(object element)
         {
-            _jvmObject.Invoke("add", element);
+            Reference.Invoke("add", element);
         }
 
         internal void AddAll(IEnumerable<object> collection)

--- a/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/Hashtable.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/Hashtable.cs
@@ -11,16 +11,14 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
     /// </summary>
     internal sealed class Hashtable : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         /// <summary>
         /// Create a <c>java.util.Hashtable</c> JVM object
         /// </summary>
         /// <param name="jvm">JVM bridge to use</param>
         internal Hashtable(IJvmBridge jvm) =>
-            _jvmObject = jvm.CallConstructor("java.util.Hashtable");
+            Reference = jvm.CallConstructor("java.util.Hashtable");
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Maps the specified key to the specified value in this Hashtable.
@@ -29,6 +27,6 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
         /// <param name="key">The Hashtable key</param>
         /// <param name="value">The value</param>
         internal void Put(object key, object value) =>
-            _jvmObject.Invoke("put", key, value);
+            Reference.Invoke("put", key, value);
     }
 }

--- a/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/Properties.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Internal/Java/Util/Properties.cs
@@ -12,14 +12,12 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
     /// </summary>
     internal class Properties : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         /// <summary>
         /// Create a <c>java.util.Properties</c> JVM object
         /// </summary>
         /// <param name="jvm">JVM bridge to use</param>
         internal Properties(IJvmBridge jvm) =>
-            _jvmObject = jvm.CallConstructor("java.util.Properties");
+            Reference = jvm.CallConstructor("java.util.Properties");
 
         /// <summary>
         /// Create a <c>java.util.Properties</c> JVM object and populate the entries
@@ -30,11 +28,11 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
         /// <c>java.util.Properties</c> JVM object</param>
         internal Properties(IJvmBridge jvm, Dictionary<string, string> properties) : this(jvm)
         {
-            if (_jvmObject != null)
+            if (Reference != null)
             {
                 foreach (KeyValuePair<string, string> property in properties)
                 {
-                    _jvmObject.Invoke(
+                    Reference.Invoke(
                         "setProperty",
                         property.Key,
                         property.Value);
@@ -42,6 +40,6 @@ namespace Microsoft.Spark.Interop.Internal.Java.Util
             }
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
     }
 }

--- a/src/csharp/Microsoft.Spark/Interop/Internal/Scala/Option.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Internal/Scala/Option.cs
@@ -11,33 +11,31 @@ namespace Microsoft.Spark.Interop.Internal.Scala
     /// </summary>
     internal sealed class Option : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Option(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns true if the option is None, false otherwise.
         /// </summary>
         /// <returns>true if the option is None, false otherwise</returns>
-        internal bool IsEmpty() => (bool)_jvmObject.Invoke("isEmpty");
+        internal bool IsEmpty() => (bool)Reference.Invoke("isEmpty");
 
         /// <summary>
         /// Returns true if the option is an instance of Some, false otherwise.
         /// </summary>
         /// <returns>true if the option is an instance of Some, false otherwise</returns>
-        internal bool IsDefined() => (bool)_jvmObject.Invoke("isDefined");
+        internal bool IsDefined() => (bool)Reference.Invoke("isDefined");
 
         /// <summary>
         /// Returns the option's value as object type if the option is nonempty,
         /// otherwise throws an exception on JVM side.
         /// </summary>
         /// <returns>object that this Option is referencing to</returns>
-        internal object Get() => _jvmObject.Invoke("get");
+        internal object Get() => Reference.Invoke("get");
 
         /// <summary>
         /// Returns the option's value if it is nonempty, or `null` if it is empty.

--- a/src/csharp/Microsoft.Spark/Interop/Internal/Scala/Seq.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Internal/Scala/Seq.cs
@@ -15,18 +15,16 @@ namespace Microsoft.Spark.Interop.Internal.Scala
     /// <typeparam name="T"></typeparam>
     internal sealed class Seq<T> : IJvmObjectReferenceProvider, IEnumerable<T>
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Seq(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public int Size => (int)_jvmObject.Invoke("size");
+        public int Size => (int)Reference.Invoke("size");
 
         public IEnumerator<T> GetEnumerator()
         {
@@ -36,6 +34,6 @@ namespace Microsoft.Spark.Interop.Internal.Scala
             }
         }
 
-        public T Apply(int index) => (T)_jvmObject.Invoke("apply", index);
+        public T Apply(int index) => (T)Reference.Invoke("apply", index);
     }
 }

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Spark.Interop.Ipc
     /// <summary>
     /// Interface of the bridge between JVM and CLR.
     /// </summary>
+    /// <remarks>
+    /// This is exposed to help users interact with the JVM. It is provided with limited
+    /// support and should be used with caution.
+    /// </remarks>
     public interface IJvmBridge : IDisposable
     {
         // Each method has three overloads: one argument,
@@ -19,50 +23,153 @@ namespace Microsoft.Spark.Interop.Ipc
         // is covered by the compiler using Array.Empty with
         // the params array overload).
 
+        /// <summary>
+        /// Call java class constructor.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="arg0">Parameter for the constructor.</param>
+        /// <returns>The <see cref="JvmObjectReference"/> of the constructed class.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         JvmObjectReference CallConstructor(
             string className,
             object arg0);
 
+        /// <summary>
+        /// Call java class constructor.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="arg0">First parameter for the constructor.</param>
+        /// <param name="arg1">Second parameter for the constructor.</param>
+        /// <returns>The <see cref="JvmObjectReference"/> of the constructed class.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         JvmObjectReference CallConstructor(
             string className,
             object arg0,
             object arg1);
 
+        /// <summary>
+        /// Call java class constructor.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="args">Parameters for the constructor.</param>
+        /// <returns>The <see cref="JvmObjectReference"/> of the constructed class.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         JvmObjectReference CallConstructor(
             string className,
             params object[] args);
 
-
+        /// <summary>
+        /// Call static java method.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="arg0">Parameter for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallStaticJavaMethod(
             string className,
             string methodName,
             object arg0);
 
+        /// <summary>
+        /// Call static java method.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="arg0">First parameter for the method.</param>
+        /// <param name="arg1">Second parameter for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallStaticJavaMethod(
             string className,
             string methodName,
             object arg0,
             object arg1);
 
+        /// <summary>
+        /// Call static java method.
+        /// </summary>
+        /// <param name="className">The class name.</param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="args">Parameters for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallStaticJavaMethod(
             string className,
             string methodName,
             params object[] args);
 
-
+        /// <summary>
+        /// Invokes a method on the JVM object that <paramref name="jvmObject"/> references to.
+        /// </summary>
+        /// <param name="jvmObject">
+        /// The <see cref="JvmObjectReference"/> on which to invoke the method.
+        /// </param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="arg0">Parameter for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             object arg0);
 
+        /// <summary>
+        /// Invokes a method on the JVM object that <paramref name="jvmObject"/> references to.
+        /// </summary>
+        /// <param name="jvmObject">
+        /// The <see cref="JvmObjectReference"/> on which to invoke the method.
+        /// </param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="arg0">First parameter for the method.</param>
+        /// <param name="arg1">Second parameter for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             object arg0,
             object arg1);
 
+        /// <summary>
+        /// Invokes a method on the JVM object that <paramref name="jvmObject"/> references to.
+        /// </summary>
+        /// <param name="jvmObject">
+        /// The <see cref="JvmObjectReference"/> on which to invoke the method.
+        /// </param>
+        /// <param name="methodName">Method name to invoke.</param>
+        /// <param name="args">Parameters for the method.</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             params object[] args);
     }

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/IJvmBridge.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Spark.Interop.Ipc
     /// <summary>
     /// Interface of the bridge between JVM and CLR.
     /// </summary>
-    internal interface IJvmBridge : IDisposable
+    public interface IJvmBridge : IDisposable
     {
         // Each method has three overloads: one argument,
         // two arguments, and a params array of arguments.

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -113,20 +113,20 @@ namespace Microsoft.Spark.Interop.Ipc
             CallJavaMethod(isStatic: true, className, methodName, args);
 
         public object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             object arg0) =>
             CallJavaMethod(isStatic: false, objectId, methodName, arg0);
 
         public object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             object arg0,
             object arg1) =>
             CallJavaMethod(isStatic: false, objectId, methodName, arg0, arg1);
 
         public object CallNonStaticJavaMethod(
-            JvmObjectReference objectId,
+            JvmObjectReference jvmObject,
             string methodName,
             object[] args) =>
             CallJavaMethod(isStatic: false, objectId, methodName, args);

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -116,20 +116,20 @@ namespace Microsoft.Spark.Interop.Ipc
             JvmObjectReference jvmObject,
             string methodName,
             object arg0) =>
-            CallJavaMethod(isStatic: false, objectId, methodName, arg0);
+            CallJavaMethod(isStatic: false, jvmObject, methodName, arg0);
 
         public object CallNonStaticJavaMethod(
             JvmObjectReference jvmObject,
             string methodName,
             object arg0,
             object arg1) =>
-            CallJavaMethod(isStatic: false, objectId, methodName, arg0, arg1);
+            CallJavaMethod(isStatic: false, jvmObject, methodName, arg0, arg1);
 
         public object CallNonStaticJavaMethod(
             JvmObjectReference jvmObject,
             string methodName,
             object[] args) =>
-            CallJavaMethod(isStatic: false, objectId, methodName, args);
+            CallJavaMethod(isStatic: false, jvmObject, methodName, args);
 
         private object CallJavaMethod(
             bool isStatic,

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
@@ -106,12 +106,20 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <summary>
         /// Gets the <see cref="JvmObjectReference"/> wrapped by the object.
         /// </summary>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         JvmObjectReference Reference { get; }
     }
 
     /// <summary>
     /// Reference to object created in JVM.
     /// </summary>
+    /// <remarks>
+    /// This is exposed to help users interact with the JVM. It is provided with limited
+    /// support and should be used with caution.
+    /// </remarks>
     public sealed class JvmObjectReference : IJvmObjectReferenceProvider
     {
         /// <summary>
@@ -154,6 +162,10 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <summary>
         /// IJvmBridge instance that created the JVM object.
         /// </summary>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         public IJvmBridge Jvm => Id.Jvm;
 
         JvmObjectReference IJvmObjectReferenceProvider.Reference => this;
@@ -163,6 +175,11 @@ namespace Microsoft.Spark.Interop.Ipc
         /// </summary>
         /// <param name="arg0">Parameter for the method.</param>
         /// <param name="methodName">Method name to invoke</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         public object Invoke(string methodName, object arg0) =>
             Jvm.CallNonStaticJavaMethod(this, methodName, arg0);
 
@@ -172,6 +189,11 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <param name="arg0">First parameter for the method.</param>
         /// <param name="arg1">Second parameter for the method.</param>
         /// <param name="methodName">Method name to invoke</param>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         public object Invoke(string methodName, object arg0, object arg1) =>
             Jvm.CallNonStaticJavaMethod(this, methodName, arg0, arg1);
 
@@ -180,7 +202,11 @@ namespace Microsoft.Spark.Interop.Ipc
         /// </summary>
         /// <param name="methodName">Method name to invoke</param>
         /// <param name="args">Parameters for the method</param>
-        /// <returns></returns>
+        /// <returns>The returned object of the method call.</returns>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
         public object Invoke(string methodName, params object[] args)
         {
             return Jvm.CallNonStaticJavaMethod(this, methodName, args);

--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmObjectReference.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Spark.Interop.Ipc
     /// <summary>
     /// Implemented by objects that contain a <see cref="JvmObjectReference"/>.
     /// </summary>
-    internal interface IJvmObjectReferenceProvider
+    public interface IJvmObjectReferenceProvider
     {
         /// <summary>
         /// Gets the <see cref="JvmObjectReference"/> wrapped by the object.
@@ -112,7 +112,7 @@ namespace Microsoft.Spark.Interop.Ipc
     /// <summary>
     /// Reference to object created in JVM.
     /// </summary>
-    internal sealed class JvmObjectReference : IJvmObjectReferenceProvider
+    public sealed class JvmObjectReference : IJvmObjectReferenceProvider
     {
         /// <summary>
         /// The time when this reference was created.
@@ -154,7 +154,7 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <summary>
         /// IJvmBridge instance that created the JVM object.
         /// </summary>
-        internal IJvmBridge Jvm => Id.Jvm;
+        public IJvmBridge Jvm => Id.Jvm;
 
         JvmObjectReference IJvmObjectReferenceProvider.Reference => this;
 
@@ -163,7 +163,7 @@ namespace Microsoft.Spark.Interop.Ipc
         /// </summary>
         /// <param name="arg0">Parameter for the method.</param>
         /// <param name="methodName">Method name to invoke</param>
-        internal object Invoke(string methodName, object arg0) =>
+        public object Invoke(string methodName, object arg0) =>
             Jvm.CallNonStaticJavaMethod(this, methodName, arg0);
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <param name="arg0">First parameter for the method.</param>
         /// <param name="arg1">Second parameter for the method.</param>
         /// <param name="methodName">Method name to invoke</param>
-        internal object Invoke(string methodName, object arg0, object arg1) =>
+        public object Invoke(string methodName, object arg0, object arg1) =>
             Jvm.CallNonStaticJavaMethod(this, methodName, arg0, arg1);
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Microsoft.Spark.Interop.Ipc
         /// <param name="methodName">Method name to invoke</param>
         /// <param name="args">Parameters for the method</param>
         /// <returns></returns>
-        internal object Invoke(string methodName, params object[] args)
+        public object Invoke(string methodName, params object[] args)
         {
             return Jvm.CallNonStaticJavaMethod(this, methodName, args);
         }

--- a/src/csharp/Microsoft.Spark/Interop/SparkEnvironment.cs
+++ b/src/csharp/Microsoft.Spark/Interop/SparkEnvironment.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Spark.Interop
     /// <summary>
     /// Contains everything needed to setup an environment for using .NET with Spark.
     /// </summary>
-    internal static class SparkEnvironment
+    public static class SparkEnvironment
     {
         private static readonly ILoggerService s_logger =
             LoggerServiceFactory.GetLogger(typeof(SparkEnvironment));
@@ -59,7 +59,14 @@ namespace Microsoft.Spark.Interop
         }
 
         private static IJvmBridge s_jvmBridge;
-        internal static IJvmBridge JvmBridge
+        /// <summary>
+        /// The bridge between the JVM and the CLR.
+        /// </summary>
+        /// <remarks>
+        /// This is exposed to help users interact with the JVM. It is provided with limited
+        /// support and should be used with caution.
+        /// </remarks>
+        public static IJvmBridge JvmBridge
         {
             get
             {

--- a/src/csharp/Microsoft.Spark/ML/Feature/Bucketizer.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/Bucketizer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Spark.ML.Feature
     /// will be thrown. The splits parameter is only used for single column usage, and splitsArray
     /// is for multiple columns.
     /// </summary>
-    public class Bucketizer : FeatureBase<Bucketizer>, IJvmObjectReferenceProvider
+    public class Bucketizer : FeatureBase<Bucketizer>
     {
         private static readonly string s_bucketizerClassName = 
             "org.apache.spark.ml.feature.Bucketizer";
@@ -44,14 +44,12 @@ namespace Microsoft.Spark.ML.Feature
         internal Bucketizer(JvmObjectReference jvmObject) : base(jvmObject)
         {
         }
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
         
         /// <summary>
         /// Gets the splits that were set using SetSplits
         /// </summary>
         /// <returns>double[], the splits to be used to bucket the input column</returns>
-        public double[] GetSplits() => (double[])_jvmObject.Invoke("getSplits");
+        public double[] GetSplits() => (double[])Reference.Invoke("getSplits");
 
         /// <summary>
         /// Split points for splitting a single column into buckets. To split multiple columns use
@@ -65,13 +63,13 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetSplits(double[] value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setSplits", value));
+            WrapAsBucketizer(Reference.Invoke("setSplits", value));
 
         /// <summary>
         /// Gets the splits that were set by SetSplitsArray
         /// </summary>
         /// <returns>double[][], the splits to be used to bucket the input columns</returns>
-        public double[][] GetSplitsArray() => (double[][])_jvmObject.Invoke("getSplitsArray");
+        public double[][] GetSplitsArray() => (double[][])Reference.Invoke("getSplitsArray");
 
         /// <summary>
         /// Split points fot splitting multiple columns into buckets. To split a single column use
@@ -85,14 +83,14 @@ namespace Microsoft.Spark.ML.Feature
         /// Values outside the splits specified will be treated as errors.</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetSplitsArray(double[][] value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setSplitsArray", (object)value));
+            WrapAsBucketizer(Reference.Invoke("setSplitsArray", (object)value));
 
         /// <summary>
         /// Gets the column that the <see cref="Bucketizer"/> should read from and convert into
         /// buckets. This would have been set by SetInputCol
         /// </summary>
         /// <returns>string, the input column</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
 
         /// <summary>
         /// Sets the column that the <see cref="Bucketizer"/> should read from and convert into
@@ -101,7 +99,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as the source of the buckets</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetInputCol(string value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setInputCol", value));
+            WrapAsBucketizer(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// Gets the columns that <see cref="Bucketizer"/> should read from and convert into
@@ -109,7 +107,7 @@ namespace Microsoft.Spark.ML.Feature
         /// </summary>
        /// <returns>IEnumerable&lt;string&gt;, list of input columns</returns>
         public IEnumerable<string> GetInputCols() => 
-            ((string[])(_jvmObject.Invoke("getInputCols"))).ToList();
+            ((string[])(Reference.Invoke("getInputCols"))).ToList();
 
         /// <summary>
         /// Sets the columns that <see cref="Bucketizer"/> should read from and convert into
@@ -121,14 +119,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">List of input columns to use as sources for buckets</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetInputCols(IEnumerable<string> value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setInputCols", value));
+            WrapAsBucketizer(Reference.Invoke("setInputCols", value));
 
         /// <summary>
         /// Gets the name of the column the output data will be written to. This is set by
         /// SetInputCol
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
 
         /// <summary>
         /// The <see cref="Bucketizer"/> will create a new column in the DataFrame, this is the
@@ -137,7 +135,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the new column which contains the bucket ID</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetOutputCol(string value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsBucketizer(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// The list of columns that the <see cref="Bucketizer"/> will create in the DataFrame.
@@ -145,7 +143,7 @@ namespace Microsoft.Spark.ML.Feature
         /// </summary>
         /// <returns>IEnumerable&lt;string&gt;, list of output columns</returns>
         public IEnumerable<string> GetOutputCols() => 
-            ((string[])_jvmObject.Invoke("getOutputCols")).ToList();
+            ((string[])Reference.Invoke("getOutputCols")).ToList();
 
         /// <summary>
         /// The list of columns that the <see cref="Bucketizer"/> will create in the DataFrame.
@@ -153,7 +151,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">List of column names which will contain the bucket ID</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetOutputCols(List<string> value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setOutputCols", value));
+            WrapAsBucketizer(Reference.Invoke("setOutputCols", value));
 
         /// <summary>
         /// Loads the <see cref="Bucketizer"/> that was previously saved using Save
@@ -174,14 +172,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <see cref="DataFrame"/> containing the original data and the new bucketed columns
         /// </returns>
         public DataFrame Transform(DataFrame source) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// How should the <see cref="Bucketizer"/> handle invalid data, choices are "skip",
         /// "error" or "keep"
         /// </summary>
         /// <returns>string showing the way Spark will handle invalid data</returns>
-        public string GetHandleInvalid() => (string)_jvmObject.Invoke("getHandleInvalid");
+        public string GetHandleInvalid() => (string)Reference.Invoke("getHandleInvalid");
 
         /// <summary>
         /// Tells the <see cref="Bucketizer"/> what to do with invalid data.
@@ -191,7 +189,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">"skip", "error" or "keep"</param>
         /// <returns>New <see cref="Bucketizer"/> object</returns>
         public Bucketizer SetHandleInvalid(string value) => 
-            WrapAsBucketizer(_jvmObject.Invoke("setHandleInvalid", value.ToString()));
+            WrapAsBucketizer(Reference.Invoke("setHandleInvalid", value.ToString()));
 
         private static Bucketizer WrapAsBucketizer(object obj) => 
             new Bucketizer((JvmObjectReference)obj);

--- a/src/csharp/Microsoft.Spark/ML/Feature/CountVectorizer.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/CountVectorizer.cs
@@ -8,7 +8,7 @@ using Microsoft.Spark.Sql;
 
 namespace Microsoft.Spark.ML.Feature
 {
-    public class CountVectorizer : FeatureBase<CountVectorizer>, IJvmObjectReferenceProvider
+    public class CountVectorizer : FeatureBase<CountVectorizer>
     {
         private static readonly string s_countVectorizerClassName = 
             "org.apache.spark.ml.feature.CountVectorizer";
@@ -33,13 +33,11 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>Fits a model to the input data.</summary>
         /// <param name="dataFrame">The <see cref="DataFrame"/> to fit the model to.</param>
         /// <returns><see cref="CountVectorizerModel"/></returns>
         public CountVectorizerModel Fit(DataFrame dataFrame) => 
-            new CountVectorizerModel((JvmObjectReference)_jvmObject.Invoke("fit", dataFrame));
+            new CountVectorizerModel((JvmObjectReference)Reference.Invoke("fit", dataFrame));
 
         /// <summary>
         /// Loads the <see cref="CountVectorizer"/> that was previously saved using Save.
@@ -59,7 +57,7 @@ namespace Microsoft.Spark.ML.Feature
         /// models that model binary events rather than integer counts. Default: false
         /// </summary>
         /// <returns>boolean</returns>
-        public bool GetBinary() => (bool)_jvmObject.Invoke("getBinary");
+        public bool GetBinary() => (bool)Reference.Invoke("getBinary");
         
         /// <summary>
         /// Sets the binary toggle to control the output vector values. If True, all nonzero counts
@@ -69,14 +67,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">Turn the binary toggle on or off</param>
         /// <returns><see cref="CountVectorizer"/> with the new binary toggle value set</returns>
         public CountVectorizer SetBinary(bool value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setBinary", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setBinary", value));
 
         /// <summary>
         /// Gets the column that the <see cref="CountVectorizer"/> should read from and convert
         /// into buckets. This would have been set by SetInputCol.
         /// </summary>
         /// <returns>The input column of type string</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
         
         /// <summary>
         /// Sets the column that the <see cref="CountVectorizer"/> should read from.
@@ -84,14 +82,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to use as the source.</param>
         /// <returns><see cref="CountVectorizer"/> with the input column set</returns>
         public CountVectorizer SetInputCol(string value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setInputCol", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setInputCol", value));
         
         /// <summary>
         /// Gets the name of the new column the <see cref="CountVectorizer"/> creates in the
         /// DataFrame.
         /// </summary>
         /// <returns>The name of the output column.</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
         
         /// <summary>
         /// Sets the name of the new column the <see cref="CountVectorizer"/> creates in the
@@ -100,7 +98,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the output column which will be created.</param>
         /// <returns>New <see cref="CountVectorizer"/> with the output column set</returns>
         public CountVectorizer SetOutputCol(string value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setOutputCol", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setOutputCol", value));
         
         /// <summary>
         /// Gets the maximum number of different documents a term could appear in to be included in
@@ -111,7 +109,7 @@ namespace Microsoft.Spark.ML.Feature
         /// </summary>
         /// <returns>The maximum document term frequency</returns>
         [Since(Versions.V2_4_0)]
-        public double GetMaxDF() => (double)_jvmObject.Invoke("getMaxDF");
+        public double GetMaxDF() => (double)Reference.Invoke("getMaxDF");
 
         /// <summary>
         /// Sets the maximum number of different documents a term could appear in to be included in
@@ -124,7 +122,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <returns>New <see cref="CountVectorizer"/> with the max df value set</returns>
         [Since(Versions.V2_4_0)]
         public CountVectorizer SetMaxDF(double value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setMaxDF", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setMaxDF", value));
         
         /// <summary>
         /// Gets the minimum number of different documents a term must appear in to be included in
@@ -133,7 +131,7 @@ namespace Microsoft.Spark.ML.Feature
         /// specifies the fraction of documents.
         /// </summary>
         /// <returns>The minimum document term frequency</returns>
-        public double GetMinDF() => (double)_jvmObject.Invoke("getMinDF");
+        public double GetMinDF() => (double)Reference.Invoke("getMinDF");
         
         /// <summary>
         /// Sets the minimum number of different documents a term must appear in to be included in
@@ -144,7 +142,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The minimum document term frequency</param>
         /// <returns>New <see cref="CountVectorizer"/> with the min df value set</returns>
         public CountVectorizer SetMinDF(double value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setMinDF", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setMinDF", value));
         
         /// <summary>
         /// Gets the filter to ignore rare words in a document. For each document, terms with
@@ -157,7 +155,7 @@ namespace Microsoft.Spark.ML.Feature
         /// affect fitting.
         /// </summary>
         /// <returns>Minimum term frequency</returns>
-        public double GetMinTF() => (double)_jvmObject.Invoke("getMinTF");
+        public double GetMinTF() => (double)Reference.Invoke("getMinTF");
 
         /// <summary>
         /// Sets the filter to ignore rare words in a document. For each document, terms with
@@ -172,7 +170,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">Minimum term frequency</param>
         /// <returns>New <see cref="CountVectorizer"/> with the min term frequency set</returns>
         public CountVectorizer SetMinTF(double value) =>
-            WrapAsCountVectorizer((JvmObjectReference)_jvmObject.Invoke("setMinTF", value));
+            WrapAsCountVectorizer((JvmObjectReference)Reference.Invoke("setMinTF", value));
         
         /// <summary>
         /// Gets the max size of the vocabulary. <see cref="CountVectorizer"/> will build a
@@ -180,7 +178,7 @@ namespace Microsoft.Spark.ML.Feature
         /// the corpus.
         /// </summary>
         /// <returns>The max size of the vocabulary of type int.</returns>
-        public int GetVocabSize() => (int)_jvmObject.Invoke("getVocabSize");
+        public int GetVocabSize() => (int)Reference.Invoke("getVocabSize");
         
         /// <summary>
         /// Sets the max size of the vocabulary. <see cref="CountVectorizer"/> will build a
@@ -190,7 +188,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The max vocabulary size</param>
         /// <returns><see cref="CountVectorizer"/> with the max vocab value set</returns>
         public CountVectorizer SetVocabSize(int value) => 
-            WrapAsCountVectorizer(_jvmObject.Invoke("setVocabSize", value));
+            WrapAsCountVectorizer(Reference.Invoke("setVocabSize", value));
         
         private static CountVectorizer WrapAsCountVectorizer(object obj) => 
             new CountVectorizer((JvmObjectReference)obj);

--- a/src/csharp/Microsoft.Spark/ML/Feature/CountVectorizerModel.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/CountVectorizerModel.cs
@@ -10,8 +10,7 @@ using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.ML.Feature
 {
-    public class CountVectorizerModel
-        : FeatureBase<CountVectorizerModel>, IJvmObjectReferenceProvider
+    public class CountVectorizerModel : FeatureBase<CountVectorizerModel>
     {
         private static readonly string s_countVectorizerModelClassName = 
             "org.apache.spark.ml.feature.CountVectorizerModel";
@@ -41,8 +40,6 @@ namespace Microsoft.Spark.ML.Feature
         internal CountVectorizerModel(JvmObjectReference jvmObject) : base(jvmObject)
         {
         }
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
         
         /// <summary>
         /// Loads the <see cref="CountVectorizerModel"/> that was previously saved using Save
@@ -62,7 +59,7 @@ namespace Microsoft.Spark.ML.Feature
         /// models that model binary events rather than integer counts. Default: false
         /// </summary>
         /// <returns>Toggle value of type boolean</returns>
-        public bool GetBinary() => (bool)_jvmObject.Invoke("getBinary");
+        public bool GetBinary() => (bool)Reference.Invoke("getBinary");
 
         /// <summary>
         /// Sets the binary toggle to control the output vector values. If True, all nonzero counts
@@ -74,14 +71,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <see cref="CountVectorizerModel"/> with the new binary toggle value set
         /// </returns>
         public CountVectorizerModel SetBinary(bool value) =>
-            WrapAsCountVectorizerModel(_jvmObject.Invoke("setBinary", value));
+            WrapAsCountVectorizerModel(Reference.Invoke("setBinary", value));
 
         /// <summary>
         /// Gets the column that the <see cref="CountVectorizerModel"/> should read from and
         /// convert into buckets. This would have been set by SetInputCol
         /// </summary>
         /// <returns>string, the input column</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
         
         /// <summary>
         /// Sets the column that the <see cref="CountVectorizerModel"/> should read from.
@@ -89,14 +86,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to use as the source.</param>
         /// <returns><see cref="CountVectorizerModel"/> with the input column set</returns>
         public CountVectorizerModel SetInputCol(string value) =>
-            WrapAsCountVectorizerModel(_jvmObject.Invoke("setInputCol", value));
+            WrapAsCountVectorizerModel(Reference.Invoke("setInputCol", value));
         
         /// <summary>
         /// Gets the name of the new column the <see cref="CountVectorizerModel"/> will create in
         /// the DataFrame.
         /// </summary>
         /// <returns>The name of the output column.</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
         
         /// <summary>
         /// Sets the name of the new column the <see cref="CountVectorizerModel"/> will create in
@@ -105,7 +102,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the output column which will be created.</param>
         /// <returns>New <see cref="CountVectorizerModel"/> with the output column set</returns>
         public CountVectorizerModel SetOutputCol(string value) =>
-            WrapAsCountVectorizerModel(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsCountVectorizerModel(Reference.Invoke("setOutputCol", value));
         
         /// <summary>
         /// Gets the maximum number of different documents a term could appear in to be included in
@@ -115,7 +112,7 @@ namespace Microsoft.Spark.ML.Feature
         /// fraction of documents the term could appear in.
         /// </summary>
         /// <returns>The maximum document term frequency of type double.</returns>
-        public double GetMaxDF() => (double)_jvmObject.Invoke("getMaxDF");
+        public double GetMaxDF() => (double)Reference.Invoke("getMaxDF");
         
         /// <summary>
         /// Gets the minimum number of different documents a term must appear in to be included in
@@ -124,7 +121,7 @@ namespace Microsoft.Spark.ML.Feature
         /// specifies the fraction of documents.
         /// </summary>
         /// <returns>The minimum document term frequency</returns>
-        public double GetMinDF() => (double)_jvmObject.Invoke("getMinDF");
+        public double GetMinDF() => (double)Reference.Invoke("getMinDF");
 
         /// <summary>
         /// Gets the filter to ignore rare words in a document. For each document, terms with
@@ -137,7 +134,7 @@ namespace Microsoft.Spark.ML.Feature
         /// affect fitting.
         /// </summary>
         /// <returns>Minimum term frequency of type double.</returns>
-        public double GetMinTF() => (double)_jvmObject.Invoke("getMinTF");
+        public double GetMinTF() => (double)Reference.Invoke("getMinTF");
 
         /// <summary>
         /// Sets the filter to ignore rare words in a document. For each document, terms with
@@ -154,7 +151,7 @@ namespace Microsoft.Spark.ML.Feature
         /// New <see cref="CountVectorizerModel"/> with the min term frequency set
         /// </returns>
         public CountVectorizerModel SetMinTF(double value) =>
-            WrapAsCountVectorizerModel(_jvmObject.Invoke("setMinTF", value));
+            WrapAsCountVectorizerModel(Reference.Invoke("setMinTF", value));
         
         /// <summary>
         /// Gets the max size of the vocabulary. <see cref="CountVectorizerModel"/> will build a
@@ -162,7 +159,7 @@ namespace Microsoft.Spark.ML.Feature
         /// the corpus.
         /// </summary>
         /// <returns>The max size of the vocabulary of type int.</returns>
-        public int GetVocabSize() => (int)_jvmObject.Invoke("getVocabSize");
+        public int GetVocabSize() => (int)Reference.Invoke("getVocabSize");
         
         /// <summary>
         /// Check transform validity and derive the output schema from the input schema.
@@ -182,9 +179,9 @@ namespace Microsoft.Spark.ML.Feature
         /// </returns>
         public StructType TransformSchema(StructType value) => 
             new StructType(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "transformSchema", 
-                    DataType.FromJson(_jvmObject.Jvm, value.Json)));
+                    DataType.FromJson(Reference.Jvm, value.Json)));
         
         /// <summary>
         /// Converts a DataFrame with a text document to a sparse vector of token counts.
@@ -192,7 +189,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="document"><see cref="DataFrame"/> to transform</param>
         /// <returns><see cref="DataFrame"/> containing the original data and the counts</returns>
         public DataFrame Transform(DataFrame document) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", document));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", document));
         
         private static CountVectorizerModel WrapAsCountVectorizerModel(object obj) => 
             new CountVectorizerModel((JvmObjectReference)obj);

--- a/src/csharp/Microsoft.Spark/ML/Feature/FeatureHasher.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/FeatureHasher.cs
@@ -11,7 +11,7 @@ using Microsoft.Spark.Sql.Types;
 
 namespace Microsoft.Spark.ML.Feature
 {
-    public class FeatureHasher: FeatureBase<FeatureHasher>, IJvmObjectReferenceProvider
+    public class FeatureHasher: FeatureBase<FeatureHasher>
     {
         private static readonly string s_featureHasherClassName = 
             "org.apache.spark.ml.feature.FeatureHasher";
@@ -35,8 +35,6 @@ namespace Microsoft.Spark.ML.Feature
         internal FeatureHasher(JvmObjectReference jvmObject) : base(jvmObject)
         {
         }
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
         
         /// <summary>
         /// Loads the <see cref="FeatureHasher"/> that was previously saved using Save.
@@ -57,7 +55,7 @@ namespace Microsoft.Spark.ML.Feature
         /// </summary>
         /// <returns>List of categorical columns, set by SetCategoricalCols</returns>
         public IEnumerable<string> GetCategoricalCols() => 
-            (string[])_jvmObject.Invoke("getCategoricalCols");
+            (string[])Reference.Invoke("getCategoricalCols");
         
         /// <summary>
         /// Marks columns as categorical columns.
@@ -65,14 +63,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">List of column names to mark as categorical columns</param>
         /// <returns>New <see cref="FeatureHasher"/> object</returns>
         public FeatureHasher SetCategoricalCols(IEnumerable<string> value) => 
-            WrapAsFeatureHasher(_jvmObject.Invoke("setCategoricalCols", value));
+            WrapAsFeatureHasher(Reference.Invoke("setCategoricalCols", value));
         
         /// <summary>
         /// Gets the columns that the <see cref="FeatureHasher"/> should read from and convert into
         /// hashes. This would have been set by SetInputCol.
         /// </summary>
         /// <returns>List of the input columns, set by SetInputCols</returns>
-        public IEnumerable<string> GetInputCols() => (string[])_jvmObject.Invoke("getInputCols");
+        public IEnumerable<string> GetInputCols() => (string[])Reference.Invoke("getInputCols");
 
         /// <summary>
         /// Sets the columns that the <see cref="FeatureHasher"/> should read from and convert into
@@ -81,7 +79,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as use the source of the hash</param>
         /// <returns>New <see cref="FeatureHasher"/> object</returns>
         public FeatureHasher SetInputCols(IEnumerable<string> value) => 
-            WrapAsFeatureHasher(_jvmObject.Invoke("setInputCols", value));
+            WrapAsFeatureHasher(Reference.Invoke("setInputCols", value));
         
         /// <summary>
         /// Gets the number of features that should be used. Since a simple modulo is used to
@@ -90,7 +88,7 @@ namespace Microsoft.Spark.ML.Feature
         /// columns.
         /// </summary>
         /// <returns>The number of features to be used</returns>
-        public int GetNumFeatures() => (int)_jvmObject.Invoke("getNumFeatures");
+        public int GetNumFeatures() => (int)Reference.Invoke("getNumFeatures");
 
         /// <summary>
         /// Sets the number of features that should be used. Since a simple modulo is used to
@@ -101,14 +99,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">int value of number of features</param>
         /// <returns>New <see cref="FeatureHasher"/> object</returns>
         public FeatureHasher SetNumFeatures(int value) => 
-            WrapAsFeatureHasher(_jvmObject.Invoke("setNumFeatures", value));
+            WrapAsFeatureHasher(Reference.Invoke("setNumFeatures", value));
         
         /// <summary>
         /// Gets the name of the column the output data will be written to. This is set by
         /// SetInputCol.
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
 
         /// <summary>
         /// Sets the name of the new column in the <see cref="DataFrame"/> created by Transform.
@@ -116,7 +114,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the new column which will contain the hash</param>
         /// <returns>New <see cref="FeatureHasher"/> object</returns>
         public FeatureHasher SetOutputCol(string value) => 
-            WrapAsFeatureHasher(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsFeatureHasher(Reference.Invoke("setOutputCol", value));
         
         /// <summary>
         /// Transforms the input <see cref="DataFrame"/>. It is recommended that you validate that
@@ -125,7 +123,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">Input <see cref="DataFrame"/> to transform</param>
         /// <returns>Transformed <see cref="DataFrame"/></returns>
         public DataFrame Transform(DataFrame value) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", value));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", value));
         
         /// <summary>
         /// Check transform validity and derive the output schema from the input schema.
@@ -145,9 +143,9 @@ namespace Microsoft.Spark.ML.Feature
         /// </returns>
         public StructType TransformSchema(StructType value) => 
             new StructType(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "transformSchema", 
-                    DataType.FromJson(_jvmObject.Jvm, value.Json)));
+                    DataType.FromJson(Reference.Jvm, value.Json)));
 
         private static FeatureHasher WrapAsFeatureHasher(object obj) => 
             new FeatureHasher((JvmObjectReference)obj);

--- a/src/csharp/Microsoft.Spark/ML/Feature/HashingTF.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/HashingTF.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Spark.ML.Feature
     /// power of two as the numFeatures parameter; otherwise the features will not be mapped evenly
     /// to the columns.
     /// </summary>
-    public class HashingTF : FeatureBase<HashingTF>, IJvmObjectReferenceProvider
+    public class HashingTF : FeatureBase<HashingTF>
     {
         private static readonly string s_hashingTfClassName = 
             "org.apache.spark.ml.feature.HashingTF";
@@ -44,8 +44,6 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Loads the <see cref="HashingTF"/> that was previously saved using Save
         /// </summary>
@@ -60,7 +58,7 @@ namespace Microsoft.Spark.ML.Feature
         /// Gets the binary toggle that controls term frequency counts
         /// </summary>
         /// <returns>Flag showing whether the binary toggle is on or off</returns>
-        public bool GetBinary() => (bool)_jvmObject.Invoke("getBinary");
+        public bool GetBinary() => (bool)Reference.Invoke("getBinary");
 
         /// <summary>
         /// Binary toggle to control term frequency counts.
@@ -69,13 +67,13 @@ namespace Microsoft.Spark.ML.Feature
         ///</summary>
         /// <param name="value">binary toggle, default is false</param>
         public HashingTF SetBinary(bool value) => 
-            WrapAsHashingTF(_jvmObject.Invoke("setBinary", value));
+            WrapAsHashingTF(Reference.Invoke("setBinary", value));
 
         /// <summary>
         /// Gets the column that the <see cref="HashingTF"/> should read from
         /// </summary>
         /// <returns>string, the name of the input column</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
 
         /// <summary>
         /// Sets the column that the <see cref="HashingTF"/> should read from
@@ -83,14 +81,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as the source</param>
         /// <returns>New <see cref="HashingTF"/> object</returns>
         public HashingTF SetInputCol(string value) => 
-            WrapAsHashingTF(_jvmObject.Invoke("setInputCol", value));
+            WrapAsHashingTF(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="HashingTF"/> will create a new column in the <see cref="DataFrame"/>,
         /// this is the name of the new column.
         /// </summary>
         /// <returns>string, the name of the output col</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
 
         /// <summary>
         /// The <see cref="HashingTF"/> will create a new column in the <see cref="DataFrame"/>,
@@ -99,7 +97,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the new column</param>
         /// <returns>New <see cref="HashingTF"/> object</returns>
         public HashingTF SetOutputCol(string value) => 
-            WrapAsHashingTF(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsHashingTF(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Gets the number of features that should be used. Since a simple modulo is used to
@@ -108,7 +106,7 @@ namespace Microsoft.Spark.ML.Feature
         /// columns.
         /// </summary>
         /// <returns>The number of features to be used</returns>
-        public int GetNumFeatures() => (int)_jvmObject.Invoke("getNumFeatures");
+        public int GetNumFeatures() => (int)Reference.Invoke("getNumFeatures");
 
         /// <summary>
         /// Sets the number of features that should be used. Since a simple modulo is used to
@@ -119,7 +117,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">int</param>
         /// <returns>New <see cref="HashingTF"/> object</returns>
         public HashingTF SetNumFeatures(int value) => 
-            WrapAsHashingTF(_jvmObject.Invoke("setNumFeatures", value));
+            WrapAsHashingTF(Reference.Invoke("setNumFeatures", value));
 
         /// <summary>
         /// Executes the <see cref="HashingTF"/> and transforms the DataFrame to include the new
@@ -128,7 +126,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="source">The <see cref="DataFrame"/> to add the tokens to</param>
         /// <returns><see cref="DataFrame"/> containing the original data and the tokens</returns>
         public DataFrame Transform(DataFrame source) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         private static HashingTF WrapAsHashingTF(object obj) => 
             new HashingTF((JvmObjectReference)obj);

--- a/src/csharp/Microsoft.Spark/ML/Feature/IDF.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/IDF.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Spark.ML.Feature
     /// of documents (controlled by the variable minDocFreq). For terms that are not in at least
     /// minDocFreq documents, the IDF is found as 0, resulting in TF-IDFs of 0.
     /// </summary>
-    public class IDF : FeatureBase<IDF>, IJvmObjectReferenceProvider
+    public class IDF : FeatureBase<IDF>
     {
         private static readonly string s_IDFClassName = "org.apache.spark.ml.feature.IDF";
         
@@ -41,27 +41,25 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
         
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Gets the column that the <see cref="IDF"/> should read from
         /// </summary>
         /// <returns>string, input column</returns>
-        public string GetInputCol() => (string)(_jvmObject.Invoke("getInputCol"));
+        public string GetInputCol() => (string)(Reference.Invoke("getInputCol"));
 
         /// <summary>
         /// Sets the column that the <see cref="IDF"/> should read from
         /// </summary>
         /// <param name="value">The name of the column to as the source</param>
         /// <returns>New <see cref="IDF"/> object</returns>
-        public IDF SetInputCol(string value) => WrapAsIDF(_jvmObject.Invoke("setInputCol", value));
+        public IDF SetInputCol(string value) => WrapAsIDF(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="IDF"/> will create a new column in the DataFrame, this is the
         /// name of the new column.
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)(_jvmObject.Invoke("getOutputCol"));
+        public string GetOutputCol() => (string)(Reference.Invoke("getOutputCol"));
 
         /// <summary>
         /// The <see cref="IDF"/> will create a new column in the DataFrame, this is the
@@ -70,13 +68,13 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the new column</param>
         /// <returns>New <see cref="IDF"/> object</returns>
         public IDF SetOutputCol(string value) => 
-            WrapAsIDF(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsIDF(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Minimum of documents in which a term should appear for filtering
         /// </summary>
         /// <returns>int, minimum number of documents in which a term should appear</returns>
-        public int GetMinDocFreq() => (int)_jvmObject.Invoke("getMinDocFreq");
+        public int GetMinDocFreq() => (int)Reference.Invoke("getMinDocFreq");
 
         /// <summary>
         /// Minimum of documents in which a term should appear for filtering
@@ -84,7 +82,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">int, the minimum of documents a term should appear in</param>
         /// <returns>New <see cref="IDF"/> object</returns>
         public IDF SetMinDocFreq(int value) => 
-            WrapAsIDF(_jvmObject.Invoke("setMinDocFreq", value));
+            WrapAsIDF(Reference.Invoke("setMinDocFreq", value));
 
         /// <summary>
         /// Fits a model to the input data.
@@ -92,7 +90,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="source">The <see cref="DataFrame"/> to fit the model to</param>
         /// <returns>New <see cref="IDFModel"/> object</returns>
         public IDFModel Fit(DataFrame source) => 
-            new IDFModel((JvmObjectReference)_jvmObject.Invoke("fit", source));
+            new IDFModel((JvmObjectReference)Reference.Invoke("fit", source));
 
         /// <summary>
         /// Loads the <see cref="IDF"/> that was previously saved using Save

--- a/src/csharp/Microsoft.Spark/ML/Feature/IDFModel.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/IDFModel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Spark.ML.Feature
     /// A <see cref="IDFModel"/> that converts the input string to lowercase and then splits it by
     /// white spaces.
     /// </summary>
-    public class IDFModel : FeatureBase<IDFModel>, IJvmObjectReferenceProvider
+    public class IDFModel : FeatureBase<IDFModel>
     {
         private static readonly string s_IDFModelClassName = 
             "org.apache.spark.ml.feature.IDFModel";
@@ -36,14 +36,12 @@ namespace Microsoft.Spark.ML.Feature
         internal IDFModel(JvmObjectReference jvmObject) : base(jvmObject)
         {
         }
-        
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-        
+                
         /// <summary>
         /// Gets the column that the <see cref="IDFModel"/> should read from
         /// </summary>
         /// <returns>string, input column</returns>
-        public string GetInputCol() => (string)(_jvmObject.Invoke("getInputCol"));
+        public string GetInputCol() => (string)(Reference.Invoke("getInputCol"));
 
         /// <summary>
         /// Sets the column that the <see cref="IDFModel"/> should read from and convert into
@@ -52,14 +50,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as the source</param>
         /// <returns>New <see cref="IDFModel"/> object</returns>
         public IDFModel SetInputCol(string value) => 
-            WrapAsIDFModel(_jvmObject.Invoke("setInputCol", value));
+            WrapAsIDFModel(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="IDFModel"/> will create a new column in the <see cref="DataFrame"/>,
         /// this is the name of the new column.
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)(_jvmObject.Invoke("getOutputCol"));
+        public string GetOutputCol() => (string)(Reference.Invoke("getOutputCol"));
 
         /// <summary>
         /// The <see cref="IDFModel"/> will create a new column in the DataFrame, this is the
@@ -69,13 +67,13 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns>New <see cref="IDFModel"/> object</returns>
         public IDFModel SetOutputCol(string value) => 
-            WrapAsIDFModel(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsIDFModel(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Minimum of documents in which a term should appear for filtering
         /// </summary>
         /// <returns>Minimum number of documents a term should appear</returns>
-        public int GetMinDocFreq() => (int)_jvmObject.Invoke("getMinDocFreq");
+        public int GetMinDocFreq() => (int)Reference.Invoke("getMinDocFreq");
 
         /// <summary>
         /// Executes the <see cref="IDFModel"/> and transforms the <see cref="DataFrame"/> to
@@ -84,7 +82,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="source">The <see cref="DataFrame"/> to add the tokens to</param>
         /// <returns><see cref="DataFrame"/> containing the original data and the tokens</returns>
         public DataFrame Transform(DataFrame source) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// Loads the <see cref="IDFModel"/> that was previously saved using Save

--- a/src/csharp/Microsoft.Spark/ML/Feature/NGram.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/NGram.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Spark.ML.Feature
     /// an array of n-grams. Null values in the input array are ignored. It returns an array
     /// of n-grams where each n-gram is represented by a space-separated string of words.
     /// </summary>
-    public class NGram : FeatureBase<NGram>, IJvmObjectReferenceProvider
+    public class NGram : FeatureBase<NGram>
     {
         private static readonly string s_nGramClassName =
             "org.apache.spark.ml.feature.NGram";
@@ -40,46 +40,44 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Gets the column that the <see cref="NGram"/> should read from.
         /// </summary>
         /// <returns>string, input column</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
 
         /// <summary>
         /// Sets the column that the <see cref="NGram"/> should read from.
         /// </summary>
         /// <param name="value">The name of the column to as the source</param>
         /// <returns>New <see cref="NGram"/> object</returns>
-        public NGram SetInputCol(string value) => WrapAsNGram(_jvmObject.Invoke("setInputCol", value));
+        public NGram SetInputCol(string value) => WrapAsNGram(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// Gets the output column that the <see cref="NGram"/> writes.
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
 
         /// <summary>
         /// Sets the output column that the <see cref="NGram"/> writes.
         /// </summary>
         /// <param name="value">The name of the new column</param>
         /// <returns>New <see cref="NGram"/> object</returns>
-        public NGram SetOutputCol(string value) => WrapAsNGram(_jvmObject.Invoke("setOutputCol", value));
+        public NGram SetOutputCol(string value) => WrapAsNGram(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Gets N value for <see cref="NGram"/>.
         /// </summary>
         /// <returns>int, N value</returns>
-        public int GetN() => (int)_jvmObject.Invoke("getN");
+        public int GetN() => (int)Reference.Invoke("getN");
 
         /// <summary>
         /// Sets N value for <see cref="NGram"/>.
         /// </summary>
         /// <param name="value">N value</param>
         /// <returns>New <see cref="NGram"/> object</returns>
-        public NGram SetN(int value) => WrapAsNGram(_jvmObject.Invoke("setN", value));
+        public NGram SetN(int value) => WrapAsNGram(Reference.Invoke("setN", value));
 
         /// <summary>
         /// Executes the <see cref="NGram"/> and transforms the DataFrame to include the new
@@ -90,7 +88,7 @@ namespace Microsoft.Spark.ML.Feature
         /// New <see cref="DataFrame"/> object with the source <see cref="DataFrame"/> transformed.
         /// </returns>
         public DataFrame Transform(DataFrame source) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// Check transform validity and derive the output schema from the input schema.
@@ -110,9 +108,9 @@ namespace Microsoft.Spark.ML.Feature
         /// </returns>
         public StructType TransformSchema(StructType value) =>
             new StructType(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "transformSchema",
-                    DataType.FromJson(_jvmObject.Jvm, value.Json)));
+                    DataType.FromJson(Reference.Jvm, value.Json)));
 
         /// <summary>
         /// Loads the <see cref="NGram"/> that was previously saved using Save.

--- a/src/csharp/Microsoft.Spark/ML/Feature/SQLTransformer.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/SQLTransformer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Spark.ML.Feature
     /// <summary>
     /// <see cref="SQLTransformer"/> implements the transformations which are defined by SQL statement.
     /// </summary>
-    public class SQLTransformer : FeatureBase<SQLTransformer>, IJvmObjectReferenceProvider
+    public class SQLTransformer : FeatureBase<SQLTransformer>
     {
         private static readonly string s_sqlTransformerClassName = 
             "org.apache.spark.ml.feature.SQLTransformer";
@@ -37,8 +37,6 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Executes the <see cref="SQLTransformer"/> and transforms the DataFrame to include the new
         /// column.
@@ -48,7 +46,7 @@ namespace Microsoft.Spark.ML.Feature
         /// New <see cref="DataFrame"/> object with the source <see cref="DataFrame"/> transformed.
         /// </returns>
         public DataFrame Transform(DataFrame source) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// Executes the <see cref="SQLTransformer"/> and transforms the schema.
@@ -59,15 +57,15 @@ namespace Microsoft.Spark.ML.Feature
         /// </returns>
         public StructType TransformSchema(StructType value) =>
             new StructType(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "transformSchema",
-                    DataType.FromJson(_jvmObject.Jvm, value.Json)));
+                    DataType.FromJson(Reference.Jvm, value.Json)));
 
         /// <summary>
         /// Gets the statement.
         /// </summary>
         /// <returns>Statement</returns>
-        public string GetStatement() => (string)_jvmObject.Invoke("getStatement");
+        public string GetStatement() => (string)Reference.Invoke("getStatement");
 
         /// <summary>
         /// Sets the statement to <see cref="SQLTransformer"/>.
@@ -77,7 +75,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <see cref="SQLTransformer"/> with the statement set.
         /// </returns>
         public SQLTransformer SetStatement(string statement) =>
-            WrapAsSQLTransformer((JvmObjectReference)_jvmObject.Invoke("setStatement", statement));
+            WrapAsSQLTransformer((JvmObjectReference)Reference.Invoke("setStatement", statement));
 
         /// <summary>
         /// Loads the <see cref="SQLTransformer"/> that was previously saved using Save.

--- a/src/csharp/Microsoft.Spark/ML/Feature/StopWordsRemover.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/StopWordsRemover.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Spark.ML.Feature
     /// <summary>
     /// A <see cref="StopWordsRemover"/> feature transformer that filters out stop words from input.
     /// </summary>
-    public class StopWordsRemover : FeatureBase<StopWordsRemover>, IJvmObjectReferenceProvider
+    public class StopWordsRemover : FeatureBase<StopWordsRemover>
     {
         private static readonly string s_stopWordsRemoverClassName =
             "org.apache.spark.ml.feature.StopWordsRemover";
@@ -38,15 +38,13 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Sets the column that the <see cref="StopWordsRemover"/> should read from.
         /// </summary>
         /// <param name="value">The name of the column to use as the source</param>
         /// <returns>New <see cref="StopWordsRemover"/> object</returns>
         public StopWordsRemover SetInputCol(string value) =>
-            WrapAsStopWordsRemover(_jvmObject.Invoke("setInputCol", value));
+            WrapAsStopWordsRemover(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="StopWordsRemover"/> will create a new column in the DataFrame, this is the
@@ -55,7 +53,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to use as the target</param>
         /// <returns>New <see cref="StopWordsRemover"/> object</returns>
         public StopWordsRemover SetOutputCol(string value) =>
-            WrapAsStopWordsRemover(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsStopWordsRemover(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Executes the <see cref="StopWordsRemover"/> and transforms the DataFrame to include the new
@@ -66,20 +64,20 @@ namespace Microsoft.Spark.ML.Feature
         /// New <see cref="DataFrame"/> object with the source <see cref="DataFrame"/> transformed
         /// </returns>
         public DataFrame Transform(DataFrame source) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// Gets the column that the <see cref="StopWordsRemover"/> should read from.
         /// </summary>
         /// <returns>Input column name</returns>
-        public string GetInputCol() => (string)_jvmObject.Invoke("getInputCol");
+        public string GetInputCol() => (string)Reference.Invoke("getInputCol");
 
         /// <summary>
         /// The <see cref="StopWordsRemover"/> will create a new column in the DataFrame, this is the
         /// name of the new column.
         /// </summary>
         /// <returns>The output column name</returns>
-        public string GetOutputCol() => (string)_jvmObject.Invoke("getOutputCol");
+        public string GetOutputCol() => (string)Reference.Invoke("getOutputCol");
 
         /// <summary>
         /// Sets locale for <see cref="StopWordsRemover"/> transform.
@@ -89,14 +87,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <returns>New <see cref="StopWordsRemover"/> object</returns>
         [Since(Versions.V2_4_0)]
         public StopWordsRemover SetLocale(string value) =>
-            WrapAsStopWordsRemover(_jvmObject.Invoke("setLocale", value));
+            WrapAsStopWordsRemover(Reference.Invoke("setLocale", value));
 
         /// <summary>
         /// Gets locale for <see cref="StopWordsRemover"/> transform
         /// </summary>
         /// <returns>The locale</returns>
         [Since(Versions.V2_4_0)]
-        public string GetLocale() => (string)_jvmObject.Invoke("getLocale");
+        public string GetLocale() => (string)Reference.Invoke("getLocale");
 
         /// <summary>
         /// Sets case sensitivity.
@@ -104,13 +102,13 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">true if case sensitive, false otherwise</param>
         /// <returns>New <see cref="StopWordsRemover"/> object</returns>
         public StopWordsRemover SetCaseSensitive(bool value) =>
-            WrapAsStopWordsRemover(_jvmObject.Invoke("setCaseSensitive", value));
+            WrapAsStopWordsRemover(Reference.Invoke("setCaseSensitive", value));
 
         /// <summary>
         /// Gets case sensitivity.
         /// </summary>
         /// <returns>true if case sensitive, false otherwise</returns>
-        public bool GetCaseSensitive() => (bool)_jvmObject.Invoke("getCaseSensitive");
+        public bool GetCaseSensitive() => (bool)Reference.Invoke("getCaseSensitive");
 
         /// <summary>
         /// Sets custom stop words.
@@ -118,14 +116,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="values">Custom stop words</param>
         /// <returns>New <see cref="StopWordsRemover"/> object</returns>
         public StopWordsRemover SetStopWords(IEnumerable<string> values) =>
-            WrapAsStopWordsRemover(_jvmObject.Invoke("setStopWords", values));
+            WrapAsStopWordsRemover(Reference.Invoke("setStopWords", values));
 
         /// <summary>
         /// Gets the custom stop words.
         /// </summary>
         /// <returns>Custom stop words</returns>
         public IEnumerable<string> GetStopWords() =>
-            (IEnumerable<string>)_jvmObject.Invoke("getStopWords");
+            (IEnumerable<string>)Reference.Invoke("getStopWords");
 
         /// <summary>
         /// Check transform validity and derive the output schema from the input schema.
@@ -145,9 +143,9 @@ namespace Microsoft.Spark.ML.Feature
         /// </returns>
         public StructType TransformSchema(StructType value) =>
             new StructType(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "transformSchema",
-                    DataType.FromJson(_jvmObject.Jvm, value.Json)));
+                    DataType.FromJson(Reference.Jvm, value.Json)));
 
         /// <summary>
         /// Load default stop words of given language for <see cref="StopWordsRemover"/>

--- a/src/csharp/Microsoft.Spark/ML/Feature/Tokenizer.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/Tokenizer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Spark.ML.Feature
     /// A <see cref="Tokenizer"/> that converts the input string to lowercase and then splits it by
     /// white spaces.
     /// </summary>
-    public class Tokenizer : FeatureBase<Tokenizer>, IJvmObjectReferenceProvider
+    public class Tokenizer : FeatureBase<Tokenizer>
     {
         private static readonly string s_tokenizerClassName = 
             "org.apache.spark.ml.feature.Tokenizer";
@@ -36,14 +36,12 @@ namespace Microsoft.Spark.ML.Feature
         internal Tokenizer(JvmObjectReference jvmObject) : base(jvmObject)
         {
         }
-        
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-        
+                
         /// <summary>
         /// Gets the column that the <see cref="Tokenizer"/> should read from
         /// </summary>
         /// <returns>string, input column</returns>
-        public string GetInputCol() => (string)(_jvmObject.Invoke("getInputCol"));
+        public string GetInputCol() => (string)(Reference.Invoke("getInputCol"));
 
         /// <summary>
         /// Sets the column that the <see cref="Tokenizer"/> should read from
@@ -51,14 +49,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as the source</param>
         /// <returns>New <see cref="Tokenizer"/> object</returns>
         public Tokenizer SetInputCol(string value) => 
-            WrapAsTokenizer(_jvmObject.Invoke("setInputCol", value));
+            WrapAsTokenizer(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="Tokenizer"/> will create a new column in the DataFrame, this is the
         /// name of the new column.
         /// </summary>
         /// <returns>string, the output column</returns>
-        public string GetOutputCol() => (string)(_jvmObject.Invoke("getOutputCol"));
+        public string GetOutputCol() => (string)(Reference.Invoke("getOutputCol"));
 
         /// <summary>
         /// The <see cref="Tokenizer"/> will create a new column in the DataFrame, this is the
@@ -67,7 +65,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the new column</param>
         /// <returns>New <see cref="Tokenizer"/> object</returns>
         public Tokenizer SetOutputCol(string value) => 
-            WrapAsTokenizer(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsTokenizer(Reference.Invoke("setOutputCol", value));
 
         /// <summary>
         /// Executes the <see cref="Tokenizer"/> and transforms the DataFrame to include the new
@@ -78,7 +76,7 @@ namespace Microsoft.Spark.ML.Feature
         /// New <see cref="DataFrame"/> object with the source <see cref="DataFrame"/> transformed
         /// </returns>
         public DataFrame Transform(DataFrame source) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", source));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", source));
 
         /// <summary>
         /// Loads the <see cref="Tokenizer"/> that was previously saved using Save

--- a/src/csharp/Microsoft.Spark/ML/Feature/Word2Vec.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/Word2Vec.cs
@@ -8,7 +8,7 @@ using Microsoft.Spark.Sql;
 
 namespace Microsoft.Spark.ML.Feature
 {
-    public class Word2Vec : FeatureBase<Word2Vec>, IJvmObjectReferenceProvider
+    public class Word2Vec : FeatureBase<Word2Vec>
     {
         private static readonly string s_word2VecClassName = 
             "org.apache.spark.ml.feature.Word2Vec";
@@ -33,13 +33,11 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
         
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Gets the column that the <see cref="Word2Vec"/> should read from.
         /// </summary>
         /// <returns>The name of the input column.</returns>
-        public string GetInputCol() => (string)(_jvmObject.Invoke("getInputCol"));
+        public string GetInputCol() => (string)(Reference.Invoke("getInputCol"));
 
         /// <summary>
         /// Sets the column that the <see cref="Word2Vec"/> should read from.
@@ -47,14 +45,14 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the column to as the source.</param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetInputCol(string value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setInputCol", value));
+            WrapAsWord2Vec(Reference.Invoke("setInputCol", value));
 
         /// <summary>
         /// The <see cref="Word2Vec"/> will create a new column in the DataFrame, this is the
         /// name of the new column.
         /// </summary>
         /// <returns>The name of the output column.</returns>
-        public string GetOutputCol() => (string)(_jvmObject.Invoke("getOutputCol"));
+        public string GetOutputCol() => (string)(Reference.Invoke("getOutputCol"));
 
         /// <summary>
         /// The <see cref="Word2Vec"/> will create a new column in the DataFrame, this is the
@@ -63,7 +61,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <param name="value">The name of the output column which will be created.</param>
         /// <returns>New <see cref="Word2Vec"/></returns>
         public Word2Vec SetOutputCol(string value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setOutputCol", value));
+            WrapAsWord2Vec(Reference.Invoke("setOutputCol", value));
         
         /// <summary>
         /// Gets the vector size, the dimension of the code that you want to transform from words.
@@ -71,7 +69,7 @@ namespace Microsoft.Spark.ML.Feature
         /// <returns>
         /// The vector size, the dimension of the code that you want to transform from words.
         /// </returns>
-        public int GetVectorSize() => (int)(_jvmObject.Invoke("getVectorSize"));
+        public int GetVectorSize() => (int)(Reference.Invoke("getVectorSize"));
         
         /// <summary>
         /// Sets the vector size, the dimension of the code that you want to transform from words.
@@ -81,7 +79,7 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetVectorSize(int value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setVectorSize", value));
+            WrapAsWord2Vec(Reference.Invoke("setVectorSize", value));
 
         /// <summary>
         /// Gets the minimum number of times a token must appear to be included in the word2vec
@@ -91,7 +89,7 @@ namespace Microsoft.Spark.ML.Feature
         /// The minimum number of times a token must appear to be included in the word2vec model's
         /// vocabulary.
         /// </returns>
-        public int GetMinCount() => (int)_jvmObject.Invoke("getMinCount");
+        public int GetMinCount() => (int)Reference.Invoke("getMinCount");
 
         /// <summary>
         /// The minimum number of times a token must appear to be included in the word2vec model's
@@ -103,24 +101,24 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns><see cref="Word2Vec"/></returns>
         public virtual Word2Vec SetMinCount(int value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setMinCount", value));
+            WrapAsWord2Vec(Reference.Invoke("setMinCount", value));
         
         /// <summary>Gets the maximum number of iterations.</summary>
         /// <returns>The maximum number of iterations.</returns>
-        public int GetMaxIter() => (int)_jvmObject.Invoke("getMaxIter");
+        public int GetMaxIter() => (int)Reference.Invoke("getMaxIter");
 
         /// <summary>Maximum number of iterations (&gt;= 0).</summary>
         /// <param name="value">The number of iterations.</param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetMaxIter(int value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setMaxIter", value));
+            WrapAsWord2Vec(Reference.Invoke("setMaxIter", value));
 
         /// <summary>
         /// Gets the maximum length (in words) of each sentence in the input data.
         /// </summary>
         /// <returns>The maximum length (in words) of each sentence in the input data.</returns>
         public virtual int GetMaxSentenceLength() => 
-            (int)_jvmObject.Invoke("getMaxSentenceLength");
+            (int)Reference.Invoke("getMaxSentenceLength");
 
         /// <summary>
         /// Sets the maximum length (in words) of each sentence in the input data.
@@ -130,11 +128,11 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetMaxSentenceLength(int value) => 
-            WrapAsWord2Vec(_jvmObject.Invoke("setMaxSentenceLength", value));
+            WrapAsWord2Vec(Reference.Invoke("setMaxSentenceLength", value));
 
         /// <summary>Gets the number of partitions for sentences of words.</summary>
         /// <returns>The number of partitions for sentences of words.</returns>
-        public int GetNumPartitions() => (int)_jvmObject.Invoke("getNumPartitions");
+        public int GetNumPartitions() => (int)Reference.Invoke("getNumPartitions");
         
         /// <summary>Sets the number of partitions for sentences of words.</summary>
         /// <param name="value">
@@ -142,31 +140,31 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetNumPartitions(int value) =>
-            WrapAsWord2Vec(_jvmObject.Invoke("setNumPartitions", value));
+            WrapAsWord2Vec(Reference.Invoke("setNumPartitions", value));
 
         /// <summary>Gets the value that is used for the random seed.</summary>
         /// <returns>The value that is used for the random seed.</returns>
-        public long GetSeed() => (long)_jvmObject.Invoke("getSeed");
+        public long GetSeed() => (long)Reference.Invoke("getSeed");
         
         /// <summary>Random seed.</summary>
         /// <param name="value">The value to use for the random seed.</param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetSeed(long value) =>
-            WrapAsWord2Vec(_jvmObject.Invoke("setSeed", value));
+            WrapAsWord2Vec(Reference.Invoke("setSeed", value));
 
         /// <summary>Gets the size to be used for each iteration of optimization.</summary>
         /// <returns>The size to be used for each iteration of optimization.</returns>
-        public double GetStepSize() => (double)_jvmObject.Invoke("getStepSize");
+        public double GetStepSize() => (double)Reference.Invoke("getStepSize");
         
         /// <summary>Step size to be used for each iteration of optimization (&gt; 0).</summary>
         /// <param name="value">Value to use for the step size.</param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetStepSize(double value) =>
-            WrapAsWord2Vec(_jvmObject.Invoke("setStepSize", value));
+            WrapAsWord2Vec(Reference.Invoke("setStepSize", value));
 
         /// <summary>Gets the window size (context words from [-window, window]).</summary>
         /// <returns>The window size.</returns>
-        public int GetWindowSize() => (int)_jvmObject.Invoke("getWindowSize");
+        public int GetWindowSize() => (int)Reference.Invoke("getWindowSize");
         
         /// <summary>The window size (context words from [-window, window]).</summary>
         /// <param name="value">
@@ -174,13 +172,13 @@ namespace Microsoft.Spark.ML.Feature
         /// </param>
         /// <returns><see cref="Word2Vec"/></returns>
         public Word2Vec SetWindowSize(int value) =>
-            WrapAsWord2Vec(_jvmObject.Invoke("setWindowSize", value));
+            WrapAsWord2Vec(Reference.Invoke("setWindowSize", value));
         
         /// <summary>Fits a model to the input data.</summary>
         /// <param name="dataFrame">The <see cref="DataFrame"/> to fit the model to.</param>
         /// <returns><see cref="Word2VecModel"/></returns>
         public Word2VecModel Fit(DataFrame dataFrame) => 
-            new Word2VecModel((JvmObjectReference)_jvmObject.Invoke("fit", dataFrame));
+            new Word2VecModel((JvmObjectReference)Reference.Invoke("fit", dataFrame));
 
         /// <summary>
         /// Loads the <see cref="Word2Vec"/> that was previously saved using Save(string).

--- a/src/csharp/Microsoft.Spark/ML/Feature/Word2VecModel.cs
+++ b/src/csharp/Microsoft.Spark/ML/Feature/Word2VecModel.cs
@@ -8,7 +8,7 @@ using Microsoft.Spark.Sql;
 
 namespace Microsoft.Spark.ML.Feature
 {
-    public class Word2VecModel : FeatureBase<Word2VecModel>, IJvmObjectReferenceProvider
+    public class Word2VecModel : FeatureBase<Word2VecModel>
     {
         private static readonly string s_word2VecModelClassName = 
             "org.apache.spark.ml.feature.Word2VecModel";
@@ -33,14 +33,12 @@ namespace Microsoft.Spark.ML.Feature
         {
         }
         
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-
         /// <summary>
         /// Transform a sentence column to a vector column to represent the whole sentence.
         /// </summary>
         /// <param name="documentDF"><see cref="DataFrame"/> to transform</param>
         public DataFrame Transform(DataFrame documentDF) => 
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("transform", documentDF));
+            new DataFrame((JvmObjectReference)Reference.Invoke("transform", documentDF));
         
         /// <summary>
         /// Find <paramref name="num"/> number of words whose vector representation most similar to
@@ -52,7 +50,7 @@ namespace Microsoft.Spark.ML.Feature
         /// vector representation.</param>
         /// <param name="num">The number of words to find that are similar to "word"</param>
         public DataFrame FindSynonyms(string word, int num) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("findSynonyms", word, num));
+            new DataFrame((JvmObjectReference)Reference.Invoke("findSynonyms", word, num));
         
         /// <summary>
         /// Loads the <see cref="Word2VecModel"/> that was previously saved using Save(string).

--- a/src/csharp/Microsoft.Spark/ML/Param/Param.cs
+++ b/src/csharp/Microsoft.Spark/ML/Param/Param.cs
@@ -22,9 +22,7 @@ namespace Microsoft.Spark.ML.Feature.Param
     {
         private static readonly string s_ParamClassName = 
             "org.apache.spark.ml.param.Param";
-        
-        private readonly JvmObjectReference _jvmObject;
-        
+
         /// <summary>
         /// Creates a new instance of a <see cref="Param"/> which will be attached to the parent
         /// specified. The most likely use case for a <see cref="Param"/> is being read from a 
@@ -56,28 +54,28 @@ namespace Microsoft.Spark.ML.Feature.Param
 
         internal Param(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
-        
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-        
+
+        public JvmObjectReference Reference { get; private set; }
+
         /// <summary>
         /// The description of what the <see cref="Param"/> does and how it works including any
         /// defaults and the current value
         /// </summary>
         /// <returns>A description of how the <see cref="Param"/> works</returns>
-        public string Doc => (string)_jvmObject.Invoke("doc");
+        public string Doc => (string)Reference.Invoke("doc");
         
         /// <summary>
         /// The name of the <see cref="Param"/>
         /// </summary>
         /// <returns>The name of the <see cref="Param"/></returns>
-        public string Name => (string)_jvmObject.Invoke("name");
+        public string Name => (string)Reference.Invoke("name");
 
         /// <summary>
         /// The object that contains the <see cref="Param"/>
         /// </summary>
         /// <returns>The UID of the parent oject that this <see cref="Param"/> belongs to</returns>
-        public string Parent => (string)_jvmObject.Invoke("parent");
+        public string Parent => (string)Reference.Invoke("parent");
     }
 }

--- a/src/csharp/Microsoft.Spark/SparkConf.cs
+++ b/src/csharp/Microsoft.Spark/SparkConf.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Spark
     /// </remarks>
     public sealed class SparkConf : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -36,7 +34,7 @@ namespace Microsoft.Spark
 
         internal SparkConf(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
 
             // Special handling for debug mode because spark.master and spark.app.name will not
             // be set in debug mode. Driver code may override these values if SetMaster or
@@ -51,7 +49,7 @@ namespace Microsoft.Spark
             }
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// The master URL to connect to, such as "local" to run locally with one thread,
@@ -61,7 +59,7 @@ namespace Microsoft.Spark
         /// <param name="master">Spark master</param>
         public SparkConf SetMaster(string master)
         {
-            _jvmObject.Invoke("setMaster", master);
+            Reference.Invoke("setMaster", master);
             return this;
         }
 
@@ -71,7 +69,7 @@ namespace Microsoft.Spark
         /// <param name="appName">Name of the app</param>
         public SparkConf SetAppName(string appName)
         {
-            _jvmObject.Invoke("setAppName", appName);
+            Reference.Invoke("setAppName", appName);
             return this;
         }
 
@@ -82,7 +80,7 @@ namespace Microsoft.Spark
         /// <returns></returns>
         public SparkConf SetSparkHome(string sparkHome)
         {
-            _jvmObject.Invoke("setSparkHome", sparkHome);
+            Reference.Invoke("setSparkHome", sparkHome);
             return this;
         }
 
@@ -93,7 +91,7 @@ namespace Microsoft.Spark
         /// <param name="value">Config value</param>
         public SparkConf Set(string key, string value)
         {
-            _jvmObject.Invoke("set", key, value);
+            Reference.Invoke("set", key, value);
             return this;
         }
 
@@ -104,7 +102,7 @@ namespace Microsoft.Spark
         /// <param name="defaultValue">Default value to use</param>
         public int GetInt(string key, int defaultValue)
         {
-            return (int)_jvmObject.Invoke("getInt", key, defaultValue);
+            return (int)Reference.Invoke("getInt", key, defaultValue);
         }
 
         /// <summary>
@@ -114,7 +112,7 @@ namespace Microsoft.Spark
         /// <param name="defaultValue">Default value to use</param>
         public string Get(string key, string defaultValue)
         {
-            return (string)_jvmObject.Invoke("get", key, defaultValue);
+            return (string)Reference.Invoke("get", key, defaultValue);
         }
 
         /// <summary>
@@ -122,7 +120,7 @@ namespace Microsoft.Spark
         /// </summary>
         public IReadOnlyList<KeyValuePair<string, string>> GetAll()
         {
-            var kvpStringCollection = (string)_jvmObject.Jvm.CallStaticJavaMethod(
+            var kvpStringCollection = (string)Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.sql.api.dotnet.JvmBridgeUtils",
                 "getSparkConfAsString",
                 this);

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Spark
     /// </summary>
     public sealed class SparkContext : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         private readonly SparkConf _conf;
 
         /// <summary>
@@ -33,10 +31,7 @@ namespace Microsoft.Spark
         /// Any settings in this config overrides the default configs as well as system properties.
         /// </param>
         public SparkContext(SparkConf conf)
-            : this(
-                ((IJvmObjectReferenceProvider)conf).Reference.Jvm.CallConstructor(
-                    "org.apache.spark.SparkContext",
-                    conf))
+            : this(conf.Reference.Jvm.CallConstructor("org.apache.spark.SparkContext", conf))
         {
         }
 
@@ -89,12 +84,12 @@ namespace Microsoft.Spark
         /// <param name="jvmObject">JVM object reference for this SparkContext object</param>
         internal SparkContext(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
-            _conf = new SparkConf((JvmObjectReference)_jvmObject.Invoke("getConf"));
+            Reference = jvmObject;
+            _conf = new SparkConf((JvmObjectReference)Reference.Invoke("getConf"));
         }
 
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns SparkConf object associated with this SparkContext object.
@@ -115,7 +110,7 @@ namespace Microsoft.Spark
         /// </returns>
         public static SparkContext GetOrCreate(SparkConf conf)
         {
-            IJvmBridge jvm = ((IJvmObjectReferenceProvider)conf).Reference.Jvm;
+            IJvmBridge jvm = conf.Reference.Jvm;
             return new SparkContext(
                 (JvmObjectReference)jvm.CallStaticJavaMethod(
                     "org.apache.spark.SparkContext",
@@ -132,7 +127,7 @@ namespace Microsoft.Spark
         /// <param name="logLevel">The desired log level as a string.</param>
         public void SetLogLevel(string logLevel)
         {
-            _jvmObject.Invoke("setLogLevel", logLevel);
+            Reference.Invoke("setLogLevel", logLevel);
         }
 
         /// <summary>
@@ -140,13 +135,13 @@ namespace Microsoft.Spark
         /// </summary>
         public void Stop()
         {
-            _jvmObject.Invoke("stop");
+            Reference.Invoke("stop");
         }
 
         /// <summary>
         /// Default level of parallelism to use when not given by user (e.g. Parallelize()).
         /// </summary>
-        public int DefaultParallelism => (int)_jvmObject.Invoke("defaultParallelism");
+        public int DefaultParallelism => (int)Reference.Invoke("defaultParallelism");
 
         /// <summary>
         /// Creates a modified version of <see cref="SparkConf"/> with the parameters that can be
@@ -189,7 +184,7 @@ namespace Microsoft.Spark
         /// <param name="value">Description of the current job</param>
         public void SetJobDescription(string value)
         {
-            _jvmObject.Invoke("setJobDescription", value);
+            Reference.Invoke("setJobDescription", value);
         }
 
         /// <summary>
@@ -210,7 +205,7 @@ namespace Microsoft.Spark
         /// </param>
         public void SetJobGroup(string groupId, string description, bool interruptOnCancel = false)
         {
-            _jvmObject.Invoke("setJobGroup", groupId, description, interruptOnCancel);
+            Reference.Invoke("setJobGroup", groupId, description, interruptOnCancel);
         }
 
         /// <summary>
@@ -218,7 +213,7 @@ namespace Microsoft.Spark
         /// </summary>
         public void ClearJobGroup()
         {
-            _jvmObject.Invoke("clearJobGroup");
+            Reference.Invoke("clearJobGroup");
         }
 
         /// <summary>
@@ -242,10 +237,10 @@ namespace Microsoft.Spark
             }
 
             return new RDD<T>(
-                (JvmObjectReference)_jvmObject.Jvm.CallStaticJavaMethod(
+                (JvmObjectReference)Reference.Jvm.CallStaticJavaMethod(
                     "org.apache.spark.api.dotnet.DotnetRDD",
                     "createJavaRDDFromArray",
-                    _jvmObject,
+                    Reference,
                     values,
                     numSlices ?? DefaultParallelism),
                 this,
@@ -262,7 +257,7 @@ namespace Microsoft.Spark
         internal RDD<string> TextFile(string path, int? minPartitions = null)
         {
             return new RDD<string>(
-                WrapAsJavaRDD((JvmObjectReference)_jvmObject.Invoke(
+                WrapAsJavaRDD((JvmObjectReference)Reference.Invoke(
                     "textFile",
                     path,
                     minPartitions ?? DefaultParallelism)),
@@ -289,7 +284,7 @@ namespace Microsoft.Spark
         /// </param>
         public void AddFile(string path, bool recursive = false)
         {
-            _jvmObject.Invoke("addFile", path, recursive);
+            Reference.Invoke("addFile", path, recursive);
         }
 
         /// <summary>
@@ -297,7 +292,7 @@ namespace Microsoft.Spark
         /// </summary>
         /// <returns>File paths that are added to resources.</returns>
         public IEnumerable<string> ListFiles() =>
-            new Seq<string>((JvmObjectReference)_jvmObject.Invoke("listFiles"));
+            new Seq<string>((JvmObjectReference)Reference.Invoke("listFiles"));
 
         /// <summary>
         /// Add an archive to be downloaded and unpacked with this Spark job on every node.
@@ -316,7 +311,7 @@ namespace Microsoft.Spark
         [Since(Versions.V3_1_0)]
         public void AddArchive(string path)
         {
-            _jvmObject.Invoke("addArchive", path);
+            Reference.Invoke("addArchive", path);
         }
 
         /// <summary>
@@ -325,7 +320,7 @@ namespace Microsoft.Spark
         /// <returns>Archive paths that are added to resources.</returns>
         [Since(Versions.V3_1_0)]
         public IEnumerable<string> ListArchives() =>
-            new Seq<string>((JvmObjectReference)_jvmObject.Invoke("listArchives"));
+            new Seq<string>((JvmObjectReference)Reference.Invoke("listArchives"));
 
         /// <summary>
         /// Sets the directory under which RDDs are going to be checkpointed.
@@ -335,7 +330,7 @@ namespace Microsoft.Spark
         /// </param>
         public void SetCheckpointDir(string directory)
         {
-            _jvmObject.Invoke("setCheckpointDir", directory);
+            Reference.Invoke("setCheckpointDir", directory);
         }
 
         /// <summary>
@@ -347,7 +342,7 @@ namespace Microsoft.Spark
         /// </returns>
         public string GetCheckpointDir()
         {
-            return (string)new Option((JvmObjectReference)_jvmObject.Invoke("getCheckpointDir")).OrNull();
+            return (string)new Option((JvmObjectReference)Reference.Invoke("getCheckpointDir")).OrNull();
         }
 
         /// <summary>
@@ -368,7 +363,7 @@ namespace Microsoft.Spark
         /// </summary>
         /// <returns>The Hadoop Configuration.</returns>
         public Configuration HadoopConfiguration() =>
-            new Configuration((JvmObjectReference)_jvmObject.Invoke("hadoopConfiguration"));
+            new Configuration((JvmObjectReference)Reference.Invoke("hadoopConfiguration"));
 
         /// <summary>
         /// Returns JVM object reference to JavaRDD object transformed
@@ -381,7 +376,7 @@ namespace Microsoft.Spark
         /// <returns>JVM object reference to JavaRDD object</returns>
         private JvmObjectReference WrapAsJavaRDD(JvmObjectReference rdd)
         {
-            return (JvmObjectReference)_jvmObject.Jvm.CallStaticJavaMethod(
+            return (JvmObjectReference)Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.api.dotnet.DotnetRDD",
                 "toJavaRDD",
                 rdd);
@@ -392,6 +387,6 @@ namespace Microsoft.Spark
         /// <returns>
         /// A string that represents the version of Spark on which this application is running.
         /// </returns>
-        public string Version() => (string)_jvmObject.Invoke("version");
+        public string Version() => (string)Reference.Invoke("version");
     }
 }

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -386,5 +386,12 @@ namespace Microsoft.Spark
                 "toJavaRDD",
                 rdd);
         }
+        /// <summary>
+        /// Returns a string that represents the version of Spark on which this application is running.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the version of Spark on which this application is running.
+        /// </returns>
+        public string Version() => (string)_jvmObject.Invoke("version");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Builder.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Builder.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Spark.Sql
         private readonly Dictionary<string, string> _options =
             new Dictionary<string, string>() { { "spark.app.kind", "sparkdotnet" } };
 
-        private readonly JvmObjectReference _jvmObject;
-
         internal Builder()
             : this(
                 (JvmObjectReference)SparkEnvironment.JvmBridge.CallStaticJavaMethod(
@@ -29,10 +27,10 @@ namespace Microsoft.Spark.Sql
 
         internal Builder(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Sets the Spark master URL to connect to, such as "local" to run locally, "local[4]" to
@@ -140,9 +138,9 @@ namespace Microsoft.Spark.Sql
                 sparkConf.Set(option.Key, option.Value);
             }
 
-            _jvmObject.Invoke("config", sparkConf);
+            Reference.Invoke("config", sparkConf);
 
-            return new SparkSession((JvmObjectReference)_jvmObject.Invoke("getOrCreate"));
+            return new SparkSession((JvmObjectReference)Reference.Invoke("getOrCreate"));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Catalog/Catalog.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Catalog/Catalog.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Spark.Sql.Catalog
     /// </summary>
     public sealed class Catalog : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Catalog(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Caches the specified table in-memory.
@@ -33,14 +31,14 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="tableName">Is either a qualified or unqualified name that designates a
         /// table. If no database identifier is provided, it refers to a table in the current
         /// database.</param>
-        public void CacheTable(string tableName) => _jvmObject.Invoke("cacheTable", tableName);
+        public void CacheTable(string tableName) => Reference.Invoke("cacheTable", tableName);
 
         /// <summary>
         /// Removes all cached tables from the in-memory cache. You can either clear all cached
         /// tables at once using this or clear each table individually using
         /// `UncacheTable("tableName")`.
         /// </summary>
-        public void ClearCache() => _jvmObject.Invoke("clearCache");
+        public void ClearCache() => Reference.Invoke("clearCache");
 
         /// <summary>
         /// Creates a table, in the hive warehouse, from the given path and returns the
@@ -55,7 +53,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="path">Path to use to create the table.</param>
         /// <returns>The contents of the files in the path parameter as a `DataFrame`.</returns>
         public DataFrame CreateTable(string tableName, string path) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("createTable", tableName, path));
+            new DataFrame((JvmObjectReference)Reference.Invoke("createTable", tableName, path));
 
         /// <summary>
         /// Creates a table, in the hive warehouse, from the given path based from a data
@@ -72,7 +70,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>The results of reading the files in path as a `DataFrame`.</returns>
         public DataFrame CreateTable(string tableName, string path, string source) =>
             new DataFrame(
-                (JvmObjectReference)_jvmObject.Invoke("createTable", tableName, path, source));
+                (JvmObjectReference)Reference.Invoke("createTable", tableName, path, source));
 
         /// <summary>
         /// Creates a table based on the dataset in a data source and a set of options.
@@ -87,7 +85,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="options">Options used to table</param>
         /// <returns>The corresponding DataFrame</returns>
         public DataFrame CreateTable(string tableName, string source, IDictionary<string, string> options) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("createTable", tableName, source, options));
+            new DataFrame((JvmObjectReference)Reference.Invoke("createTable", tableName, source, options));
 
         /// <summary>
         /// Creates a table based on the dataset in a data source and a set of options.
@@ -109,7 +107,7 @@ namespace Microsoft.Spark.Sql.Catalog
             string description,
             IDictionary<string, string> options) =>
             new DataFrame(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "createTable", tableName, source, description, options));
 
         /// <summary>
@@ -131,11 +129,11 @@ namespace Microsoft.Spark.Sql.Catalog
             StructType schema,
             IDictionary<string, string> options) =>
             new DataFrame(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "createTable",
                     tableName,
                     source,
-                    DataType.FromJson(_jvmObject.Jvm, schema.Json),
+                    DataType.FromJson(Reference.Jvm, schema.Json),
                     options));
 
         /// <summary>
@@ -160,11 +158,11 @@ namespace Microsoft.Spark.Sql.Catalog
             string description,
             IDictionary<string, string> options) =>
             new DataFrame(
-                (JvmObjectReference)_jvmObject.Invoke(
+                (JvmObjectReference)Reference.Invoke(
                     "createTable",
                     tableName,
                     source,
-                    DataType.FromJson(_jvmObject.Jvm, schema.Json),
+                    DataType.FromJson(Reference.Jvm, schema.Json),
                     description,
                     options));
 
@@ -175,7 +173,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// `SparkSession.Sql("USE DATABASE databaseName")`.
         /// </summary>
         /// <returns>The database name as a string.</returns>
-        public string CurrentDatabase() => (string)_jvmObject.Invoke("currentDatabase");
+        public string CurrentDatabase() => (string)Reference.Invoke("currentDatabase");
 
         /// <summary>
         /// Check if the database with the specified name exists. This will check the list
@@ -184,7 +182,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="dbName">Name of the database to check.</param>
         /// <returns>bool, true if the database exists and false if it does not exist.</returns>
         public bool DatabaseExists(string dbName) =>
-            (bool)_jvmObject.Invoke("databaseExists", dbName);
+            (bool)Reference.Invoke("databaseExists", dbName);
 
         /// <summary>
         /// Drops the global temporary view with the given view name in the catalog.
@@ -196,7 +194,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// </param>
         /// <returns>bool, true if the view was dropped and false if it was not dropped.</returns>
         public bool DropGlobalTempView(string viewName) =>
-            (bool)_jvmObject.Invoke("dropGlobalTempView", viewName);
+            (bool)Reference.Invoke("dropGlobalTempView", viewName);
 
         /// <summary>
         /// Drops the local temporary view with the given view name in the catalog.
@@ -212,7 +210,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// </param>
         /// <returns>bool, true if the view was dropped and false if it was not dropped.</returns>
         public bool DropTempView(string viewName) =>
-            (bool)_jvmObject.Invoke("dropTempView", viewName);
+            (bool)Reference.Invoke("dropTempView", viewName);
 
         /// <summary>
         /// Check if the function with the specified name exists. `FunctionsExists` includes in-built
@@ -224,7 +222,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// current database.</param>
         /// <returns>bool, true if the function exists and false it is does not.</returns>
         public bool FunctionExists(string functionName) =>
-            (bool)_jvmObject.Invoke("functionExists", functionName);
+            (bool)Reference.Invoke("functionExists", functionName);
 
         /// <summary>
         /// Check if the function with the specified name exists in the specified database. If you
@@ -235,7 +233,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="functionName">Is an unqualified name that designates a function.</param>
         /// <returns>bool, true if the function exists and false it is does not.</returns>
         public bool FunctionExists(string dbName, string functionName) =>
-            (bool)_jvmObject.Invoke("functionExists", dbName, functionName);
+            (bool)Reference.Invoke("functionExists", dbName, functionName);
 
         /// <summary>
         /// Get the database with the specified name.
@@ -247,7 +245,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`Database` object which includes the name, description and locationUri of
         /// the database.</returns>
         public Database GetDatabase(string dbName) =>
-            new Database((JvmObjectReference)_jvmObject.Invoke("getDatabase", dbName));
+            new Database((JvmObjectReference)Reference.Invoke("getDatabase", dbName));
 
         /// <summary>
         /// Get the function with the specified name. If you are trying to get an in-built
@@ -259,7 +257,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`Function` object which includes the class name, database, description,
         /// whether it is temporary and the name of the function.</returns>
         public Function GetFunction(string functionName) =>
-            new Function((JvmObjectReference)_jvmObject.Invoke("getFunction", functionName));
+            new Function((JvmObjectReference)Reference.Invoke("getFunction", functionName));
 
         /// <summary>
         /// Get the function with the specified name. If you are trying to get an in-built function
@@ -273,7 +271,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// whether it is temporary and the name of the function.</returns>
         public Function GetFunction(string dbName, string functionName) =>
             new Function(
-                (JvmObjectReference)_jvmObject.Invoke("getFunction", dbName, functionName));
+                (JvmObjectReference)Reference.Invoke("getFunction", dbName, functionName));
 
         /// <summary>
         /// Get the table or view with the specified name. You can use this to find the tables
@@ -285,7 +283,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`Table` object which includes name, database, description, table type and
         /// whether the table is temporary or not.</returns>
         public Table GetTable(string tableName) =>
-            new Table((JvmObjectReference)_jvmObject.Invoke("getTable", tableName));
+            new Table((JvmObjectReference)Reference.Invoke("getTable", tableName));
 
         /// <summary>
         /// Get the table or view with the specified name in the specified database. You can use
@@ -298,7 +296,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`Table` object which includes name, database, description, table type and
         /// whether the table is temporary or not.</returns>
         public Table GetTable(string dbName, string tableName) =>
-            new Table((JvmObjectReference)_jvmObject.Invoke("getTable", dbName, tableName));
+            new Table((JvmObjectReference)Reference.Invoke("getTable", dbName, tableName));
 
         /// <summary>
         /// Returns true if the table is currently cached in-memory. If the table is cached then it
@@ -308,7 +306,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// table. If no database identifier is provided, it refers to a table in the current
         /// database.</param>
         /// <returns>bool, true if the table is cahced and false if it is not cached</returns>
-        public bool IsCached(string tableName) => (bool)_jvmObject.Invoke("isCached", tableName);
+        public bool IsCached(string tableName) => (bool)Reference.Invoke("isCached", tableName);
 
         /// <summary>
         /// Returns a list of columns for the given table/view or temporary view. The DataFrame
@@ -322,7 +320,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// nullable, if the column is partitioned and if the column is broken in buckets.
         /// </returns>
         public DataFrame ListColumns(string tableName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listColumns", tableName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listColumns", tableName));
 
         /// <summary>
         /// Returns a list of columns for the given table/view in the specified database.
@@ -336,7 +334,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// nullable, if the column is partitioned and if the column is broken in buckets.
         /// </returns>
         public DataFrame ListColumns(string dbName, string tableName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listColumns", dbName, tableName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listColumns", dbName, tableName));
 
         /// <summary>
         /// Returns a list of databases available across all sessions. The `DataFrame` contains
@@ -345,7 +343,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`DataFrame` with the  name, description and locationUri of each database.
         /// </returns>
         public DataFrame ListDatabases() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listDatabases"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listDatabases"));
 
         /// <summary>
         /// Returns a list of functions registered in the current database. This includes all
@@ -355,7 +353,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`DataFrame` with the class name, database, description, whether it is
         /// temporary and the name of each function.</returns>
         public DataFrame ListFunctions() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listFunctions"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listFunctions"));
 
         /// <summary>
         /// Returns a list of functions registered in the specified database. This includes all
@@ -366,7 +364,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`DataFrame` with the class name, database, description, whether it is
         /// temporary and the name of each function.</returns>
         public DataFrame ListFunctions(string dbName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listFunctions", dbName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listFunctions", dbName));
 
         /// <summary>
         /// Returns a list of tables/views in the current database. The `DataFrame` includes the
@@ -375,7 +373,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`DataFrame` with the name, database, description, table type and whether the
         /// table is temporary or not for each table in the default database</returns>
         public DataFrame ListTables() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listTables"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listTables"));
 
         /// <summary>
         /// Returns a list of tables/views in the specified database. The `DataFrame` includes the
@@ -385,7 +383,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>`DataFrame` with the name, database, description, table type and whether the
         /// table is temporary or not for each table in the named database</returns>
         public DataFrame ListTables(string dbName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("listTables", dbName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("listTables", dbName));
 
         /// <summary>
         /// Recovers all the partitions in the directory of a table and update the catalog. This
@@ -395,7 +393,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// table. If no database identifier is provided, it refers to a table in the current
         /// database.</param>
         public void RecoverPartitions(string tableName) =>
-            _jvmObject.Invoke("recoverPartitions", tableName);
+            Reference.Invoke("recoverPartitions", tableName);
 
         /// <summary>
         /// Invalidates and refreshes all the cached data (and the associated metadata) for any
@@ -403,7 +401,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// i.e. "/" would invalidate everything that is cached.
         /// </summary>
         /// <param name="path">Path to refresh</param>
-        public void RefreshByPath(string path) => _jvmObject.Invoke("refreshByPath", path);
+        public void RefreshByPath(string path) => Reference.Invoke("refreshByPath", path);
 
         /// <summary>
         /// Invalidates and refreshes all the cached data and metadata of the given table. For
@@ -416,14 +414,14 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <param name="tableName">Is either a qualified or unqualified name that designates a
         /// table. If no database identifier is provided, it refers to a table in the current
         /// database.</param>
-        public void RefreshTable(string tableName) => _jvmObject.Invoke("refreshTable", tableName);
+        public void RefreshTable(string tableName) => Reference.Invoke("refreshTable", tableName);
 
         /// <summary>
         /// Sets the current default database in this session.
         /// </summary>
         /// <param name="dbName">The name of the database to set.</param>
         public void SetCurrentDatabase(string dbName) =>
-            _jvmObject.Invoke("setCurrentDatabase", dbName);
+            Reference.Invoke("setCurrentDatabase", dbName);
 
         /// <summary>
         /// Check if the table or view with the specified name exists. This can either be a
@@ -434,7 +432,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// database.</param>
         /// <returns>bool, true if the table exists and false if it does not exist</returns>
         public bool TableExists(string tableName) =>
-            (bool)_jvmObject.Invoke("tableExists", tableName);
+            (bool)Reference.Invoke("tableExists", tableName);
 
         /// <summary>
         /// Check if the table or view with the specified name exists in the specified database.
@@ -444,7 +442,7 @@ namespace Microsoft.Spark.Sql.Catalog
         /// <returns>bool, true if the table exists in the specified database and false if it does
         /// not exist</returns>
         public bool TableExists(string dbName, string tableName) =>
-            (bool)_jvmObject.Invoke("tableExists", dbName, tableName);
+            (bool)Reference.Invoke("tableExists", dbName, tableName);
 
         /// <summary>
         /// Removes the specified table from the in-memory cache.
@@ -455,6 +453,6 @@ namespace Microsoft.Spark.Sql.Catalog
         ///
         /// To cache a table use `CacheTable(tableName)`.
         /// </param>
-        public void UncacheTable(string tableName) => _jvmObject.Invoke("uncacheTable", tableName);
+        public void UncacheTable(string tableName) => Reference.Invoke("uncacheTable", tableName);
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Catalog/Database.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Catalog/Database.cs
@@ -11,31 +11,29 @@ namespace Microsoft.Spark.Sql.Catalog
     /// </summary>
     public sealed class Database : IJvmObjectReferenceProvider
     {
-        private JvmObjectReference _jvmObject;
-
         internal Database(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
-        
+        public JvmObjectReference Reference { get; private set; }
+
         /// <summary>
         /// Description of the database.
         /// </summary>
         /// <returns>string, the description of the database.</returns>
-        public string Description => (string)_jvmObject.Invoke("description");
+        public string Description => (string)Reference.Invoke("description");
 
         /// <summary>
         /// Path (in the form of a uri) to data files
         /// </summary>
         /// <returns>string, the location of the database.</returns>
-        public string LocationUri => (string)_jvmObject.Invoke("locationUri");
+        public string LocationUri => (string)Reference.Invoke("locationUri");
 
         /// <summary>
         /// Name of the database.
         /// </summary>
         /// <returns>string, the name of the database.</returns>
-        public string Name => (string)_jvmObject.Invoke("name");
+        public string Name => (string)Reference.Invoke("name");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Catalog/Function.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Catalog/Function.cs
@@ -11,44 +11,42 @@ namespace Microsoft.Spark.Sql.Catalog
     /// </summary>
     public sealed class Function : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Function(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Name of the database the function belongs to.
         /// </summary>
         /// <returns>string, the name of the database that the function is in.</returns>
-        public string Database => (string)_jvmObject.Invoke("database");
+        public string Database => (string)Reference.Invoke("database");
 
         /// <summary>
         /// Description of the function.
         /// </summary>
         /// <returns>string, the description of the function.</returns>
-        public string Description => (string)_jvmObject.Invoke("description");
+        public string Description => (string)Reference.Invoke("description");
 
         /// <summary>
         /// Whether the function is temporary or not
         /// </summary>
         /// <returns>bool, true if the function is temporary and false if it is not temporary.
         /// </returns>
-        public bool IsTemporary => (bool)_jvmObject.Invoke("isTemporary");
+        public bool IsTemporary => (bool)Reference.Invoke("isTemporary");
 
         /// <summary>
         /// Name of the function
         /// </summary>
         /// <returns>string, the name of the function.</returns>
-        public string Name => (string)_jvmObject.Invoke("name");
+        public string Name => (string)Reference.Invoke("name");
 
         /// <summary>
         /// The fully qualified class name of the function
         /// </summary>
         /// <returns>string, the name of the class that implements the function.</returns>
-        public string ClassName => (string)_jvmObject.Invoke("className");
+        public string ClassName => (string)Reference.Invoke("className");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Catalog/Table.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Catalog/Table.cs
@@ -11,43 +11,41 @@ namespace Microsoft.Spark.Sql.Catalog
     /// </summary>
     public sealed class Table : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal Table(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Name of the database the table belongs to.
         /// </summary>
         /// <returns>string, the name of the database the table is in.</returns>
-        public string Database => (string)_jvmObject.Invoke("database");
+        public string Database => (string)Reference.Invoke("database");
 
         /// <summary>
         /// Description of the table.
         /// </summary>
         /// <returns>string, the description of the table.</returns>
-        public string Description => (string)_jvmObject.Invoke("description");
+        public string Description => (string)Reference.Invoke("description");
 
         /// <summary>
         /// Whether the table is temporary or not.
         /// </summary>
         /// <returns>bool, true if the table is temporary, false if it is not.</returns>
-        public bool IsTemporary => (bool)_jvmObject.Invoke("isTemporary");
+        public bool IsTemporary => (bool)Reference.Invoke("isTemporary");
 
         /// <summary>
         /// The name of the table.
         /// </summary>
         /// <returns>string, the name of the table.</returns>
-        public string Name => (string)_jvmObject.Invoke("name");
+        public string Name => (string)Reference.Invoke("name");
 
         /// <summary>
         /// The type of table (e.g. view/table)
         /// </summary>
         /// <returns>string, will return either `view` or `table` </returns>
-        public string TableType => (string)_jvmObject.Invoke("tableType");
+        public string TableType => (string)Reference.Invoke("tableType");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Column.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Column.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class Column : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
 
         /// <summary>
         /// Constructor for Column class.
@@ -21,10 +20,10 @@ namespace Microsoft.Spark.Sql
         /// <param name="jvmObject">JVM object reference</param>
         internal Column(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Negate the given column.
@@ -879,7 +878,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         internal JvmObjectReference Expr()
         {
-            return (JvmObjectReference)_jvmObject.Invoke("expr");
+            return (JvmObjectReference)Reference.Invoke("expr");
         }
 
         // Equals() and GetHashCode() are required to be defined when operator==/!=
@@ -902,20 +901,20 @@ namespace Microsoft.Spark.Sql
                 return true;
             }
 
-            return obj is Column other && _jvmObject.Equals(other._jvmObject);
+            return obj is Column other && Reference.Equals(other.Reference);
         }
 
         /// <summary>
         /// Calculates the hash code for this object.
         /// </summary>
         /// <returns>Hash code for this object</returns>
-        public override int GetHashCode() => _jvmObject.GetHashCode();
+        public override int GetHashCode() => Reference.GetHashCode();
 
         /// <summary>
         /// Invoke the toString method of the column instance
         /// </summary>
         /// <returns>Column name of this column</returns>
-        public override string ToString() => (string)_jvmObject.Invoke("toString");
+        public override string ToString() => (string)Reference.Invoke("toString");
 
         /// <summary>
         /// Invokes a method under "org.apache.spark.sql.functions" with the given column.
@@ -926,7 +925,7 @@ namespace Microsoft.Spark.Sql
         private static Column ApplyFunction(Column column, string name)
         {
             return new Column(
-                (JvmObjectReference)column._jvmObject.Jvm.CallStaticJavaMethod(
+                (JvmObjectReference)column.Reference.Jvm.CallStaticJavaMethod(
                     "org.apache.spark.sql.functions",
                     name,
                     column));
@@ -939,7 +938,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New column after applying the operator</returns>
         private Column ApplyMethod(string op)
         {
-            return new Column((JvmObjectReference)_jvmObject.Invoke(op));
+            return new Column((JvmObjectReference)Reference.Invoke(op));
         }
 
         /// <summary>
@@ -950,7 +949,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New column after applying the operator</returns>
         private Column ApplyMethod(string op, object other)
         {
-            return new Column((JvmObjectReference)_jvmObject.Invoke(op, other));
+            return new Column((JvmObjectReference)Reference.Invoke(op, other));
         }
 
         /// <summary>
@@ -962,7 +961,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New column after applying the operator</returns>
         private Column ApplyMethod(string op, object other1, object other2)
         {
-            return new Column((JvmObjectReference)_jvmObject.Invoke(op, other1, other2));
+            return new Column((JvmObjectReference)Reference.Invoke(op, other1, other2));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrame.cs
@@ -19,14 +19,12 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class DataFrame : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DataFrame(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Selects column based on the column name.
@@ -37,7 +35,7 @@ namespace Microsoft.Spark.Sql
         {
             get
             {
-                return WrapAsColumn(_jvmObject.Invoke("col", columnName));
+                return WrapAsColumn(Reference.Invoke("col", columnName));
             }
         }
 
@@ -45,7 +43,7 @@ namespace Microsoft.Spark.Sql
         /// Converts this strongly typed collection of data to generic `DataFrame`.
         /// </summary>
         /// <returns></returns>
-        public DataFrame ToDF() => WrapAsDataFrame(_jvmObject.Invoke("toDF"));
+        public DataFrame ToDF() => WrapAsDataFrame(Reference.Invoke("toDF"));
 
         /// <summary>
         /// Converts this strongly typed collection of data to generic `DataFrame`
@@ -54,21 +52,21 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame ToDF(params string[] colNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("toDF", (object)colNames));
+            WrapAsDataFrame(Reference.Invoke("toDF", (object)colNames));
 
         /// <summary>
         /// Returns the schema associated with this `DataFrame`.
         /// </summary>
         /// <returns>Schema associated with this data frame</returns>
         public StructType Schema() =>
-            new StructType((JvmObjectReference)_jvmObject.Invoke("schema"));
+            new StructType((JvmObjectReference)Reference.Invoke("schema"));
 
         /// <summary>
         /// Prints the schema to the console in a nice tree format.
         /// </summary>
         public void PrintSchema() =>
             Console.WriteLine(
-                (string)((JvmObjectReference)_jvmObject.Invoke("schema")).Invoke("treeString"));
+                (string)((JvmObjectReference)Reference.Invoke("schema")).Invoke("treeString"));
 
         /// <summary>
         /// Prints the schema up to the given level to the console in a nice tree format.
@@ -76,7 +74,7 @@ namespace Microsoft.Spark.Sql
         [Since(Versions.V3_0_0)]
         public void PrintSchema(int level)
         {
-            var schema = (JvmObjectReference)_jvmObject.Invoke("schema");
+            var schema = (JvmObjectReference)Reference.Invoke("schema");
             Console.WriteLine((string)schema.Invoke("treeString", level));
         }
 
@@ -86,7 +84,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="extended">prints only physical if set to false</param>
         public void Explain(bool extended = false)
         {
-            var execution = (JvmObjectReference)_jvmObject.Invoke("queryExecution");
+            var execution = (JvmObjectReference)Reference.Invoke("queryExecution");
             Console.WriteLine((string)execution.Invoke(extended ? "toString" : "simpleString"));
         }
 
@@ -106,8 +104,8 @@ namespace Microsoft.Spark.Sql
         [Since(Versions.V3_0_0)]
         public void Explain(string mode)
         {
-            var execution = (JvmObjectReference)_jvmObject.Invoke("queryExecution");
-            var explainMode = (JvmObjectReference)_jvmObject.Jvm.CallStaticJavaMethod(
+            var execution = (JvmObjectReference)Reference.Invoke("queryExecution");
+            var explainMode = (JvmObjectReference)Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.sql.execution.ExplainMode",
                 "fromString",
                 mode);
@@ -134,21 +132,21 @@ namespace Microsoft.Spark.Sql
         /// Spark executors.
         /// </summary>
         /// <returns>True if Collect() and Take() can be run locally</returns>
-        public bool IsLocal() => (bool)_jvmObject.Invoke("isLocal");
+        public bool IsLocal() => (bool)Reference.Invoke("isLocal");
 
         /// <summary>
         /// Returns true if this DataFrame is empty.
         /// </summary>
         /// <returns>True if empty</returns>
         [Since(Versions.V2_4_0)]
-        public bool IsEmpty() => (bool)_jvmObject.Invoke("isEmpty");
+        public bool IsEmpty() => (bool)Reference.Invoke("isEmpty");
 
         /// <summary>
         /// Returns true if this `DataFrame` contains one or more sources that continuously
         /// return data as it arrives.
         /// </summary>
         /// <returns>True if streaming DataFrame</returns>
-        public bool IsStreaming() => (bool)_jvmObject.Invoke("isStreaming");
+        public bool IsStreaming() => (bool)Reference.Invoke("isStreaming");
 
         /// <summary>
         /// Returns a checkpointed version of this `DataFrame`.
@@ -162,7 +160,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="eager">Whether to checkpoint this `DataFrame` immediately</param>
         /// <returns>Checkpointed DataFrame</returns>
         public DataFrame Checkpoint(bool eager = true) =>
-            WrapAsDataFrame(_jvmObject.Invoke("checkpoint", eager));
+            WrapAsDataFrame(Reference.Invoke("checkpoint", eager));
 
         /// <summary>
         /// Returns a locally checkpointed version of this `DataFrame`.
@@ -176,7 +174,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="eager">Whether to checkpoint this `DataFrame` immediately</param>
         /// <returns>DataFrame object</returns>
         public DataFrame LocalCheckpoint(bool eager = true) =>
-            WrapAsDataFrame(_jvmObject.Invoke("localCheckpoint", eager));
+            WrapAsDataFrame(Reference.Invoke("localCheckpoint", eager));
 
         /// <summary>
         /// Defines an event time watermark for this DataFrame. A watermark tracks a point in time
@@ -191,7 +189,7 @@ namespace Microsoft.Spark.Sql
         /// </param>
         /// <returns>DataFrame object</returns>
         public DataFrame WithWatermark(string eventTime, string delayThreshold) =>
-            WrapAsDataFrame(_jvmObject.Invoke("withWatermark", eventTime, delayThreshold));
+            WrapAsDataFrame(Reference.Invoke("withWatermark", eventTime, delayThreshold));
 
         /// <summary>
         /// Displays rows of the `DataFrame` in tabular form.
@@ -202,28 +200,28 @@ namespace Microsoft.Spark.Sql
         /// <param name="vertical">If set to true, prints output rows vertically
         ///                        (one line per column value).</param>
         public void Show(int numRows = 20, int truncate = 20, bool vertical = false) =>
-            Console.WriteLine(_jvmObject.Invoke("showString", numRows, truncate, vertical));
+            Console.WriteLine(Reference.Invoke("showString", numRows, truncate, vertical));
 
         /// <summary>
         /// Returns a `DataFrameNaFunctions` for working with missing data.
         /// </summary>
         /// <returns>DataFrameNaFunctions object</returns>
         public DataFrameNaFunctions Na() =>
-            new DataFrameNaFunctions((JvmObjectReference)_jvmObject.Invoke("na"));
+            new DataFrameNaFunctions((JvmObjectReference)Reference.Invoke("na"));
 
         /// <summary>
         ///Returns a `DataFrameStatFunctions` for working statistic functions support.
         /// </summary>
         /// <returns>DataFrameNaFunctions object</returns>
         public DataFrameStatFunctions Stat() =>
-            new DataFrameStatFunctions((JvmObjectReference)_jvmObject.Invoke("stat"));
+            new DataFrameStatFunctions((JvmObjectReference)Reference.Invoke("stat"));
 
         /// <summary>
         /// Returns the content of the DataFrame as a DataFrame of JSON strings.
         /// </summary>
         /// <returns>DataFrame object with JSON strings.</returns>
         public DataFrame ToJSON() =>
-            WrapAsDataFrame(_jvmObject.Invoke("toJSON"));
+            WrapAsDataFrame(Reference.Invoke("toJSON"));
 
         /// <summary>
         /// Join with another `DataFrame`.
@@ -234,7 +232,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="right">Right side of the join operator</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Join(DataFrame right) =>
-            WrapAsDataFrame(_jvmObject.Invoke("join", right));
+            WrapAsDataFrame(Reference.Invoke("join", right));
 
         /// <summary>
         /// Inner equi-join with another `DataFrame` using the given column.
@@ -245,7 +243,7 @@ namespace Microsoft.Spark.Sql
         /// </param>
         /// <returns>DataFrame object</returns>
         public DataFrame Join(DataFrame right, string usingColumn) =>
-            WrapAsDataFrame(_jvmObject.Invoke("join", right, usingColumn));
+            WrapAsDataFrame(Reference.Invoke("join", right, usingColumn));
 
         /// <summary>
         /// Equi-join with another `DataFrame` using the given columns. A cross join with
@@ -262,7 +260,7 @@ namespace Microsoft.Spark.Sql
             DataFrame right,
             IEnumerable<string> usingColumns,
             string joinType = "inner") =>
-            WrapAsDataFrame(_jvmObject.Invoke("join", right, usingColumns, joinType));
+            WrapAsDataFrame(Reference.Invoke("join", right, usingColumns, joinType));
 
         /// <summary>
         /// Join with another `DataFrame`, using the given join expression.
@@ -274,7 +272,7 @@ namespace Microsoft.Spark.Sql
         /// `right_outer`, `left_semi`, `left_anti`.</param>
         /// <returns></returns>
         public DataFrame Join(DataFrame right, Column joinExpr, string joinType = "inner") =>
-            WrapAsDataFrame(_jvmObject.Invoke("join", right, joinExpr, joinType));
+            WrapAsDataFrame(Reference.Invoke("join", right, joinExpr, joinType));
 
         /// <summary>
         /// Explicit Cartesian join with another `DataFrame`.
@@ -285,7 +283,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="right">Right side of the join operator</param>
         /// <returns>DataFrame object</returns>
         public DataFrame CrossJoin(DataFrame right) =>
-            WrapAsDataFrame(_jvmObject.Invoke("crossJoin", right));
+            WrapAsDataFrame(Reference.Invoke("crossJoin", right));
 
         /// <summary>
         /// Returns a new `DataFrame` with each partition sorted by the given expressions.
@@ -297,7 +295,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names to sort by</param>
         /// <returns>DataFrame object</returns>
         public DataFrame SortWithinPartitions(string column, params string[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sortWithinPartitions", column, columns));
+            WrapAsDataFrame(Reference.Invoke("sortWithinPartitions", column, columns));
 
         /// <summary>
         /// Returns a new `DataFrame` with each partition sorted by the given expressions.
@@ -308,7 +306,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions to sort by</param>
         /// <returns>DataFrame object</returns>
         public DataFrame SortWithinPartitions(params Column[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sortWithinPartitions", (object)columns));
+            WrapAsDataFrame(Reference.Invoke("sortWithinPartitions", (object)columns));
 
         /// <summary>
         /// Returns a new `DataFrame` sorted by the specified column, all in ascending order.
@@ -317,7 +315,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names to sort by</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Sort(string column, params string[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sort", column, columns));
+            WrapAsDataFrame(Reference.Invoke("sort", column, columns));
 
         /// <summary>
         /// Returns a new `DataFrame` sorted by the given expressions.
@@ -325,7 +323,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions to sort by</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Sort(params Column[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sort", (object)columns));
+            WrapAsDataFrame(Reference.Invoke("sort", (object)columns));
 
         /// <summary>
         /// Returns a new Dataset sorted by the given expressions.
@@ -337,7 +335,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names to sort by</param>
         /// <returns></returns>
         public DataFrame OrderBy(string column, params string[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("orderBy", column, columns));
+            WrapAsDataFrame(Reference.Invoke("orderBy", column, columns));
 
         /// <summary>
         /// Returns a new Dataset sorted by the given expressions.
@@ -348,7 +346,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions to sort by</param>
         /// <returns>DataFrame object</returns>
         public DataFrame OrderBy(params Column[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("orderBy", (object)columns));
+            WrapAsDataFrame(Reference.Invoke("orderBy", (object)columns));
 
         /// <summary>
         /// Specifies some hint on the current `DataFrame`.
@@ -365,8 +363,8 @@ namespace Microsoft.Spark.Sql
             // If parameters are empty, create an empty int array so
             // that the type conversion between CLR and JVM works.
             return ((parameters == null) || (parameters.Length == 0)) ?
-                WrapAsDataFrame(_jvmObject.Invoke("hint", name, new int[] { })) :
-                WrapAsDataFrame(_jvmObject.Invoke("hint", name, parameters));
+                WrapAsDataFrame(Reference.Invoke("hint", name, new int[] { })) :
+                WrapAsDataFrame(Reference.Invoke("hint", name, parameters));
         }
 
         /// <summary>
@@ -374,7 +372,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="colName">Column name</param>
         /// <returns>Column object</returns>
-        public Column Col(string colName) => WrapAsColumn(_jvmObject.Invoke("col", colName));
+        public Column Col(string colName) => WrapAsColumn(Reference.Invoke("col", colName));
 
         /// <summary>
         /// Selects column based on the column name specified as a regex.
@@ -382,21 +380,21 @@ namespace Microsoft.Spark.Sql
         /// <param name="colName">Column name as a regex</param>
         /// <returns>Column object</returns>
         public Column ColRegex(string colName) =>
-            WrapAsColumn(_jvmObject.Invoke("colRegex", colName));
+            WrapAsColumn(Reference.Invoke("colRegex", colName));
 
         /// <summary>
         /// Returns a new `DataFrame` with an alias set.
         /// </summary>
         /// <param name="alias">Alias name</param>
         /// <returns>Column object</returns>
-        public DataFrame As(string alias) => WrapAsDataFrame(_jvmObject.Invoke("as", alias));
+        public DataFrame As(string alias) => WrapAsDataFrame(Reference.Invoke("as", alias));
 
         /// <summary>
         /// Returns a new `DataFrame` with an alias set. Same as As().
         /// </summary>
         /// <param name="alias">Alias name</param>
         /// <returns>Column object</returns>
-        public DataFrame Alias(string alias) => WrapAsDataFrame(_jvmObject.Invoke("alias", alias));
+        public DataFrame Alias(string alias) => WrapAsDataFrame(Reference.Invoke("alias", alias));
 
         /// <summary>
         /// Selects a set of column based expressions.
@@ -404,7 +402,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Select(params Column[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("select", (object)columns));
+            WrapAsDataFrame(Reference.Invoke("select", (object)columns));
 
         /// <summary>
         /// Selects a set of columns. This is a variant of Select() that can only select
@@ -414,7 +412,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Select(string column, params string[] columns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("select", column, columns));
+            WrapAsDataFrame(Reference.Invoke("select", column, columns));
 
         /// <summary>
         /// Selects a set of SQL expressions. This is a variant of Select() that
@@ -423,7 +421,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="expressions"></param>
         /// <returns>DataFrame object</returns>
         public DataFrame SelectExpr(params string[] expressions) =>
-            WrapAsDataFrame(_jvmObject.Invoke("selectExpr", (object)expressions));
+            WrapAsDataFrame(Reference.Invoke("selectExpr", (object)expressions));
 
         /// <summary>
         /// Filters rows using the given condition.
@@ -431,7 +429,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="condition">Condition expression</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Filter(Column condition) =>
-            WrapAsDataFrame(_jvmObject.Invoke("filter", condition));
+            WrapAsDataFrame(Reference.Invoke("filter", condition));
 
         /// <summary>
         /// Filters rows using the given SQL expression.
@@ -439,7 +437,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="conditionExpr">SQL expression</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Filter(string conditionExpr) =>
-            WrapAsDataFrame(_jvmObject.Invoke("filter", conditionExpr));
+            WrapAsDataFrame(Reference.Invoke("filter", conditionExpr));
 
         /// <summary>
         /// Filters rows using the given condition. This is an alias for Filter().
@@ -447,7 +445,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="condition">Condition expression</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Where(Column condition) =>
-            WrapAsDataFrame(_jvmObject.Invoke("where", condition));
+            WrapAsDataFrame(Reference.Invoke("where", condition));
 
         /// <summary>
         /// Filters rows using the given SQL expression. This is an alias for Filter().
@@ -455,7 +453,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="conditionExpr">SQL expression</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Where(string conditionExpr) =>
-            WrapAsDataFrame(_jvmObject.Invoke("where", conditionExpr));
+            WrapAsDataFrame(Reference.Invoke("where", conditionExpr));
 
         /// <summary>
         /// Groups the DataFrame using the specified columns, so we can run aggregation on them.
@@ -463,7 +461,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset GroupBy(params Column[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("groupBy", (object)columns));
+            WrapAsGroupedDataset(Reference.Invoke("groupBy", (object)columns));
 
         /// <summary>
         /// Groups the DataFrame using the specified columns.
@@ -472,7 +470,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset GroupBy(string column, params string[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("groupBy", column, columns));
+            WrapAsGroupedDataset(Reference.Invoke("groupBy", column, columns));
 
         /// <summary>
         /// Create a multi-dimensional rollup for the current `DataFrame` using the
@@ -481,7 +479,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset Rollup(params Column[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("rollup", (object)columns));
+            WrapAsGroupedDataset(Reference.Invoke("rollup", (object)columns));
 
         /// <summary>
         /// Create a multi-dimensional rollup for the current `DataFrame` using the
@@ -491,7 +489,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset Rollup(string column, params string[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("rollup", column, columns));
+            WrapAsGroupedDataset(Reference.Invoke("rollup", column, columns));
 
         /// <summary>
         /// Create a multi-dimensional cube for the current `DataFrame` using the
@@ -500,7 +498,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Column expressions</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset Cube(params Column[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("cube", (object)columns));
+            WrapAsGroupedDataset(Reference.Invoke("cube", (object)columns));
 
         /// <summary>
         /// Create a multi-dimensional cube for the current `DataFrame` using the
@@ -510,7 +508,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columns">Additional column names</param>
         /// <returns>RelationalGroupedDataset object</returns>
         public RelationalGroupedDataset Cube(string column, params string[] columns) =>
-            WrapAsGroupedDataset(_jvmObject.Invoke("cube", column, columns));
+            WrapAsGroupedDataset(Reference.Invoke("cube", column, columns));
 
         /// <summary>
         /// Aggregates on the entire `DataFrame` without groups.
@@ -519,7 +517,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="exprs">Additional column expressions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Agg(Column expr, params Column[] exprs) =>
-            WrapAsDataFrame(_jvmObject.Invoke("agg", expr, exprs));
+            WrapAsDataFrame(Reference.Invoke("agg", expr, exprs));
 
         /// <summary>
         /// Define (named) metrics to observe on the Dataset. This method returns an 'observed'
@@ -540,7 +538,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         [Since(Versions.V3_0_0)]
         public DataFrame Observe(string name, Column expr, params Column[] exprs) =>
-            WrapAsDataFrame(_jvmObject.Invoke("observe", name, expr, exprs));
+            WrapAsDataFrame(Reference.Invoke("observe", name, expr, exprs));
 
         /// <summary>
         /// Create a write configuration builder for v2 sources.
@@ -549,14 +547,14 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrameWriterV2 object</returns>
         [Since(Versions.V3_0_0)]
         public DataFrameWriterV2 WriteTo(string table) =>
-            new DataFrameWriterV2((JvmObjectReference)_jvmObject.Invoke("writeTo", table));
+            new DataFrameWriterV2((JvmObjectReference)Reference.Invoke("writeTo", table));
 
         /// <summary>
         /// Returns a new `DataFrame` by taking the first `number` rows.
         /// </summary>
         /// <param name="n">Number of rows to take</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Limit(int n) => WrapAsDataFrame(_jvmObject.Invoke("limit", n));
+        public DataFrame Limit(int n) => WrapAsDataFrame(Reference.Invoke("limit", n));
 
         /// <summary>
         /// Returns a new `DataFrame` containing union of rows in this `DataFrame`
@@ -565,7 +563,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="other">Other DataFrame</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Union(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("union", other));
+            WrapAsDataFrame(Reference.Invoke("union", other));
 
         /// <summary>
         /// Returns a new `DataFrame` containing union of rows in this `DataFrame`
@@ -574,7 +572,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="other">Other DataFrame</param>
         /// <returns>DataFrame object</returns>
         public DataFrame UnionByName(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("unionByName", other));
+            WrapAsDataFrame(Reference.Invoke("unionByName", other));
 
         /// <summary>
         /// Returns a new <see cref="DataFrame"/> containing union of rows in this
@@ -586,7 +584,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         [Since(Versions.V3_1_0)]
         public DataFrame UnionByName(DataFrame other, bool allowMissingColumns) =>
-            WrapAsDataFrame(_jvmObject.Invoke("unionByName", other, allowMissingColumns));
+            WrapAsDataFrame(Reference.Invoke("unionByName", other, allowMissingColumns));
 
         /// <summary>
         /// Returns a new `DataFrame` containing rows only in both this `DataFrame`
@@ -598,7 +596,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="other">Other DataFrame</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Intersect(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("intersect", other));
+            WrapAsDataFrame(Reference.Invoke("intersect", other));
 
         /// <summary>
         /// Returns a new `DataFrame` containing rows only in both this `DataFrame`
@@ -611,7 +609,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         [Since(Versions.V2_4_0)]
         public DataFrame IntersectAll(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("intersectAll", other));
+            WrapAsDataFrame(Reference.Invoke("intersectAll", other));
 
         /// <summary>
         /// Returns a new `DataFrame` containing rows in this `DataFrame` but
@@ -623,7 +621,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="other">Other DataFrame</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Except(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("except", other));
+            WrapAsDataFrame(Reference.Invoke("except", other));
 
         /// <summary>
         /// Returns a new `DataFrame` containing rows in this `DataFrame` but
@@ -636,7 +634,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         [Since(Versions.V2_4_0)]
         public DataFrame ExceptAll(DataFrame other) =>
-            WrapAsDataFrame(_jvmObject.Invoke("exceptAll", other));
+            WrapAsDataFrame(Reference.Invoke("exceptAll", other));
 
         /// <summary>
         /// Returns a new `DataFrame` by sampling a fraction of rows (without replacement),
@@ -652,8 +650,8 @@ namespace Microsoft.Spark.Sql
             long? seed = null) =>
             WrapAsDataFrame(
                 seed.HasValue ?
-                _jvmObject.Invoke("sample", withReplacement, fraction, seed.GetValueOrDefault()) :
-                _jvmObject.Invoke("sample", withReplacement, fraction));
+                Reference.Invoke("sample", withReplacement, fraction, seed.GetValueOrDefault()) :
+                Reference.Invoke("sample", withReplacement, fraction));
 
         /// <summary>
         /// Randomly splits this `DataFrame` with the provided weights.
@@ -664,8 +662,8 @@ namespace Microsoft.Spark.Sql
         public DataFrame[] RandomSplit(double[] weights, long? seed = null)
         {
             var dataFrames = (JvmObjectReference[])(seed.HasValue ?
-                _jvmObject.Invoke("randomSplit", weights, seed.GetValueOrDefault()) :
-                _jvmObject.Invoke("randomSplit", weights));
+                Reference.Invoke("randomSplit", weights, seed.GetValueOrDefault()) :
+                Reference.Invoke("randomSplit", weights));
 
             return dataFrames.Select(jvmObject => new DataFrame(jvmObject)).ToArray();
         }
@@ -678,7 +676,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="col">Column expression for the new column</param>
         /// <returns>DataFrame object</returns>
         public DataFrame WithColumn(string colName, Column col) =>
-            WrapAsDataFrame(_jvmObject.Invoke("withColumn", colName, col));
+            WrapAsDataFrame(Reference.Invoke("withColumn", colName, col));
 
         /// <summary>
         /// Returns a new Dataset with a column renamed.
@@ -688,7 +686,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="newName">New column name to replace with</param>
         /// <returns>DataFrame object</returns>
         public DataFrame WithColumnRenamed(string existingName, string newName) =>
-            WrapAsDataFrame(_jvmObject.Invoke("withColumnRenamed", existingName, newName));
+            WrapAsDataFrame(Reference.Invoke("withColumnRenamed", existingName, newName));
 
         /// <summary>
         /// Returns a new `DataFrame` with columns dropped.
@@ -697,7 +695,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to drop</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Drop(params string[] colNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("drop", (object)colNames));
+            WrapAsDataFrame(Reference.Invoke("drop", (object)colNames));
 
         /// <summary>
         /// Returns a new `DataFrame` with a column dropped.
@@ -705,14 +703,14 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="col">Column expression</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Drop(Column col) => WrapAsDataFrame(_jvmObject.Invoke("drop", col));
+        public DataFrame Drop(Column col) => WrapAsDataFrame(Reference.Invoke("drop", col));
 
         /// <summary>
         /// Returns a new `DataFrame` that contains only the unique rows from this `DataFrame`.
         /// This is an alias for Distinct().
         /// </summary>
         /// <returns></returns>
-        public DataFrame DropDuplicates() => WrapAsDataFrame(_jvmObject.Invoke("dropDuplicates"));
+        public DataFrame DropDuplicates() => WrapAsDataFrame(Reference.Invoke("dropDuplicates"));
 
         /// <summary>
         /// Returns a new `DataFrame` with duplicate rows removed, considering only
@@ -722,7 +720,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="cols">Additional column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame DropDuplicates(string col, params string[] cols) =>
-            WrapAsDataFrame(_jvmObject.Invoke("dropDuplicates", col, cols));
+            WrapAsDataFrame(Reference.Invoke("dropDuplicates", col, cols));
 
         /// <summary>
         /// Computes basic statistics for numeric and string columns, including count, mean,
@@ -737,7 +735,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="cols">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Describe(params string[] cols) =>
-            WrapAsDataFrame(_jvmObject.Invoke("describe", (object)cols));
+            WrapAsDataFrame(Reference.Invoke("describe", (object)cols));
 
         /// <summary>
         /// Computes specified statistics for numeric and string columns.
@@ -757,7 +755,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="statistics">Statistics to compute</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Summary(params string[] statistics) =>
-            WrapAsDataFrame(_jvmObject.Invoke("summary", (object)statistics));
+            WrapAsDataFrame(Reference.Invoke("summary", (object)statistics));
 
         /// <summary>
         /// Returns the first `n` rows.
@@ -848,7 +846,7 @@ namespace Microsoft.Spark.Sql
         {
             (int port, string secret, JvmObjectReference server) =
                 ParseConnectionInfo(
-                    _jvmObject.Invoke("toPythonIterator", prefetchPartitions),
+                    Reference.Invoke("toPythonIterator", prefetchPartitions),
                     true);
             using ISocketWrapper socket = SocketFactory.CreateSocket();
             socket.Connect(IPAddress.Loopback, port, secret);
@@ -862,7 +860,7 @@ namespace Microsoft.Spark.Sql
         /// Returns the number of rows in the `DataFrame`.
         /// </summary>
         /// <returns></returns>
-        public long Count() => (long)_jvmObject.Invoke("count");
+        public long Count() => (long)Reference.Invoke("count");
 
         /// <summary>
         /// Returns a new `DataFrame` that has exactly `numPartitions` partitions.
@@ -870,7 +868,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="numPartitions">Number of partitions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Repartition(int numPartitions) =>
-            WrapAsDataFrame(_jvmObject.Invoke("repartition", numPartitions));
+            WrapAsDataFrame(Reference.Invoke("repartition", numPartitions));
 
         /// <summary>
         /// Returns a new `DataFrame` partitioned by the given partitioning expressions into
@@ -880,7 +878,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="partitionExprs">Partitioning expressions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Repartition(int numPartitions, params Column[] partitionExprs) =>
-            WrapAsDataFrame(_jvmObject.Invoke("repartition", numPartitions, partitionExprs));
+            WrapAsDataFrame(Reference.Invoke("repartition", numPartitions, partitionExprs));
 
         /// <summary>
         /// Returns a new `DataFrame` partitioned by the given partitioning expressions, using
@@ -889,7 +887,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="partitionExprs">Partitioning expressions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Repartition(params Column[] partitionExprs) =>
-            WrapAsDataFrame(_jvmObject.Invoke("repartition", (object)partitionExprs));
+            WrapAsDataFrame(Reference.Invoke("repartition", (object)partitionExprs));
 
         /// <summary>
         /// Returns a new `DataFrame` partitioned by the given partitioning expressions into
@@ -906,7 +904,7 @@ namespace Microsoft.Spark.Sql
             }
 
             return WrapAsDataFrame(
-                _jvmObject.Invoke("repartitionByRange", numPartitions, partitionExprs));
+                Reference.Invoke("repartitionByRange", numPartitions, partitionExprs));
         }
 
         /// <summary>
@@ -917,7 +915,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="partitionExprs">Partitioning expressions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame RepartitionByRange(params Column[] partitionExprs) =>
-            WrapAsDataFrame(_jvmObject.Invoke("repartitionByRange", (object)partitionExprs));
+            WrapAsDataFrame(Reference.Invoke("repartitionByRange", (object)partitionExprs));
 
         /// <summary>
         /// Returns a new `DataFrame` that has exactly `numPartitions` partitions, when the
@@ -927,20 +925,20 @@ namespace Microsoft.Spark.Sql
         /// <param name="numPartitions">Number of partitions</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Coalesce(int numPartitions) =>
-            WrapAsDataFrame(_jvmObject.Invoke("coalesce", numPartitions));
+            WrapAsDataFrame(Reference.Invoke("coalesce", numPartitions));
 
         /// <summary>
         /// Returns a new Dataset that contains only the unique rows from this `DataFrame`.
         /// This is an alias for DropDuplicates().
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Distinct() => WrapAsDataFrame(_jvmObject.Invoke("distinct"));
+        public DataFrame Distinct() => WrapAsDataFrame(Reference.Invoke("distinct"));
 
         /// <summary>
         /// Persist this <see cref="DataFrame"/> with the default storage level MEMORY_AND_DISK.
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Persist() => WrapAsDataFrame(_jvmObject.Invoke("persist"));
+        public DataFrame Persist() => WrapAsDataFrame(Reference.Invoke("persist"));
 
         /// <summary>
         /// Persist this <see cref="DataFrame"/> with the given storage level.
@@ -950,20 +948,20 @@ namespace Microsoft.Spark.Sql
         /// </param>
         /// <returns>DataFrame object</returns>
         public DataFrame Persist(StorageLevel storageLevel) =>
-            WrapAsDataFrame(_jvmObject.Invoke("persist", storageLevel));
+            WrapAsDataFrame(Reference.Invoke("persist", storageLevel));
 
         /// <summary>
         /// Persist this <see cref="DataFrame"/> with the default storage level MEMORY_AND_DISK.
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Cache() => WrapAsDataFrame(_jvmObject.Invoke("cache"));
+        public DataFrame Cache() => WrapAsDataFrame(Reference.Invoke("cache"));
 
         /// <summary>
         /// Get the <see cref="DataFrame"/>'s current <see cref="StorageLevel"/>.
         /// </summary>
         /// <returns><see cref="StorageLevel"/> object</returns>
         public StorageLevel StorageLevel() =>
-            new StorageLevel((JvmObjectReference)_jvmObject.Invoke("storageLevel"));
+            new StorageLevel((JvmObjectReference)Reference.Invoke("storageLevel"));
 
         /// <summary>
         /// Mark the Dataset as non-persistent, and remove all blocks for it from memory and disk.
@@ -974,7 +972,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="blocking"></param>
         /// <returns></returns>
         public DataFrame Unpersist(bool blocking = false) =>
-            WrapAsDataFrame(_jvmObject.Invoke("unpersist", blocking));
+            WrapAsDataFrame(Reference.Invoke("unpersist", blocking));
 
         /// <summary>
         /// Creates a local temporary view using the given name. The lifetime of this
@@ -983,7 +981,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="viewName">Name of the view</param>
         public void CreateTempView(string viewName)
         {
-            _jvmObject.Invoke("createTempView", viewName);
+            Reference.Invoke("createTempView", viewName);
         }
 
         /// <summary>
@@ -993,7 +991,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="viewName">Name of the view</param>
         public void CreateOrReplaceTempView(string viewName)
         {
-            _jvmObject.Invoke("createOrReplaceTempView", viewName);
+            Reference.Invoke("createOrReplaceTempView", viewName);
         }
 
         /// <summary>
@@ -1003,7 +1001,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="viewName">Name of the view</param>
         public void CreateGlobalTempView(string viewName)
         {
-            _jvmObject.Invoke("createGlobalTempView", viewName);
+            Reference.Invoke("createGlobalTempView", viewName);
         }
 
         /// <summary>
@@ -1013,7 +1011,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="viewName">Name of the view</param>
         public void CreateOrReplaceGlobalTempView(string viewName)
         {
-            _jvmObject.Invoke("createOrReplaceGlobalTempView", viewName);
+            Reference.Invoke("createOrReplaceGlobalTempView", viewName);
         }
 
         /// <summary>
@@ -1022,14 +1020,14 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <returns>DataFrameWriter object</returns>
         public DataFrameWriter Write() =>
-            new DataFrameWriter((JvmObjectReference)_jvmObject.Invoke("write"));
+            new DataFrameWriter((JvmObjectReference)Reference.Invoke("write"));
 
         /// <summary>
         /// Interface for saving the content of the streaming Dataset out into external storage.
         /// </summary>
         /// <returns>DataStreamWriter object</returns>
         public DataStreamWriter WriteStream() =>
-            new DataStreamWriter((JvmObjectReference)_jvmObject.Invoke("writeStream"), this);
+            new DataStreamWriter((JvmObjectReference)Reference.Invoke("writeStream"), this);
 
         /// <summary>
         /// Returns a best-effort snapshot of the files that compose this <see cref="DataFrame"/>.
@@ -1038,7 +1036,7 @@ namespace Microsoft.Spark.Sql
         /// files. Duplicates are removed.
         /// </summary>
         /// <returns>Files that compose this DataFrame</returns>
-        public IEnumerable<string> InputFiles() => (string[])_jvmObject.Invoke("inputFiles");
+        public IEnumerable<string> InputFiles() => (string[])Reference.Invoke("inputFiles");
 
         /// <summary>
         /// Returns `true` when the logical query plans inside both <see cref="DataFrame"/>s are
@@ -1059,7 +1057,7 @@ namespace Microsoft.Spark.Sql
         /// </returns>
         [Since(Versions.V3_1_0)]
         public bool SameSemantics(DataFrame other) =>
-            (bool)_jvmObject.Invoke("sameSemantics", other);
+            (bool)Reference.Invoke("sameSemantics", other);
 
         /// <summary>
         /// Returns a hash code of the logical query plan against this <see cref="DataFrame"/>.
@@ -1071,7 +1069,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>Hash code of the logical query plan</returns>
         [Since(Versions.V3_1_0)]
         public int SemanticHash() =>
-            (int)_jvmObject.Invoke("semanticHash");
+            (int)Reference.Invoke("semanticHash");
 
         /// <summary>
         /// Returns row objects based on the function (either "toPythonIterator",
@@ -1100,7 +1098,7 @@ namespace Microsoft.Spark.Sql
             string funcName,
             params object[] args)
         {
-            object result = _jvmObject.Invoke(funcName, args);
+            object result = Reference.Invoke(funcName, args);
             Version version = SparkEnvironment.SparkVersion;
             return (version.Major, version.Minor) switch
             {

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameNaFunctions.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameNaFunctions.cs
@@ -12,20 +12,18 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class DataFrameNaFunctions : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DataFrameNaFunctions(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing any null or NaN values.
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Drop() => WrapAsDataFrame(_jvmObject.Invoke("drop"));
+        public DataFrame Drop() => WrapAsDataFrame(Reference.Invoke("drop"));
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing null or NaN values.
@@ -36,7 +34,7 @@ namespace Microsoft.Spark.Sql
         /// </remarks>
         /// <param name="how">Determines the behavior of dropping rows</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Drop(string how) => WrapAsDataFrame(_jvmObject.Invoke("drop", how));
+        public DataFrame Drop(string how) => WrapAsDataFrame(Reference.Invoke("drop", how));
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing any null or NaN values
@@ -45,7 +43,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Drop(IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("drop", columnNames));
+            WrapAsDataFrame(Reference.Invoke("drop", columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing any null or NaN values
@@ -59,7 +57,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Drop(string how, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("drop", how, columnNames));
+            WrapAsDataFrame(Reference.Invoke("drop", how, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing less than `minNonNulls`
@@ -68,7 +66,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="minNonNulls"></param>
         /// <returns>DataFrame object</returns>
         public DataFrame Drop(int minNonNulls) =>
-            WrapAsDataFrame(_jvmObject.Invoke("drop", minNonNulls));
+            WrapAsDataFrame(Reference.Invoke("drop", minNonNulls));
 
         /// <summary>
         /// Returns a new `DataFrame` that drops rows containing less than `minNonNulls`
@@ -78,7 +76,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Drop(int minNonNulls, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("drop", minNonNulls, columnNames));
+            WrapAsDataFrame(Reference.Invoke("drop", minNonNulls, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in numeric columns
@@ -86,7 +84,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="value">Value to replace with</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Fill(long value) => WrapAsDataFrame(_jvmObject.Invoke("fill", value));
+        public DataFrame Fill(long value) => WrapAsDataFrame(Reference.Invoke("fill", value));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in numeric columns
@@ -94,7 +92,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="value">Value to replace with</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Fill(double value) => WrapAsDataFrame(_jvmObject.Invoke("fill", value));
+        public DataFrame Fill(double value) => WrapAsDataFrame(Reference.Invoke("fill", value));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in numeric columns
@@ -102,7 +100,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="value">Value to replace with</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Fill(string value) => WrapAsDataFrame(_jvmObject.Invoke("fill", value));
+        public DataFrame Fill(string value) => WrapAsDataFrame(Reference.Invoke("fill", value));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in specified numeric
@@ -112,7 +110,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(long value, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", value, columnNames));
+            WrapAsDataFrame(Reference.Invoke("fill", value, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in specified numeric
@@ -122,7 +120,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(double value, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", value, columnNames));
+            WrapAsDataFrame(Reference.Invoke("fill", value, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in specified string
@@ -132,14 +130,14 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(string value, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", value, columnNames));
+            WrapAsDataFrame(Reference.Invoke("fill", value, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values in boolean columns with `value`.
         /// </summary>
         /// <param name="value">Value to replace with</param>
         /// <returns>DataFrame object</returns>
-        public DataFrame Fill(bool value) => WrapAsDataFrame(_jvmObject.Invoke("fill", value));
+        public DataFrame Fill(bool value) => WrapAsDataFrame(Reference.Invoke("fill", value));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null or NaN values in specified boolean
@@ -149,7 +147,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(bool value, IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", value, columnNames));
+            WrapAsDataFrame(Reference.Invoke("fill", value, columnNames));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values.
@@ -161,7 +159,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="valueMap">Values to replace null values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(IDictionary<string, int> valueMap) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", valueMap));
+            WrapAsDataFrame(Reference.Invoke("fill", valueMap));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values.
@@ -173,7 +171,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="valueMap">Values to replace null values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(IDictionary<string, long> valueMap) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", valueMap));
+            WrapAsDataFrame(Reference.Invoke("fill", valueMap));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values.
@@ -185,7 +183,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="valueMap">Values to replace null values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(IDictionary<string, double> valueMap) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", valueMap));
+            WrapAsDataFrame(Reference.Invoke("fill", valueMap));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values.
@@ -197,7 +195,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="valueMap">Values to replace null values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(IDictionary<string, string> valueMap) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", valueMap));
+            WrapAsDataFrame(Reference.Invoke("fill", valueMap));
 
         /// <summary>
         /// Returns a new `DataFrame` that replaces null values.
@@ -209,7 +207,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="valueMap">Values to replace null values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Fill(IDictionary<string, bool> valueMap) =>
-            WrapAsDataFrame(_jvmObject.Invoke("fill", valueMap));
+            WrapAsDataFrame(Reference.Invoke("fill", valueMap));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -221,7 +219,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="replacement">Map that stores the replacement values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Replace(string columnName, IDictionary<double, double> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnName, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnName, replacement));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -233,7 +231,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="replacement">Map that stores the replacement values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Replace(string columnName, IDictionary<bool, bool> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnName, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnName, replacement));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -245,7 +243,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="replacement">Map that stores the replacement values</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Replace(string columnName, IDictionary<string, string> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnName, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnName, replacement));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -259,7 +257,7 @@ namespace Microsoft.Spark.Sql
         public DataFrame Replace(
             IEnumerable<string> columnNames,
             IDictionary<double, double> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnNames, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnNames, replacement));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -270,7 +268,7 @@ namespace Microsoft.Spark.Sql
         public DataFrame Replace(
             IEnumerable<string> columnNames,
             IDictionary<bool, bool> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnNames, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnNames, replacement));
 
         /// <summary>
         /// Replaces values matching keys in `replacement` map with the corresponding values.
@@ -281,7 +279,7 @@ namespace Microsoft.Spark.Sql
         public DataFrame Replace(
             IEnumerable<string> columnNames,
             IDictionary<string, string> replacement) =>
-            WrapAsDataFrame(_jvmObject.Invoke("replace", columnNames, replacement));
+            WrapAsDataFrame(Reference.Invoke("replace", columnNames, replacement));
 
         private DataFrame WrapAsDataFrame(object obj) => new DataFrame((JvmObjectReference)obj);
     }

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameReader.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class DataFrameReader : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DataFrameReader(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Specifies the input data source format.
@@ -32,7 +30,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameReader object</returns>
         public DataFrameReader Format(string source)
         {
-            _jvmObject.Invoke("format", source);
+            Reference.Invoke("format", source);
             return this;
         }
         
@@ -48,7 +46,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameReader object</returns>
         public DataFrameReader Schema(StructType schema)
         {
-            _jvmObject.Invoke("schema", DataType.FromJson(_jvmObject.Jvm, schema.Json));
+            Reference.Invoke("schema", DataType.FromJson(Reference.Jvm, schema.Json));
             return this;
         }
         
@@ -64,7 +62,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameReader object</returns>
         public DataFrameReader Schema(string schemaString)
         {
-            _jvmObject.Invoke("schema", schemaString);
+            Reference.Invoke("schema", schemaString);
             return this;
         }
 
@@ -119,7 +117,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameReader object</returns>
         public DataFrameReader Options(Dictionary<string, string> options)
         {
-            _jvmObject.Invoke("options", options);
+            Reference.Invoke("options", options);
             return this;
         }
 
@@ -128,7 +126,7 @@ namespace Microsoft.Spark.Sql
         /// (e.g. external key-value stores).
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Load() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
+        public DataFrame Load() => new DataFrame((JvmObjectReference)Reference.Invoke("load"));
 
         /// <summary>
         /// Loads input in as a DataFrame, for data sources that require a path 
@@ -137,7 +135,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="path">Input path</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Load(string path) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", path));
+            new DataFrame((JvmObjectReference)Reference.Invoke("load", path));
 
         /// <summary>
         /// Loads input in as a DataFrame from the given paths.
@@ -149,7 +147,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="paths">Input paths</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Load(params string[] paths) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", (object)paths));
+            new DataFrame((JvmObjectReference)Reference.Invoke("load", (object)paths));
 
         /// <summary>
         /// Construct a DataFrame representing the database table accessible via JDBC URL
@@ -160,11 +158,11 @@ namespace Microsoft.Spark.Sql
         /// <param name="properties">JDBC database connection arguments</param>
         /// <returns>DataFrame representing the database table accessible via JDBC</returns>
         public DataFrame Jdbc(string url, string table, Dictionary<string, string> properties) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            new DataFrame((JvmObjectReference)Reference.Invoke(
                 "jdbc",
                 url,
                 table,
-                new Properties(_jvmObject.Jvm, properties)));
+                new Properties(Reference.Jvm, properties)));
 
         /// <summary>
         /// Construct a DataFrame representing the database table accessible via JDBC URL
@@ -195,7 +193,7 @@ namespace Microsoft.Spark.Sql
             long upperBound,
             int numPartitions,
             Dictionary<string, string> properties) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            new DataFrame((JvmObjectReference)Reference.Invoke(
                 "jdbc",
                 url,
                 table,
@@ -203,7 +201,7 @@ namespace Microsoft.Spark.Sql
                 lowerBound,
                 upperBound,
                 numPartitions,
-                new Properties(_jvmObject.Jvm, properties)));
+                new Properties(Reference.Jvm, properties)));
 
         /// <summary>
         /// Construct a DataFrame representing the database table accessible via JDBC URL
@@ -221,12 +219,12 @@ namespace Microsoft.Spark.Sql
             string table,
             IEnumerable<string> predicates,
             Dictionary<string, string> properties) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            new DataFrame((JvmObjectReference)Reference.Invoke(
                 "jdbc",
                 url,
                 table,
                 predicates,
-                new Properties(_jvmObject.Jvm, properties)));
+                new Properties(Reference.Jvm, properties)));
 
         /// <summary>
         /// Loads a JSON file (one object per line) and returns the result as a DataFrame.
@@ -262,7 +260,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="tableName">Name of the table to read</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Table(string tableName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("table", tableName));
 
         /// <summary>
         /// Loads text files and returns a DataFrame whose schema starts with a string column
@@ -280,7 +278,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameReader object</returns>
         private DataFrameReader OptionInternal(string key, object value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -297,7 +295,7 @@ namespace Microsoft.Spark.Sql
                 throw new ArgumentException($"paths cannot be empty for source: {source}");
             }
 
-            return new DataFrame((JvmObjectReference)_jvmObject.Invoke(source, (object)paths));
+            return new DataFrame((JvmObjectReference)Reference.Invoke(source, (object)paths));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameStatFunctions.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameStatFunctions.cs
@@ -12,14 +12,12 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class DataFrameStatFunctions : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal DataFrameStatFunctions(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Calculates the approximate quantiles of a numerical column of a DataFrame.
@@ -38,7 +36,7 @@ namespace Microsoft.Spark.Sql
             string columnName,
             IEnumerable<double> probabilities,
             double relativeError) =>
-            (double[])_jvmObject.Invoke(
+            (double[])Reference.Invoke(
                 "approxQuantile", columnName, probabilities, relativeError);
 
         /// <summary>
@@ -48,7 +46,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colName2">Second column name</param>
         /// <returns>The covariance of the two columns</returns>
         public double Cov(string colName1, string colName2) =>
-            (double)_jvmObject.Invoke("cov", colName1, colName2);
+            (double)Reference.Invoke("cov", colName1, colName2);
 
         /// <summary>
         /// Calculates the correlation of two columns of a DataFrame.
@@ -61,7 +59,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="method">Method name for calculating correlation</param>
         /// <returns>The Pearson Correlation Coefficient</returns>
         public double Corr(string colName1, string colName2, string method) =>
-            (double)_jvmObject.Invoke("corr", colName1, colName2, method);
+            (double)Reference.Invoke("corr", colName1, colName2, method);
 
         /// <summary>
         /// Calculates the Pearson Correlation Coefficient of two columns of a DataFrame.
@@ -70,7 +68,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colName2">Second column name</param>
         /// <returns>The Pearson Correlation Coefficient</returns>
         public double Corr(string colName1, string colName2) =>
-            (double)_jvmObject.Invoke("corr", colName1, colName2);
+            (double)Reference.Invoke("corr", colName1, colName2);
 
         /// <summary>
         /// Computes a pair-wise frequency table of the given columns, also known as 
@@ -80,7 +78,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colName2">Second column name</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Crosstab(string colName1, string colName2) =>
-            WrapAsDataFrame(_jvmObject.Invoke("crosstab", colName1, colName2));
+            WrapAsDataFrame(Reference.Invoke("crosstab", colName1, colName2));
 
         /// <summary>
         /// Finding frequent items for columns, possibly with false positives.
@@ -92,7 +90,7 @@ namespace Microsoft.Spark.Sql
         /// </param>
         /// <returns>DataFrame object</returns>
         public DataFrame FreqItems(IEnumerable<string> columnNames, double support) =>
-            WrapAsDataFrame(_jvmObject.Invoke("freqItems", columnNames, support));
+            WrapAsDataFrame(Reference.Invoke("freqItems", columnNames, support));
 
         /// <summary>
         /// Finding frequent items for columns, possibly with false positives with
@@ -101,7 +99,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="columnNames">Column names</param>
         /// <returns>DataFrame object</returns>
         public DataFrame FreqItems(IEnumerable<string> columnNames) =>
-            WrapAsDataFrame(_jvmObject.Invoke("freqItems", columnNames));
+            WrapAsDataFrame(Reference.Invoke("freqItems", columnNames));
 
         /// <summary>
         /// Returns a stratified sample without replacement based on the fraction given
@@ -119,7 +117,7 @@ namespace Microsoft.Spark.Sql
             string columnName,
             IDictionary<T, double> fractions,
             long seed) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sampleBy", columnName, fractions, seed));
+            WrapAsDataFrame(Reference.Invoke("sampleBy", columnName, fractions, seed));
 
         /// <summary>
         /// Returns a stratified sample without replacement based on the fraction given
@@ -135,7 +133,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         [Since(Versions.V3_0_0)]
         public DataFrame SampleBy<T>(Column column, IDictionary<T, double> fractions, long seed) =>
-            WrapAsDataFrame(_jvmObject.Invoke("sampleBy", column, fractions, seed));
+            WrapAsDataFrame(Reference.Invoke("sampleBy", column, fractions, seed));
 
         private DataFrame WrapAsDataFrame(object obj) => new DataFrame((JvmObjectReference)obj);
     }

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameWriter.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameWriter.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class DataFrameWriter : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal DataFrameWriter(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal DataFrameWriter(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Specifies the behavior when data or table already exists.
@@ -48,7 +46,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         public DataFrameWriter Mode(string saveMode)
         {
-            _jvmObject.Invoke("mode", saveMode);
+            Reference.Invoke("mode", saveMode);
             return this;
         }
 
@@ -60,7 +58,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         public DataFrameWriter Format(string source)
         {
-            _jvmObject.Invoke("format", source);
+            Reference.Invoke("format", source);
             return this;
         }
 
@@ -115,7 +113,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         public DataFrameWriter Options(Dictionary<string, string> options)
         {
-            _jvmObject.Invoke("options", options);
+            Reference.Invoke("options", options);
             return this;
         }
 
@@ -127,7 +125,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         public DataFrameWriter PartitionBy(params string[] colNames)
         {
-            _jvmObject.Invoke("partitionBy", (object)colNames);
+            Reference.Invoke("partitionBy", (object)colNames);
             return this;
         }
 
@@ -144,7 +142,7 @@ namespace Microsoft.Spark.Sql
             string colName,
             params string[] colNames)
         {
-            _jvmObject.Invoke("bucketBy", numBuckets, colName, colNames);
+            Reference.Invoke("bucketBy", numBuckets, colName, colNames);
             return this;
         }
 
@@ -156,7 +154,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         public DataFrameWriter SortBy(string colName, params string[] colNames)
         {
-            _jvmObject.Invoke("sortBy", colName, colNames);
+            Reference.Invoke("sortBy", colName, colNames);
             return this;
         }
 
@@ -164,25 +162,25 @@ namespace Microsoft.Spark.Sql
         /// Saves the content of the DataFrame at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Save(string path) => _jvmObject.Invoke("save", path);
+        public void Save(string path) => Reference.Invoke("save", path);
 
         /// <summary>
         /// Saves the content of the DataFrame as the specified table.
         /// </summary>
-        public void Save() => _jvmObject.Invoke("save");
+        public void Save() => Reference.Invoke("save");
 
         /// <summary>
         /// Inserts the content of the DataFrame to the specified table. It requires that
         /// the schema of the DataFrame is the same as the schema of the table.
         /// </summary>
         /// <param name="tableName">Name of the table</param>
-        public void InsertInto(string tableName) => _jvmObject.Invoke("insertInto", tableName);
+        public void InsertInto(string tableName) => Reference.Invoke("insertInto", tableName);
 
         /// <summary>
         /// Saves the content of the DataFrame as the specified table.
         /// </summary>
         /// <param name="tableName">Name of the table</param>
-        public void SaveAsTable(string tableName) => _jvmObject.Invoke("saveAsTable", tableName);
+        public void SaveAsTable(string tableName) => Reference.Invoke("saveAsTable", tableName);
 
         /// <summary>
         /// Saves the content of the DataFrame to a external database table via JDBC
@@ -192,38 +190,38 @@ namespace Microsoft.Spark.Sql
         /// <param name="properties">JDBC database connection arguments</param>
         public void Jdbc(string url, string table, Dictionary<string, string> properties)
         {
-            _jvmObject.Invoke("jdbc", url, table, new Properties(_jvmObject.Jvm, properties));
+            Reference.Invoke("jdbc", url, table, new Properties(Reference.Jvm, properties));
         }
 
         /// <summary>
         /// Saves the content of the DataFrame in JSON format at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Json(string path) => _jvmObject.Invoke("json", path);
+        public void Json(string path) => Reference.Invoke("json", path);
 
         /// <summary>
         /// Saves the content of the DataFrame in Parquet format at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Parquet(string path) => _jvmObject.Invoke("parquet", path);
+        public void Parquet(string path) => Reference.Invoke("parquet", path);
 
         /// <summary>
         /// Saves the content of the DataFrame in ORC format at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Orc(string path) => _jvmObject.Invoke("orc", path);
+        public void Orc(string path) => Reference.Invoke("orc", path);
 
         /// <summary>
         /// Saves the content of the DataFrame in a text file at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Text(string path) => _jvmObject.Invoke("text", path);
+        public void Text(string path) => Reference.Invoke("text", path);
 
         /// <summary>
         /// Saves the content of the DataFrame in CSV format at the specified path.
         /// </summary>
         /// <param name="path">Path to save the content</param>
-        public void Csv(string path) => _jvmObject.Invoke("csv", path);
+        public void Csv(string path) => Reference.Invoke("csv", path);
 
         /// <summary>
         /// Helper function to add given key/value pair as a new option.
@@ -233,7 +231,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriter object</returns>
         private DataFrameWriter OptionInternal(string key, object value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
     }

--- a/src/csharp/Microsoft.Spark/Sql/DataFrameWriterV2.cs
+++ b/src/csharp/Microsoft.Spark/Sql/DataFrameWriterV2.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Spark.Sql
     [Since(Versions.V3_0_0)]
     public sealed class DataFrameWriterV2 : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal DataFrameWriterV2(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal DataFrameWriterV2(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Specifies a provider for the underlying output data source. Spark's default catalog
@@ -28,7 +26,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Using(string provider)
         {
-            _jvmObject.Invoke("using", provider);
+            Reference.Invoke("using", provider);
             return this;
         }
 
@@ -40,7 +38,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Option(string key, string value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -52,7 +50,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Option(string key, bool value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -64,7 +62,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Option(string key, long value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -76,7 +74,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Option(string key, double value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -87,7 +85,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 Options(Dictionary<string, string> options)
         {
-            _jvmObject.Invoke("options", options);
+            Reference.Invoke("options", options);
             return this;
         }
 
@@ -99,7 +97,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 TableProperty(string property, string value)
         {
-            _jvmObject.Invoke("tableProperty", property, value);
+            Reference.Invoke("tableProperty", property, value);
             return this;
         }
 
@@ -113,41 +111,41 @@ namespace Microsoft.Spark.Sql
         /// <returns>This DataFrameWriterV2 object</returns>
         public DataFrameWriterV2 PartitionedBy(Column column, params Column[] columns)
         {
-            _jvmObject.Invoke("partitionedBy", column, columns);
+            Reference.Invoke("partitionedBy", column, columns);
             return this;
         }
 
         /// <summary>
         /// Create a new table from the contents of the data frame.
         /// </summary>
-        public void Create() => _jvmObject.Invoke("create");
+        public void Create() => Reference.Invoke("create");
 
         /// <summary>
         /// Replace an existing table with the contents of the data frame.
         /// </summary>
-        public void Replace() => _jvmObject.Invoke("replace");
+        public void Replace() => Reference.Invoke("replace");
 
         /// <summary>
         /// Create a new table or replace an existing table with the contents of the data frame.
         /// </summary>
-        public void CreateOrReplace() => _jvmObject.Invoke("createOrReplace");
+        public void CreateOrReplace() => Reference.Invoke("createOrReplace");
 
         /// <summary>
         /// Append the contents of the data frame to the output table.
         /// </summary>
-        public void Append() => _jvmObject.Invoke("append");
+        public void Append() => Reference.Invoke("append");
 
         /// <summary>
         /// Overwrite rows matching the given filter condition with the contents of the data frame
         /// in the output table.
         /// </summary>
         /// <param name="condition">Condition filter to overwrite based on</param>
-        public void Overwrite(Column condition) => _jvmObject.Invoke("overwrite", condition);
+        public void Overwrite(Column condition) => Reference.Invoke("overwrite", condition);
 
         /// <summary>
         /// Overwrite all partition for which the data frame contains at least one row with the
         /// contents of the data frame in the output table.
         /// </summary>
-        public void OverwritePartitions() => _jvmObject.Invoke("overwritePartitions");
+        public void OverwritePartitions() => Reference.Invoke("overwritePartitions");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Expressions/UserDefinedFunction.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Expressions/UserDefinedFunction.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Spark.Sql.Expressions
     /// </summary>
     internal sealed class UserDefinedFunction : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal static UserDefinedFunction Create(
             string name,
             byte[] command,
@@ -46,10 +44,10 @@ namespace Microsoft.Spark.Sql.Expressions
 
         internal UserDefinedFunction(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         // Apply0 and Apply10 is defined so that a corresponding Func<> can
         // be constructed in Functions.Udf.
@@ -151,7 +149,7 @@ namespace Microsoft.Spark.Sql.Expressions
 
         internal Column Apply(params Column[] columns)
         {
-            return new Column((JvmObjectReference)_jvmObject.Invoke("apply", (object)columns));
+            return new Column((JvmObjectReference)Reference.Invoke("apply", (object)columns));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Expressions/WindowSpec.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Expressions/WindowSpec.cs
@@ -11,14 +11,12 @@ namespace Microsoft.Spark.Sql.Expressions
     /// </summary>
     public sealed class WindowSpec : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal WindowSpec(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Defines the partitioning columns in a `WindowSpec`.
@@ -27,7 +25,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// <param name="colNames">Additional column names</param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec PartitionBy(string colName, params string[] colNames) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("partitionBy", colName, colNames));
+            WrapAsWindowSpec(Reference.Invoke("partitionBy", colName, colNames));
 
         /// <summary>
         /// Defines the partitioning columns in a `WindowSpec`.
@@ -35,7 +33,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// <param name="columns">Column expressions</param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec PartitionBy(params Column[] columns) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("partitionBy", (object)columns));
+            WrapAsWindowSpec(Reference.Invoke("partitionBy", (object)columns));
 
         /// <summary>
         /// Defines the ordering columns in a `WindowSpec`.
@@ -44,7 +42,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// <param name="colNames">Additional column names</param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec OrderBy(string colName, params string[] colNames) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("orderBy", colName, colNames));
+            WrapAsWindowSpec(Reference.Invoke("orderBy", colName, colNames));
 
         /// <summary>
         /// Defines the ordering columns in a `WindowSpec`.
@@ -52,7 +50,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// <param name="columns">Column expressions</param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec OrderBy(params Column[] columns) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("orderBy", (object)columns));
+            WrapAsWindowSpec(Reference.Invoke("orderBy", (object)columns));
 
         /// <summary>
         /// Defines the frame boundaries, from `start` (inclusive) to `end` (inclusive).
@@ -67,7 +65,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// </param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec RowsBetween(long start, long end) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("rowsBetween", start, end));
+            WrapAsWindowSpec(Reference.Invoke("rowsBetween", start, end));
 
         /// <summary>
         /// Defines the frame boundaries, from `start` (inclusive) to `end` (inclusive).
@@ -82,7 +80,7 @@ namespace Microsoft.Spark.Sql.Expressions
         /// </param>
         /// <returns>WindowSpec object</returns>
         public WindowSpec RangeBetween(long start, long end) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("rangeBetween", start, end));
+            WrapAsWindowSpec(Reference.Invoke("rangeBetween", start, end));
 
         /// <summary>
         /// Defines the frame boundaries, from `start` (inclusive) to `end` (inclusive).
@@ -102,7 +100,7 @@ namespace Microsoft.Spark.Sql.Expressions
         [Deprecated(Versions.V2_4_0)]
         [Removed(Versions.V3_0_0)]
         public WindowSpec RangeBetween(Column start, Column end) =>
-            WrapAsWindowSpec(_jvmObject.Invoke("rangeBetween", start, end));
+            WrapAsWindowSpec(Reference.Invoke("rangeBetween", start, end));
 
         private WindowSpec WrapAsWindowSpec(object obj) => new WindowSpec((JvmObjectReference)obj);
     }

--- a/src/csharp/Microsoft.Spark/Sql/RelationalGroupedDataset.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RelationalGroupedDataset.cs
@@ -18,16 +18,15 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class RelationalGroupedDataset : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
         private readonly DataFrame _dataFrame;
 
         internal RelationalGroupedDataset(JvmObjectReference jvmObject, DataFrame dataFrame)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
             _dataFrame = dataFrame;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Compute aggregates by specifying a series of aggregate columns.
@@ -36,14 +35,14 @@ namespace Microsoft.Spark.Sql
         /// <param name="exprs">Additional columns to aggregate on</param>
         /// <returns>New DataFrame object with aggregation applied</returns>
         public DataFrame Agg(Column expr, params Column[] exprs) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("agg", expr, exprs));
+            new DataFrame((JvmObjectReference)Reference.Invoke("agg", expr, exprs));
 
         /// <summary>
         /// Count the number of rows for each group.
         /// </summary>
         /// <returns>New DataFrame object with count applied</returns>
         public DataFrame Count() =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("count"));
+            new DataFrame((JvmObjectReference)Reference.Invoke("count"));
 
         /// <summary>
         /// Compute the mean value for each numeric columns for each group.
@@ -51,7 +50,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to compute mean on</param>
         /// <returns>New DataFrame object with mean applied</returns>
         public DataFrame Mean(params string[] colNames) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("mean", (object)colNames));
+            new DataFrame((JvmObjectReference)Reference.Invoke("mean", (object)colNames));
 
         /// <summary>
         /// Compute the max value for each numeric columns for each group.
@@ -59,7 +58,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to compute max on</param>
         /// <returns>New DataFrame object with max applied</returns>
         public DataFrame Max(params string[] colNames) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("max", (object)colNames));
+            new DataFrame((JvmObjectReference)Reference.Invoke("max", (object)colNames));
 
         /// <summary>
         /// Compute the average value for each numeric columns for each group.
@@ -67,7 +66,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to compute average on</param>
         /// <returns>New DataFrame object with average applied</returns>
         public DataFrame Avg(params string[] colNames) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("avg", (object)colNames));
+            new DataFrame((JvmObjectReference)Reference.Invoke("avg", (object)colNames));
 
         /// <summary>
         /// Compute the min value for each numeric columns for each group.
@@ -75,7 +74,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to compute min on</param>
         /// <returns>New DataFrame object with min applied</returns>
         public DataFrame Min(params string[] colNames) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("min", (object)colNames));
+            new DataFrame((JvmObjectReference)Reference.Invoke("min", (object)colNames));
 
         /// <summary>
         /// Compute the sum for each numeric columns for each group.
@@ -83,7 +82,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="colNames">Name of columns to compute sum on</param>
         /// <returns>New DataFrame object with sum applied</returns>
         public DataFrame Sum(params string[] colNames) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("sum", (object)colNames));
+            new DataFrame((JvmObjectReference)Reference.Invoke("sum", (object)colNames));
 
         /// <summary>
         /// Pivots a column of the current DataFrame and performs the specified aggregation.
@@ -92,7 +91,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New RelationalGroupedDataset object with pivot applied</returns>
         public RelationalGroupedDataset Pivot(string pivotColumn) => 
             new RelationalGroupedDataset(
-                (JvmObjectReference)_jvmObject.Invoke("pivot", pivotColumn), _dataFrame);
+                (JvmObjectReference)Reference.Invoke("pivot", pivotColumn), _dataFrame);
 
         /// <summary>
         /// Pivots a column of the current DataFrame and performs the specified aggregation.
@@ -103,7 +102,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New RelationalGroupedDataset object with pivot applied</returns>
         public RelationalGroupedDataset Pivot(string pivotColumn, IEnumerable<object> values) =>
             new RelationalGroupedDataset(
-                (JvmObjectReference)_jvmObject.Invoke("pivot", pivotColumn, values), _dataFrame);
+                (JvmObjectReference)Reference.Invoke("pivot", pivotColumn, values), _dataFrame);
 
         /// <summary>
         /// Pivots a column of the current DataFrame and performs the specified aggregation.
@@ -112,7 +111,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New RelationalGroupedDataset object with pivot applied</returns>
         public RelationalGroupedDataset Pivot(Column pivotColumn) => 
             new RelationalGroupedDataset(
-                (JvmObjectReference)_jvmObject.Invoke("pivot", pivotColumn), _dataFrame);
+                (JvmObjectReference)Reference.Invoke("pivot", pivotColumn), _dataFrame);
 
         /// <summary>
         /// Pivots a column of the current DataFrame and performs the specified aggregation.
@@ -123,7 +122,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>New RelationalGroupedDataset object with pivot applied</returns>
         public RelationalGroupedDataset Pivot(Column pivotColumn, IEnumerable<object> values) =>
             new RelationalGroupedDataset(
-                (JvmObjectReference)_jvmObject.Invoke("pivot", pivotColumn, values), _dataFrame);
+                (JvmObjectReference)Reference.Invoke("pivot", pivotColumn, values), _dataFrame);
 
         /// <summary>
         /// Maps each group of the current DataFrame using a UDF and
@@ -148,7 +147,7 @@ namespace Microsoft.Spark.Sql
                 new DataFrameGroupedMapUdfWrapper(func).Execute;
 
             var udf = UserDefinedFunction.Create(
-                _jvmObject.Jvm,
+                Reference.Jvm,
                 func.Method.ToString(),
                 CommandSerDe.Serialize(
                     wrapper,
@@ -166,7 +165,7 @@ namespace Microsoft.Spark.Sql
 
             Column udfColumn = udf.Apply(columns);
 
-            return new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            return new DataFrame((JvmObjectReference)Reference.Invoke(
                 "flatMapGroupsInPandas",
                 udfColumn.Expr()));
         }
@@ -194,7 +193,7 @@ namespace Microsoft.Spark.Sql
                 new ArrowGroupedMapUdfWrapper(func).Execute;
 
             UserDefinedFunction udf = UserDefinedFunction.Create(
-                _jvmObject.Jvm,
+                Reference.Jvm,
                 func.Method.ToString(),
                 CommandSerDe.Serialize(
                     wrapper,
@@ -212,7 +211,7 @@ namespace Microsoft.Spark.Sql
 
             Column udfColumn = udf.Apply(columns);
 
-            return new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            return new DataFrame((JvmObjectReference)Reference.Invoke(
                 "flatMapGroupsInPandas",
                 udfColumn.Expr()));
         }

--- a/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RuntimeConfig.cs
@@ -11,38 +11,36 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class RuntimeConfig : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal RuntimeConfig(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal RuntimeConfig(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Sets the given Spark runtime configuration property.
         /// </summary>
         /// <param name="key">Config name</param>
         /// <param name="value">Config value</param>
-        public void Set(string key, string value) => _jvmObject.Invoke("set", key, value);
+        public void Set(string key, string value) => Reference.Invoke("set", key, value);
 
         /// <summary>
         /// Sets the given Spark runtime configuration property.
         /// </summary>
         /// <param name="key">Config name</param>
         /// <param name="value">Config value</param>
-        public void Set(string key, bool value) => _jvmObject.Invoke("set", key, value);
+        public void Set(string key, bool value) => Reference.Invoke("set", key, value);
 
         /// <summary>
         /// Sets the given Spark runtime configuration property.
         /// </summary>
         /// <param name="key">Config name</param>
         /// <param name="value">Config value</param>
-        public void Set(string key, long value) => _jvmObject.Invoke("set", key, value);
+        public void Set(string key, long value) => Reference.Invoke("set", key, value);
 
         /// <summary>
         /// Returns the value of Spark runtime configuration property for the given key.
         /// </summary>
         /// <param name="key">Key to use</param>
-        public string Get(string key) => (string)_jvmObject.Invoke("get", key);
+        public string Get(string key) => (string)Reference.Invoke("get", key);
 
         /// <summary>
         /// Returns the value of Spark runtime configuration property for the given key.
@@ -50,13 +48,13 @@ namespace Microsoft.Spark.Sql
         /// <param name="key">Key to use</param>
         /// <param name="defaultValue">Default value to use</param>
         public string Get(string key, string defaultValue) =>
-            (string)_jvmObject.Invoke("get", key, defaultValue);
+            (string)Reference.Invoke("get", key, defaultValue);
 
         /// <summary>
         /// Resets the configuration property for the given key.
         /// </summary>
         /// <param name="key">Key to unset</param>
-        public void Unset(string key) => _jvmObject.Invoke("unset", key);
+        public void Unset(string key) => Reference.Invoke("unset", key);
 
         /// <summary>
         /// Indicates whether the configuration property with the given key
@@ -68,6 +66,6 @@ namespace Microsoft.Spark.Sql
         /// Core, invalid(not existing) and other non-modifiable configuration properties,
         /// the returned value is false.
         /// </returns>
-        public bool IsModifiable(string key) => (bool)_jvmObject.Invoke("isModifiable", key);
+        public bool IsModifiable(string key) => (bool)Reference.Invoke("isModifiable", key);
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -181,6 +181,14 @@ namespace Microsoft.Spark.Sql
             new SparkSession((JvmObjectReference)_jvmObject.Invoke("newSession"));
 
         /// <summary>
+        /// Returns a string that represents the version of Spark on which this application is running.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the version of Spark on which this application is running.
+        /// </returns>
+        public string Version() => (string)_jvmObject.Invoke("version");
+        
+        /// <summary>
         /// Returns the specified table/view as a DataFrame.
         /// </summary>
         /// <param name="tableName">Name of a table or view</param>

--- a/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
+++ b/src/csharp/Microsoft.Spark/Sql/SparkSession.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class SparkSession : IDisposable, IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         private readonly Lazy<SparkContext> _sparkContext;
         private readonly Lazy<Catalog.Catalog> _catalog;
 
@@ -33,15 +31,15 @@ namespace Microsoft.Spark.Sql
         /// <param name="jvmObject">Reference to the JVM SparkSession object</param>
         internal SparkSession(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
             _sparkContext = new Lazy<SparkContext>(
                 () => new SparkContext(
-                    (JvmObjectReference)_jvmObject.Invoke("sparkContext")));
+                    (JvmObjectReference)Reference.Invoke("sparkContext")));
             _catalog = new Lazy<Catalog.Catalog>(
-                () => new Catalog.Catalog((JvmObjectReference)_jvmObject.Invoke("catalog")));
+                () => new Catalog.Catalog((JvmObjectReference)Reference.Invoke("catalog")));
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns SparkContext object associated with this SparkSession.
@@ -69,7 +67,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="session">SparkSession object</param>
         public static void SetActiveSession(SparkSession session) =>
-            session._jvmObject.Jvm.CallStaticJavaMethod(
+            session.Reference.Jvm.CallStaticJavaMethod(
                 s_sparkSessionClassName, "setActiveSession", session);
 
         /// <summary>
@@ -101,7 +99,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <param name="session">SparkSession object</param>
         public static void SetDefaultSession(SparkSession session) =>
-            session._jvmObject.Jvm.CallStaticJavaMethod(
+            session.Reference.Jvm.CallStaticJavaMethod(
                 s_sparkSessionClassName, "setDefaultSession", session);
 
         /// <summary>
@@ -156,7 +154,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <returns>The RuntimeConfig object</returns>
         public RuntimeConfig Conf() =>
-            new RuntimeConfig((JvmObjectReference)_jvmObject.Invoke("conf"));
+            new RuntimeConfig((JvmObjectReference)Reference.Invoke("conf"));
 
         /// <summary>
         /// Returns a <see cref="StreamingQueryManager"/> that allows managing all the
@@ -164,7 +162,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <returns><see cref="StreamingQueryManager"/> object</returns>
         public StreamingQueryManager Streams() =>
-            new StreamingQueryManager((JvmObjectReference)_jvmObject.Invoke("streams"));
+            new StreamingQueryManager((JvmObjectReference)Reference.Invoke("streams"));
 
         /// <summary>
         /// Start a new session with isolated SQL configurations, temporary tables, registered
@@ -178,7 +176,7 @@ namespace Microsoft.Spark.Sql
         /// </remarks>
         /// <returns>New SparkSession object</returns>
         public SparkSession NewSession() =>
-            new SparkSession((JvmObjectReference)_jvmObject.Invoke("newSession"));
+            new SparkSession((JvmObjectReference)Reference.Invoke("newSession"));
 
         /// <summary>
         /// Returns a string that represents the version of Spark on which this application is running.
@@ -186,7 +184,7 @@ namespace Microsoft.Spark.Sql
         /// <returns>
         /// A string that represents the version of Spark on which this application is running.
         /// </returns>
-        public string Version() => (string)_jvmObject.Invoke("version");
+        public string Version() => (string)Reference.Invoke("version");
         
         /// <summary>
         /// Returns the specified table/view as a DataFrame.
@@ -194,7 +192,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="tableName">Name of a table or view</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Table(string tableName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("table", tableName));
 
         /// <summary>
         /// Creates a <see cref="DataFrame"/> from an <see cref="IEnumerable"/> containing
@@ -207,10 +205,10 @@ namespace Microsoft.Spark.Sql
         /// <param name="schema">Schema as StructType</param>
         /// <returns>DataFrame object</returns>
         public DataFrame CreateDataFrame(IEnumerable<GenericRow> data, StructType schema) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            new DataFrame((JvmObjectReference)Reference.Invoke(
                 "createDataFrame",
                 data,
-                DataType.FromJson(_jvmObject.Jvm, schema.Json)));
+                DataType.FromJson(Reference.Jvm, schema.Json)));
 
         /// <summary>
         /// Creates a Dataframe given data as <see cref="IEnumerable"/> of type <see cref="int"/>
@@ -299,7 +297,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="sqlText">SQL query text</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Sql(string sqlText) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("sql", sqlText));
+            new DataFrame((JvmObjectReference)Reference.Invoke("sql", sqlText));
 
         /// <summary>
         /// Execute an arbitrary string command inside an external execution engine rather than
@@ -319,7 +317,7 @@ namespace Microsoft.Spark.Sql
             string runner,
             string command,
             Dictionary<string, string> options) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(
+            new DataFrame((JvmObjectReference)Reference.Invoke(
                 "executeCommand",
                 runner,
                 command,
@@ -331,7 +329,7 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <returns>DataFrameReader object</returns>
         public DataFrameReader Read() =>
-            new DataFrameReader((JvmObjectReference)_jvmObject.Invoke("read"));
+            new DataFrameReader((JvmObjectReference)Reference.Invoke("read"));
 
         /// <summary>
         /// Creates a DataFrame with a single column named id, containing elements in
@@ -340,7 +338,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="end">The end value (exclusive)</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Range(long end) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("range", end));
+            new DataFrame((JvmObjectReference)Reference.Invoke("range", end));
 
         /// <summary>
         /// Creates a DataFrame with a single column named id, containing elements in 
@@ -350,7 +348,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="end">The end value (exclusive)</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Range(long start, long end) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("range", start, end));
+            new DataFrame((JvmObjectReference)Reference.Invoke("range", start, end));
 
         /// <summary>
         /// Creates a DataFrame with a single column named id, containing elements in
@@ -361,7 +359,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="step">Step value to use when creating the range</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Range(long start, long end, long step) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("range", start, end, step));
+            new DataFrame((JvmObjectReference)Reference.Invoke("range", start, end, step));
 
         /// <summary>
         /// Creates a DataFrame with a single column named id, containing elements in
@@ -375,14 +373,14 @@ namespace Microsoft.Spark.Sql
         /// <returns>DataFrame object</returns>
         public DataFrame Range(long start, long end, long step, int numPartitions) =>
             new DataFrame(
-                (JvmObjectReference)_jvmObject.Invoke("range", start, end, step, numPartitions));
+                (JvmObjectReference)Reference.Invoke("range", start, end, step, numPartitions));
 
         /// <summary>
         /// Returns a DataStreamReader that can be used to read streaming data in as a DataFrame.
         /// </summary>
         /// <returns>DataStreamReader object</returns>
         public DataStreamReader ReadStream() =>
-            new DataStreamReader((JvmObjectReference)_jvmObject.Invoke("readStream"));
+            new DataStreamReader((JvmObjectReference)Reference.Invoke("readStream"));
 
         /// <summary>
         /// Returns UDFRegistraion object with which user-defined functions (UDF) can 
@@ -390,12 +388,12 @@ namespace Microsoft.Spark.Sql
         /// </summary>
         /// <returns>UDFRegistration object</returns>
         public UdfRegistration Udf() =>
-            new UdfRegistration((JvmObjectReference)_jvmObject.Invoke("udf"));
+            new UdfRegistration((JvmObjectReference)Reference.Invoke("udf"));
 
         /// <summary>
         /// Stops the underlying SparkContext.
         /// </summary>
-        public void Stop() => _jvmObject.Invoke("stop");
+        public void Stop() => Reference.Invoke("stop");
 
         /// <summary>
         /// Returns a single column schema of the given datatype.

--- a/src/csharp/Microsoft.Spark/Sql/StorageLevel.cs
+++ b/src/csharp/Microsoft.Spark/Sql/StorageLevel.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Spark.Sql
         private static StorageLevel s_memoryAndDiskSer;
         private static StorageLevel s_memoryAndDiskSer2;
         private static StorageLevel s_offHeap;
-        private readonly JvmObjectReference _jvmObject;
         private bool? _useDisk;
         private bool? _useMemory;
         private bool? _useOffHeap;
@@ -40,7 +39,7 @@ namespace Microsoft.Spark.Sql
 
         internal StorageLevel(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
         public StorageLevel(
@@ -66,7 +65,7 @@ namespace Microsoft.Spark.Sql
             _replication = replication;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns the StorageLevel object with all parameters set to false.
@@ -179,39 +178,39 @@ namespace Microsoft.Spark.Sql
         /// <summary>
         /// Returns bool value of UseDisk of this StorageLevel.
         /// </summary>
-        public bool UseDisk => _useDisk ??= (bool)_jvmObject.Invoke("useDisk");
+        public bool UseDisk => _useDisk ??= (bool)Reference.Invoke("useDisk");
 
         /// <summary>
         /// Returns bool value of UseMemory of this StorageLevel.
         /// </summary>
-        public bool UseMemory => _useMemory ??= (bool)_jvmObject.Invoke("useMemory");
+        public bool UseMemory => _useMemory ??= (bool)Reference.Invoke("useMemory");
 
         /// <summary>
         /// Returns bool value of UseOffHeap of this StorageLevel.
         /// </summary>
-        public bool UseOffHeap => _useOffHeap ??= (bool)_jvmObject.Invoke("useOffHeap");
+        public bool UseOffHeap => _useOffHeap ??= (bool)Reference.Invoke("useOffHeap");
 
         /// <summary>
         /// Returns bool value of Deserialized of this StorageLevel.
         /// </summary>
-        public bool Deserialized => _deserialized ??= (bool)_jvmObject.Invoke("deserialized");
+        public bool Deserialized => _deserialized ??= (bool)Reference.Invoke("deserialized");
 
         /// <summary>
         /// Returns int value of Replication of this StorageLevel.
         /// </summary>
-        public int Replication => _replication ??= (int)_jvmObject.Invoke("replication");
+        public int Replication => _replication ??= (int)Reference.Invoke("replication");
 
         /// <summary>
         /// Returns the description string of this StorageLevel.
         /// </summary>
         /// <returns>Description as string.</returns>
-        public string Description() => (string)_jvmObject.Invoke("description");
+        public string Description() => (string)Reference.Invoke("description");
 
         /// <summary>
         /// Returns the string representation of this StorageLevel.
         /// </summary>
         /// <returns>representation as string value.</returns>
-        public override string ToString() => (string)_jvmObject.Invoke("toString");
+        public override string ToString() => (string)Reference.Invoke("toString");
 
         /// <summary>
         /// Checks if the given object is same as the current object.

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamReader.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Spark.Sql.Streaming
     /// </summary>
     public sealed class DataStreamReader : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal DataStreamReader(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal DataStreamReader(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Specifies the input data source format.
@@ -27,7 +25,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamReader object</returns>
         public DataStreamReader Format(string source)
         {
-            _jvmObject.Invoke("format", source);
+            Reference.Invoke("format", source);
             return this;
         }
 
@@ -43,7 +41,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamReader object</returns>
         public DataStreamReader Schema(StructType schema)
         {
-            _jvmObject.Invoke("schema", DataType.FromJson(_jvmObject.Jvm, schema.Json));
+            Reference.Invoke("schema", DataType.FromJson(Reference.Jvm, schema.Json));
             return this;
         }
 
@@ -59,7 +57,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamReader object</returns>
         public DataStreamReader Schema(string schemaString)
         {
-            _jvmObject.Invoke("schema", schemaString);
+            Reference.Invoke("schema", schemaString);
             return this;
         }
 
@@ -118,7 +116,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamReader object</returns>
         public DataStreamReader Options(Dictionary<string, string> options)
         {
-            _jvmObject.Invoke("options", options);
+            Reference.Invoke("options", options);
             return this;
         }
 
@@ -127,7 +125,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// that don't require a path (e.g.external key-value stores).
         /// </summary>
         /// <returns>DataFrame object</returns>
-        public DataFrame Load() => new DataFrame((JvmObjectReference)_jvmObject.Invoke("load"));
+        public DataFrame Load() => new DataFrame((JvmObjectReference)Reference.Invoke("load"));
 
         /// <summary>
         /// Loads input in as a <see cref="DataFrame"/>, for data streams that read
@@ -136,7 +134,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <param name="path">File path for streaming</param>
         /// <returns>DataFrame object</returns>
         public DataFrame Load(string path) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("load", path));
+            new DataFrame((JvmObjectReference)Reference.Invoke("load", path));
 
         /// <summary>
         /// Loads a JSON file stream and returns the results as a <see cref="DataFrame"/>.
@@ -174,7 +172,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>DataFrame object</returns>
         [Since(Versions.V3_1_0)]
         public DataFrame Table(string tableName) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke("table", tableName));
+            new DataFrame((JvmObjectReference)Reference.Invoke("table", tableName));
 
         /// <summary>
         /// Loads text files and returns a <see cref="DataFrame"/> whose schema starts
@@ -193,7 +191,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataFrameReader object</returns>
         private DataStreamReader OptionInternal(string key, object value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
 
@@ -204,6 +202,6 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <param name="path">File path for streaming</param>
         /// <returns>DataFrame object</returns>
         private DataFrame LoadSource(string source, string path) =>
-            new DataFrame((JvmObjectReference)_jvmObject.Invoke(source, path));
+            new DataFrame((JvmObjectReference)Reference.Invoke(source, path));
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamWriter.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/DataStreamWriter.cs
@@ -17,16 +17,15 @@ namespace Microsoft.Spark.Sql.Streaming
     /// </summary>
     public sealed class DataStreamWriter : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
         private readonly DataFrame _df;
 
         internal DataStreamWriter(JvmObjectReference jvmObject, DataFrame df)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
             _df = df;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Specifies how data of a streaming DataFrame is written to a streaming sink.
@@ -45,7 +44,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter OutputMode(string outputMode)
         {
-            _jvmObject.Invoke("outputMode", outputMode);
+            Reference.Invoke("outputMode", outputMode);
             return this;
         }
 
@@ -64,7 +63,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter Format(string source)
         {
-            _jvmObject.Invoke("format", source);
+            Reference.Invoke("format", source);
             return this;
         }
 
@@ -76,7 +75,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter PartitionBy(params string[] colNames)
         {
-            _jvmObject.Invoke("partitionBy", (object)colNames);
+            Reference.Invoke("partitionBy", (object)colNames);
             return this;
         }
 
@@ -135,7 +134,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter Options(Dictionary<string, string> options)
         {
-            _jvmObject.Invoke("options", options);
+            Reference.Invoke("options", options);
             return this;
         }
 
@@ -146,7 +145,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter Trigger(Trigger trigger)
         {
-            _jvmObject.Invoke("trigger", trigger);
+            Reference.Invoke("trigger", trigger);
             return this;
         }
 
@@ -160,7 +159,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         public DataStreamWriter QueryName(string queryName)
         {
-            _jvmObject.Invoke("queryName", queryName);
+            Reference.Invoke("queryName", queryName);
             return this;
         }
 
@@ -173,9 +172,9 @@ namespace Microsoft.Spark.Sql.Streaming
         {
             if (!string.IsNullOrEmpty(path))
             {
-                return new StreamingQuery((JvmObjectReference)_jvmObject.Invoke("start", path));
+                return new StreamingQuery((JvmObjectReference)Reference.Invoke("start", path));
             }
-            return new StreamingQuery((JvmObjectReference)_jvmObject.Invoke("start"));
+            return new StreamingQuery((JvmObjectReference)Reference.Invoke("start"));
         }
 
         /// <summary>
@@ -199,7 +198,7 @@ namespace Microsoft.Spark.Sql.Streaming
         [Since(Versions.V3_1_0)]
         public StreamingQuery ToTable(string tableName)
         {
-            return new StreamingQuery((JvmObjectReference)_jvmObject.Invoke("toTable", tableName));
+            return new StreamingQuery((JvmObjectReference)Reference.Invoke("toTable", tableName));
         }
 
         /// <summary>
@@ -216,17 +215,17 @@ namespace Microsoft.Spark.Sql.Streaming
                 new ForeachWriterWrapperUdfWrapper(
                     new ForeachWriterWrapper(writer).Process).Execute;
 
-            _jvmObject.Invoke(
+            Reference.Invoke(
                 "foreach",
-                _jvmObject.Jvm.CallConstructor(
+                Reference.Jvm.CallConstructor(
                     "org.apache.spark.sql.execution.python.PythonForeachWriter",
                     UdfUtils.CreatePythonFunction(
-                        _jvmObject.Jvm,
+                        Reference.Jvm,
                         CommandSerDe.Serialize(
                             wrapper,
                             CommandSerDe.SerializedMode.Row,
                             CommandSerDe.SerializedMode.Row)),
-                    DataType.FromJson(_jvmObject.Jvm, _df.Schema().Json)));
+                    DataType.FromJson(Reference.Jvm, _df.Schema().Json)));
 
             return this;
         }
@@ -248,8 +247,8 @@ namespace Microsoft.Spark.Sql.Streaming
         public DataStreamWriter ForeachBatch(Action<DataFrame, long> func)
         {
             int callbackId = SparkEnvironment.CallbackServer.RegisterCallback(
-                new ForeachBatchCallbackHandler(_jvmObject.Jvm, func));
-            _jvmObject.Jvm.CallStaticJavaMethod(
+                new ForeachBatchCallbackHandler(Reference.Jvm, func));
+            Reference.Jvm.CallStaticJavaMethod(
                 "org.apache.spark.sql.api.dotnet.DotnetForeachBatchHelper",
                 "callForeachBatch",
                 SparkEnvironment.CallbackServer.JvmCallbackClient,
@@ -266,7 +265,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <returns>This DataStreamWriter object</returns>
         private DataStreamWriter OptionInternal(string key, object value)
         {
-            _jvmObject.Invoke("option", key, value);
+            Reference.Invoke("option", key, value);
             return this;
         }
     }

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/StreamingQuery.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/StreamingQuery.cs
@@ -12,16 +12,14 @@ namespace Microsoft.Spark.Sql.Streaming
     /// </summary>
     public sealed class StreamingQuery : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal StreamingQuery(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal StreamingQuery(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns the user-specified name of the query, or null if not specified.
         /// </summary>
-        public string Name => (string)_jvmObject.Invoke("name");
+        public string Name => (string)Reference.Invoke("name");
 
         /// <summary>
         /// Returns the unique id of this query that persists across restarts from checkpoint data.
@@ -30,7 +28,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <see cref="RunId"/>.
         /// </summary>
         public string Id =>
-            (string)((JvmObjectReference)_jvmObject.Invoke("id")).Invoke("toString");
+            (string)((JvmObjectReference)Reference.Invoke("id")).Invoke("toString");
 
         /// <summary>
         /// Returns the unique id of this run of the query. That is, every start/restart of
@@ -39,18 +37,18 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <see cref="RunId"/>s.
         /// </summary>
         public string RunId =>
-            (string)((JvmObjectReference)_jvmObject.Invoke("runId")).Invoke("toString");
+            (string)((JvmObjectReference)Reference.Invoke("runId")).Invoke("toString");
 
         /// <summary>
         /// Returns true if this query is actively running.
         /// </summary>
         /// <returns>True if this query is actively running</returns>
-        public bool IsActive() => (bool)_jvmObject.Invoke("isActive");
+        public bool IsActive() => (bool)Reference.Invoke("isActive");
 
         /// <summary>
         /// Waits for the termination of this query, either by Stop() or by an exception.
         /// </summary>
-        public void AwaitTermination() => _jvmObject.Invoke("awaitTermination");
+        public void AwaitTermination() => Reference.Invoke("awaitTermination");
 
         /// <summary>
         /// Returns true if this query is terminated within the timeout in milliseconds.
@@ -63,7 +61,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <param name="timeoutMs">Timeout value in milliseconds</param>
         /// <returns>true if this query is terminated within timeout</returns>
         public bool AwaitTermination(long timeoutMs) =>
-            (bool)_jvmObject.Invoke("awaitTermination", timeoutMs);
+            (bool)Reference.Invoke("awaitTermination", timeoutMs);
 
         /// <summary>
         /// Blocks until all available data in the source has been processed and committed to the
@@ -73,19 +71,19 @@ namespace Microsoft.Spark.Sql.Streaming
         /// `org.apache.spark.sql.execution.streaming.Source` prior to invocation.
         /// (i.e. `getOffset` must immediately reflect the addition).
         /// </summary>
-        public void ProcessAllAvailable() => _jvmObject.Invoke("processAllAvailable");
+        public void ProcessAllAvailable() => Reference.Invoke("processAllAvailable");
 
         /// <summary>
         /// Stops the execution of this query if it is running. This method blocks until the
         /// threads performing execution stop.
         /// </summary>
-        public void Stop() => _jvmObject.Invoke("stop");
+        public void Stop() => Reference.Invoke("stop");
 
         /// <summary>
         /// Prints the physical plan to the console for debugging purposes.
         /// </summary>
         /// <param name="extended">Whether to do extended explain or not</param>
-        public void Explain(bool extended = false) => _jvmObject.Invoke("explain", extended);
+        public void Explain(bool extended = false) => Reference.Invoke("explain", extended);
 
         /// <summary>
         /// The <see cref="StreamingQueryException"/> if the query was terminated by an exception,
@@ -93,7 +91,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// </summary>
         public StreamingQueryException Exception()
         {
-            var optionalException = new Option((JvmObjectReference)_jvmObject.Invoke("exception"));
+            var optionalException = new Option((JvmObjectReference)Reference.Invoke("exception"));
             if (optionalException.IsDefined())
             {
                 var exception = (JvmObjectReference)optionalException.Get();

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/StreamingQueryManager.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/StreamingQueryManager.cs
@@ -14,18 +14,16 @@ namespace Microsoft.Spark.Sql.Streaming
     /// </summary>
     public sealed class StreamingQueryManager : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
+        internal StreamingQueryManager(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal StreamingQueryManager(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Returns a list of active queries associated with this SQLContext.
         /// </summary>
         /// <returns>Active queries associated with this SQLContext.</returns>
         public IEnumerable<StreamingQuery> Active() =>
-            ((JvmObjectReference[])_jvmObject.Invoke("active"))
+            ((JvmObjectReference[])Reference.Invoke("active"))
                 .Select(sq => new StreamingQuery(sq));
 
         /// <summary>
@@ -37,7 +35,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// <see cref="StreamingQuery"/> if there is an active query with the given id.
         /// </returns>
         public StreamingQuery Get(string id) =>
-            new StreamingQuery((JvmObjectReference)_jvmObject.Invoke("get", id));
+            new StreamingQuery((JvmObjectReference)Reference.Invoke("get", id));
 
         /// <summary>
         /// Wait until any of the queries on the associated SQLContext has terminated since the
@@ -60,7 +58,7 @@ namespace Microsoft.Spark.Sql.Streaming
         /// Throws StreamingQueryException on the JVM if any query has terminated with an
         /// exception.
         /// </summary>
-        public void AwaitAnyTermination() => _jvmObject.Invoke("awaitAnyTermination");
+        public void AwaitAnyTermination() => Reference.Invoke("awaitAnyTermination");
 
         /// <summary>
         /// Wait until any of the queries on the associated SQLContext has terminated since the
@@ -88,12 +86,12 @@ namespace Microsoft.Spark.Sql.Streaming
         /// or not.
         /// </param>
         public void AwaitAnyTermination(long timeoutMs) =>
-            _jvmObject.Invoke("awaitAnyTermination", timeoutMs);
+            Reference.Invoke("awaitAnyTermination", timeoutMs);
 
         /// <summary>
         /// Forget about past terminated queries so that <see cref="AwaitAnyTermination()"/> can be
         /// used again to wait for new terminations
         /// </summary>
-        public void ResetTerminated() => _jvmObject.Invoke("resetTerminated");
+        public void ResetTerminated() => Reference.Invoke("resetTerminated");
     }
 }

--- a/src/csharp/Microsoft.Spark/Sql/Streaming/Trigger.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Streaming/Trigger.cs
@@ -17,11 +17,9 @@ namespace Microsoft.Spark.Sql.Streaming
         private static readonly string s_triggerClassName = 
             "org.apache.spark.sql.streaming.Trigger";
 
-        private readonly JvmObjectReference _jvmObject;
+        internal Trigger(JvmObjectReference jvmObject) => Reference = jvmObject;
 
-        internal Trigger(JvmObjectReference jvmObject) => _jvmObject = jvmObject;
-
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// A trigger policy that runs a query periodically based on an interval 

--- a/src/csharp/Microsoft.Spark/Sql/UDFRegistration.cs
+++ b/src/csharp/Microsoft.Spark/Sql/UDFRegistration.cs
@@ -15,14 +15,12 @@ namespace Microsoft.Spark.Sql
     /// </summary>
     public sealed class UdfRegistration : IJvmObjectReferenceProvider
     {
-        private readonly JvmObjectReference _jvmObject;
-
         internal UdfRegistration(JvmObjectReference jvmObject)
         {
-            _jvmObject = jvmObject;
+            Reference = jvmObject;
         }
 
-        JvmObjectReference IJvmObjectReferenceProvider.Reference => _jvmObject;
+        public JvmObjectReference Reference { get; private set; }
 
         /// <summary>
         /// Registers the given delegate as a user-defined function with the specified name.
@@ -423,7 +421,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="className">Class name that defines UDF</param>
         public void RegisterJava<TResult>(string name, string className)
         {
-            _jvmObject.Invoke("registerJava", name, className, GetDataType<TResult>());
+            Reference.Invoke("registerJava", name, className, GetDataType<TResult>());
         }
 
         /// <summary>
@@ -433,7 +431,7 @@ namespace Microsoft.Spark.Sql
         /// <param name="className">Class name that defines UDAF</param>
         public void RegisterJavaUDAF(string name, string className)
         {
-            _jvmObject.Invoke("registerJavaUDAF", name, className);
+            Reference.Invoke("registerJavaUDAF", name, className);
         }
 
         /// <summary>
@@ -485,18 +483,18 @@ namespace Microsoft.Spark.Sql
                 CommandSerDe.SerializedMode.Row);
 
             UserDefinedFunction udf = UserDefinedFunction.Create(
-                _jvmObject.Jvm,
+                Reference.Jvm,
                 name,
                 command,
                 evalType,
                 returnType);
 
-            _jvmObject.Invoke("registerPython", name, udf);
+            Reference.Invoke("registerPython", name, udf);
         }
 
         private JvmObjectReference GetDataType<T>()
         {
-            return DataType.FromJson(_jvmObject.Jvm, UdfUtils.GetReturnType(typeof(T)));
+            return DataType.FromJson(Reference.Jvm, UdfUtils.GetReturnType(typeof(T)));
         }
     }
 }


### PR DESCRIPTION
This PR provides public APIs to the JvmBridge, JvmObjectReference, and IJvmObjectReferenceProvider classes.  It allows users to invoke JVM calls by:

Accessing the JVMBridge directly:
```csharp
using Microsoft.Spark.Interop;
SparkEnvironment.JvmBridge.CallConstructor(...)
SparkEnvironment.JvmBridge.CallNonStaticJavaMethod(...)
SparkEnvironment.JvmBridge.CallStaticJavaMethod(...)
```

Invoke methods on JvmObjectReferences directly:
```csharp
SparkSession spark = SparkSession
    .Builder()
    .AppName("Example")
    .Config("spark.some.config.option", "some-value")
    .GetOrCreate();

spark.Reference.Invoke("methodName", args)
```


Most of the file changes follow the same pattern.  I left some PR comments to bring focus on some of the important file changes, which are `IJVMBridge.cs`, `JvmObjectReference.cs`, and `SparkEnvironment.cs`


> This is exposed to help users interact with the JVM. It is provided with limited support and should be used with caution.