### PR TITLE
Removing deprecated tasks

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -125,19 +125,6 @@ jobs:
     workspace: ${{ parameters.workspace }}
 
   steps:
-  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
-    - task: sendStartTelemetry@0
-      displayName: 'Send Helix Start Telemetry'
-      inputs:
-        helixRepo: ${{ parameters.helixRepo }}
-        ${{ if ne(parameters.helixType, '') }}:
-          helixType: ${{ parameters.helixType }}
-        buildConfig: $(_BuildConfig)
-        runAsPublic: ${{ parameters.runAsPublic }}
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: always()
-
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: MicroBuildSigningPlugin@2
@@ -165,13 +152,6 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         env:
           TeamName: $(_TeamName)
-
-  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
-    - task: sendEndTelemetry@0
-      displayName: 'Send Helix End Telemetry'
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: always()
 
   - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Hi dotnet/spark, 

The .NET Eng Services team is fully deprecating a couple of custom Azure DevOps tasks that haven't been used in many years. This PR is to clean up usage of those tasks. 

Thanks!
Missy

See: https://github.com/dotnet/dnceng/issues/507

We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

