### PR TITLE
Switch to 1ES hosted pools on release/branch-1.0 (#1021)(#1030)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,8 @@ stages:
         - Build
       displayName: Sign Artifacts
       pool:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        name: NetCore1ESPool-Internal
+        queue: ImageOverride -equals build.windows.10.amd64.vs2017
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ stages:
       displayName: Sign Artifacts
       pool:
         name: NetCore1ESPool-Internal
-        queue: ImageOverride -equals build.windows.10.amd64.vs2017
+        demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Backporting PRs #1021 and #1030.

--

We've officially decommissioned the old BuildPools (see partners mail) in favor of 1ES hosted pools. This change moves dotnet/spark appropriately.