### PR TITLE
At least allow Spark 3.2.2 to be used

### DIFF
--- a/src/scala/microsoft-spark-3-2/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
+++ b/src/scala/microsoft-spark-3-2/src/main/scala/org/apache/spark/deploy/dotnet/DotnetRunner.scala
@@ -40,7 +40,7 @@ import scala.util.Try
 object DotnetRunner extends Logging {
   private val DEBUG_PORT = 5567
   private val supportedSparkMajorMinorVersionPrefix = "3.2"
-  private val supportedSparkVersions = Set[String]("3.2.0", "3.2.1")
+  private val supportedSparkVersions = Set[String]("3.2.0", "3.2.1", "3.2.2")
 
   val SPARK_VERSION = DotnetUtils.normalizeSparkVersion(spark.SPARK_VERSION)
 


### PR DESCRIPTION
3.2.2 has been out for almost 4 months, and 2 months ago @Niharikadutta mentioned that support for it is being worked on here. What's the status of this? GCP Dataproc Serverless now cannot be run with Spark 3.2.1 (See [Dataproc Serverless Spark runtime releases](https://cloud.google.com/dataproc-serverless/docs/concepts/versions/spark-runtime-versions)).

 I'm not very familiar with this codebase so I don't really expect this PR to merge as-is, but I can get a basic Spark program to run on 3.2.2 by simply allowing it without any other changes...

Fixes #1095

- [X] There's a descriptive title that will make sense to other developers some time from now. 
- [X] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [X] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

