### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -22,8 +22,12 @@ stages:
           pool: Hosted VS2017
         ${{ else }}:
           pool:
-            name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              name: NetCore1ESPool-Public
+              demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         steps:
         - task: PowerShell@2


### PR DESCRIPTION
Migrate to 1ES hosted pools. This PR update the pipeline yaml to use new pools.

Tracking issue: dotnet/core-eng#14276