### PR TITLE
Switch to 1ES hosted pools on main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,8 +121,8 @@ stages:
         - Build
       displayName: Sign Artifacts
       pool:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        name: NetCore1ESPool-Internal
+        queue: ImageOverride -equals build.windows.10.amd64.vs2017
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
We've officially decommissioned the old BuildPools (see partners mail) in favor of 1ES hosted pools. This change moves dotnet/spark appropriately.