### PR TITLE
Downgrade MDA to v0.4.0

### DIFF
--- a/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
+++ b/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
+++ b/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.DependencyManager" Version="10.10.0-beta.20254.4" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -30,10 +30,10 @@
   <ItemGroup>
     <PackageReference Include="Apache.Arrow" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Data.Analysis" Version="0.18.0" />
+    <PackageReference Include="Microsoft.Data.Analysis" Version="0.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Razorvine.Pyrolite" Version="4.26.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We need to downgrade MDA version to v0.4.0 since there are incompatibilities between this version and dotnet-interactive version currently supported in Synapse. Upgrading this would require adding support for .NET 6 in Spark .NET