### PR TITLE
JvmBridge semaphore fix

### DIFF
--- a/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
+++ b/src/csharp/Microsoft.Spark/Interop/Ipc/JvmBridge.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Spark.Interop.Ipc
         {
             object returnValue = null;
             ISocketWrapper socket = null;
-            bool acquiredSemaphore = false;
+            var acquiredSemaphore = false;
 
             try
             {


### PR DESCRIPTION
This PR address issue #1060 by doing the following:

- moved field usage of _socketSemaphore to a single method, vs cross-method ensuring that one method has strict acquire/release semantics and that no other calls to GetConnection(), even inadvertently could ever mess with the semaphore
- Moved semaphore Wait() call to the first method of the try/finally so that it gets called no matter what
- I added an ifnull check around _sockets.Enqueue(socket), just to be extra safe as well in the finally block.

I have tested this using a fairly large project that was exhibiting the error (See the bug) but I'm unsure of how to write an automated test around the original failure scenario without adding some API abstractions around the semaphore lock itself and making something like PerformSemaphoreLockedOperation(SemaphoreSlim semaphore, Action action); I didn't wan't to go overboard.

