### PR TITLE
Update windows pool due to scheduled brownout

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -19,7 +19,8 @@ stages:
     - ${{ each option in test.jobOptions }}:
       - job: Run_${{ replace(option.pool, ' ', '_') }}
         ${{ if eq(lower(option.pool), 'windows') }}:
-          pool: Hosted VS2017
+          pool:
+            vmImage: 'windows-2019'
         ${{ else }}:
           pool:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,8 @@ stages:
   displayName: Build Sources
   jobs:
   - job: Build
-    pool: Hosted VS2017
+    pool: 
+      vmImage: 'windows-2019'
 
     variables:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -122,7 +123,7 @@ stages:
       displayName: Sign Artifacts
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals build.windows.10.amd64.vs2017
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -169,7 +170,8 @@ stages:
       dependsOn:
         - Sign
       displayName: Publish Artifacts
-      pool: Hosted VS2017
+      pool: 
+        vmImage: 'windows-2019'
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
The `windows-2016` pool is being deprecated, and pipelines were failing with the following error:

```
This is a scheduled windows-2016 brownout. The windows-2016 environment is deprecated and will be removed on June 30, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5403
,##[error]The remote provider was unable to process the request.
```

Hence, this PR updates the pool agents to use `windows-2019`.