### PR TITLE
Fix signer information mismatch issue (Backport #752)

### DIFF
--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,7 +17,7 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Dotnet.DOTNET_NUM_BACKEND_THREADS
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_NUM_BACKEND_THREADS
 import org.apache.spark.{SparkConf, SparkEnv}
 
 /**

--- a/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-2-3/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -4,7 +4,9 @@
  * See the LICENSE file in the project root for more information.
  */
 
-package org.apache.spark.internal.config
+package org.apache.spark.internal.config.dotnet
+
+import org.apache.spark.internal.config.ConfigBuilder
 
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,7 +17,7 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Dotnet.DOTNET_NUM_BACKEND_THREADS
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_NUM_BACKEND_THREADS
 import org.apache.spark.{SparkConf, SparkEnv}
 
 /**

--- a/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-2-4/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -4,7 +4,9 @@
  * See the LICENSE file in the project root for more information.
  */
 
-package org.apache.spark.internal.config
+package org.apache.spark.internal.config.dotnet
+
+import org.apache.spark.internal.config.ConfigBuilder
 
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/api/dotnet/DotnetBackend.scala
@@ -17,7 +17,7 @@ import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Dotnet._
+import org.apache.spark.internal.config.dotnet.Dotnet.DOTNET_NUM_BACKEND_THREADS
 import org.apache.spark.{SparkConf, SparkEnv}
 
 /**

--- a/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
+++ b/src/scala/microsoft-spark-3-0/src/main/scala/org/apache/spark/internal/config/dotnet/Dotnet.scala
@@ -4,7 +4,9 @@
  * See the LICENSE file in the project root for more information.
  */
 
-package org.apache.spark.internal.config
+package org.apache.spark.internal.config.dotnet
+
+import org.apache.spark.internal.config.ConfigBuilder
 
 private[spark] object Dotnet {
   val DOTNET_NUM_BACKEND_THREADS = ConfigBuilder("spark.dotnet.numDotnetBackendThreads").intConf


### PR DESCRIPTION
This PR backports PR #752 

---

Fixes #751

This PR fixes signer information mismatch issue for` org.apache.spark.internal.config.Dotnet` by moving the package into `org.apache.spark.internal.config.dotnet`; this will avoid conflicting signer information.