### PR TITLE
Fixes the README release link tag for releasing the new v1.0.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     <tbody align="center">
         <tr>
             <td >2.3</td>
-            <td rowspan=3><a href="https://github.com/dotnet/spark/releases/tag/v1.0.1">v1.0.2</a></td>
+            <td rowspan=3><a href="https://github.com/dotnet/spark/releases/tag/v1.0.2">v1.0.2</a></td>
         </tr>
         <tr>
             <td>2.4*</td>


### PR DESCRIPTION
This PR fixes the README release link tag for releasing the new v1.0.2 release.