### PR TITLE
Migrate to 1ES hosted pool on v1.0.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,8 @@ stages:
         - Build
       displayName: Sign Artifacts
       pool:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,12 @@ stages:
         - Build
       displayName: Sign Artifacts
       pool:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
`NetCoreInternal-Pool` is not longer supported on internal pipeline:

```
There was a resource authorization issue: "The pipeline is not valid. Could not find a pool with name NetCoreInternal-Pool. The pool does not exist or has not been authorized for use.
```

This PR migrates to 1ES hosted pools instead