### PR TITLE
Extensions.DotNet.Interactive - Add ENV to control disposal of tmp dir

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
     public class AssemblyKernelExtension : IKernelExtension
     {
         private const string TempDirEnvVar = "DOTNET_SPARK_EXTENSION_INTERACTIVE_TMPDIR";
-        private const string DisposeTempDirEnvVar = "DOTNET_SPARK_EXTENSION_INTERACTIVE_DISPOSE_TMPDIR";
+        private const string PreserveTempDirEnvVar = "DOTNET_SPARK_EXTENSION_INTERACTIVE_PRESERVE_TMPDIR";
 
         private readonly PackageResolver _packageResolver =
             new PackageResolver(new SupportNugetWrapper());
@@ -43,7 +43,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
 
                 DirectoryInfo tempDir = CreateTempDirectory();
 
-                if (EnvironmentUtils.GetEnvironmentVariableAsBool(DisposeTempDirEnvVar))
+                if (!EnvironmentUtils.GetEnvironmentVariableAsBool(PreserveTempDirEnvVar))
                 {
                     compositeKernel.RegisterForDisposal(new DisposableDirectory(tempDir));
                 }

--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive/AssemblyKernelExtension.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
     public class AssemblyKernelExtension : IKernelExtension
     {
         private const string TempDirEnvVar = "DOTNET_SPARK_EXTENSION_INTERACTIVE_TMPDIR";
+        private const string DisposeTempDirEnvVar = "DOTNET_SPARK_EXTENSION_INTERACTIVE_DISPOSE_TMPDIR";
 
         private readonly PackageResolver _packageResolver =
             new PackageResolver(new SupportNugetWrapper());
@@ -41,7 +42,11 @@ namespace Microsoft.Spark.Extensions.DotNet.Interactive
                 Environment.SetEnvironmentVariable(Constants.RunningREPLEnvVar, "true");
 
                 DirectoryInfo tempDir = CreateTempDirectory();
-                compositeKernel.RegisterForDisposal(new DisposableDirectory(tempDir));
+
+                if (EnvironmentUtils.GetEnvironmentVariableAsBool(DisposeTempDirEnvVar))
+                {
+                    compositeKernel.RegisterForDisposal(new DisposableDirectory(tempDir));
+                }
 
                 compositeKernel.AddMiddleware(async (command, context, next) =>
                 {


### PR DESCRIPTION
The DotnetInteractive extension creates a temp directory to store dlls and nuget packages and registers this temp directory with the DotnetInteractive kernel for disposal.

This PR adds a new ENV variable to control whether this tmp directory should be registered for disposal.