### PR TITLE
Wait before running apt command

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -44,13 +44,13 @@ stages:
 
               while($numRetry -le $maxRetry)
               {
-                  sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1
+                  sudo fuser /var/lib/dpkg/lock-frontend 2>&1
 
                   if ($LASTEXITCODE -ne 0) { Break }
                   
                   sleep 1
                   $numRetry++
-                  echo 'Waited $numRetry s for release of /var/lib/dpkg/lock-frontend'
+                  echo "Waited $numRetry s for release of /var/lib/dpkg/lock-frontend"
               }
               
               sudo apt update

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -39,6 +39,10 @@ stages:
             pwsh: true
             targetType: inline
             script: |
+              while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1 ; do
+                echo 'Waiting for release of dpkg locks'
+                sleep 1
+              done
               sudo apt update
               sudo apt -y install maven
               mvn -version

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -39,7 +39,7 @@ stages:
             pwsh: true
             targetType: inline
             script: |
-              $(Build.SourcesDirectory)/eng/waitForDpkg.sh
+              & "$(Build.SourcesDirectory)/eng/waitForDpkg.sh"
               sudo apt update
               sudo apt -y install maven
               mvn -version

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -44,9 +44,11 @@ stages:
 
               while($numRetry -le $maxRetry)
               {
-                  sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1
+                  sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1
+
                   if ($LASTEXITCODE -eq 0) { Break }
-                  echo 'Waiting for release of dpkg locks'
+                  
+                  echo 'Waiting for release of /var/lib/dpkg/lock-frontend'
                   sleep 1
                   $numRetry++     
               }

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -40,7 +40,7 @@ stages:
             targetType: inline
             script: |
               $numRetry = 0
-              $maxRetry = 60*5
+              $maxRetry = 60*10
 
               while($numRetry -le $maxRetry)
               {

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -44,7 +44,7 @@ stages:
 
               while($numRetry -le $maxRetry)
               {
-                  sudo fuser -v --% var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock 2>&1
+                  sudo fuser -v /var/lib/dpkg/lock-frontend 2>&1
 
                   if ($LASTEXITCODE -ne 0) { Break }
                   

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -39,7 +39,18 @@ stages:
             pwsh: true
             targetType: inline
             script: |
-              bash "$(Build.SourcesDirectory)/eng/waitForDpkg.sh"
+              $numRetry = 0
+              $maxRetry = 60*5
+
+              while($numRetry -le $maxRetry)
+              {
+                  sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1
+                  if ($LASTEXITCODE -eq 0) { Break }
+                  echo 'Waiting for release of dpkg locks'
+                  sleep 1
+                  $numRetry++     
+              }
+              
               sudo apt update
               sudo apt -y install maven
               mvn -version

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -39,7 +39,7 @@ stages:
             pwsh: true
             targetType: inline
             script: |
-              & "$(Build.SourcesDirectory)/eng/waitForDpkg.sh"
+              bash "$(Build.SourcesDirectory)/eng/waitForDpkg.sh"
               sudo apt update
               sudo apt -y install maven
               mvn -version

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -46,11 +46,11 @@ stages:
               {
                   sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1
 
-                  if ($LASTEXITCODE -eq 0) { Break }
+                  if ($LASTEXITCODE -ne 0) { Break }
                   
-                  echo 'Waiting for release of /var/lib/dpkg/lock-frontend'
                   sleep 1
-                  $numRetry++     
+                  $numRetry++
+                  echo 'Waited $numRetry s for release of /var/lib/dpkg/lock-frontend'
               }
               
               sudo apt update

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -44,13 +44,13 @@ stages:
 
               while($numRetry -le $maxRetry)
               {
-                  sudo fuser /var/lib/dpkg/lock-frontend 2>&1
+                  sudo fuser -v --% var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock 2>&1
 
                   if ($LASTEXITCODE -ne 0) { Break }
                   
                   sleep 1
                   $numRetry++
-                  echo "Waited $numRetry s for release of /var/lib/dpkg/lock-frontend"
+                  echo "Waited $numRetry s for release of dpkg locks"
               }
               
               sudo apt update

--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -39,10 +39,7 @@ stages:
             pwsh: true
             targetType: inline
             script: |
-              while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1 ; do
-                echo 'Waiting for release of dpkg locks'
-                sleep 1
-              done
+              $(Build.SourcesDirectory)/eng/waitForDpkg.sh
               sudo apt update
               sudo apt -y install maven
               mvn -version

--- a/eng/waitForDpkg.sh
+++ b/eng/waitForDpkg.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1 ; do
+     echo 'Waiting for release of dpkg locks'
+     sleep 1
+done

--- a/eng/waitForDpkg.sh
+++ b/eng/waitForDpkg.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1 ; do
-     echo 'Waiting for release of dpkg locks'
-     sleep 1
-done


### PR DESCRIPTION
Trying out a fix for the CI issue that's surfacing as:

```
E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable) 
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it? 
```

When running `apt` commands.  As seen here: https://dev.azure.com/dnceng-public/public/_build/results?buildId=126859&view=logs&j=6275ae02-8f8b-5df6-73dc-1bd6a4ec92dd&t=bfb24330-1904-5583-de8c-be2e1157559c&l=29