### PR TITLE
Update v1.0.2 release notes

### DIFF
--- a/docs/release-notes/1.0.2/release-1.0.2.md
+++ b/docs/release-notes/1.0.2/release-1.0.2.md
@@ -12,6 +12,7 @@ This is a maintenance release which contains backported PRs to support capturing
 ### Infrastructure / Documentation / Etc.
 
 * Fix build pipeline due to bintray no longer available as spark-package repository ([#1052](https://github.com/dotnet/spark/pull/1052))
+* Switch to 1ES hosted pools ([#1056](https://github.com/dotnet/spark/pull/1056))
 
 
 ### Breaking Changes


### PR DESCRIPTION
This PR updates the 1.0.2 release notes with [latest commit](https://github.com/dotnet/spark/commit/9c90c8246d70b3fa8ec6f00567f2c04a705bdae9)