### PR TITLE
Update maven download link

### DIFF
--- a/docs/building/ubuntu-instructions.md
+++ b/docs/building/ubuntu-instructions.md
@@ -40,7 +40,7 @@ If you already have all the pre-requisites, skip to the [build](ubuntu-instructi
        ```bash
        mkdir -p ~/bin/maven
        cd ~/bin/maven
-       wget https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+       wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
        tar -xvzf apache-maven-3.6.3-bin.tar.gz
        ln -s apache-maven-3.6.3 current
        export M2_HOME=~/bin/maven/current


### PR DESCRIPTION
The URL in the tutorial does not resolve. I went to https://maven.apache.org/download.cgi and edited the link for the current version to get the 3.6.3 `.tar.gz` in the commit. Alternatively, that page also leads to the [archives](https://archive.apache.org/dist/maven/maven-3/), where 3.6.3 can be downloaded from https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.

I hope this was trivial enough to not warrant a separate issue.