### PR TITLE
Fix build pipeline due to bintray no longer available as spark-package repository in v1.0.1 (#1007)

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -22,6 +22,13 @@ stages:
         DOTNET_WORKER_DIR: $(CurrentDotnetWorkerDir)
 
       steps:
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core sdk'
+        inputs:
+          packageType: sdk
+          version: 3.1.x
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
         inputs:

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Spark.E2ETest
                 Path.Combine(_tempDirectory.Path, "spark-warehouse")).AbsoluteUri;
             string warehouseDir = $"--conf spark.sql.warehouse.dir={warehouseUri}";
 
+            // Spark24 < 2.4.8 and Spark30 < 3.0.3 use bintray as the repository
+            // service for spark-packages. As of  May 1st, 2021 bintray has been sunset and is no
+            // longer available. Specify additional remote repositories to search for the maven
+            // coordinates given with --packages.
+            string repositories = "--repositories https://repos.spark-packages.org/";
+
             string extraArgs = Environment.GetEnvironmentVariable(
                 EnvironmentVariableNames.ExtraSparkSubmitArgs) ?? "";
 
@@ -175,7 +181,8 @@ namespace Microsoft.Spark.E2ETest
             string logOption = "--conf spark.driver.extraJavaOptions=-Dlog4j.configuration=" +
                 $"{resourceUri}/log4j.properties";
 
-            args = $"{logOption} {warehouseDir} {extraArgs} {classArg} --master local {jar} debug";
+            args = $"{logOption} {warehouseDir} {extraArgs} {repositories} {classArg} " +
+                $"--master local {jar} debug";
         }
 
         private string GetJarPrefix()

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Spark.E2ETest
             };
 
             _process.Start();
+            _process.BeginErrorReadLine();
             _process.BeginOutputReadLine();
 
             bool processExited = false;


### PR DESCRIPTION
This PR backports PR #1007 

---

This PR fixes the build pipeline due to the following issues:

- Spark 24 < 2.4.8, Spark3.0 < 3.0.3, and Spark31 < 3.1.2 use bintray repository for spark-packages and the repository no longer available.