### PR TITLE
Update windows pool due to scheduled brownout on v1.x

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -13,7 +13,8 @@ stages:
     dependsOn: Build
     jobs:
     - job: Run
-      pool: Hosted VS2017
+      pool:
+        vmImage: 'windows-2019'
   
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,8 @@ stages:
   displayName: Build Sources
   jobs:
   - job: Build
-    pool: Hosted VS2017
+    pool:
+      vmImage: 'windows-2019'
 
     variables:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -91,7 +92,7 @@ stages:
       displayName: Sign Artifacts
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals build.windows.10.amd64.vs2017
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -138,7 +139,8 @@ stages:
       dependsOn:
         - Sign
       displayName: Publish Artifacts
-      pool: Hosted VS2017
+      pool:
+        vmImage: 'windows-2019'
 
       variables:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
The `windows-2016` pool is being deprecated, and pipelines were failing with the following error:

```
This is a scheduled windows-2016 brownout. The windows-2016 environment is deprecated and will be removed on June 30, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5403
,##[error]The remote provider was unable to process the request.
```

Hence, this PR updates the pool agents to use `windows-2019`.