### PR TITLE
Replace BinaryFormatter with MessagePack serialization

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest.ExternalLibrary/ExternalClass.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest.ExternalLibrary/ExternalClass.cs
@@ -6,7 +6,6 @@ using System;
 
 namespace Microsoft.Spark.E2ETest.ExternalLibrary
 {
-    [Serializable]
     public class ExternalClass
     {
         private string _s;

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/BroadcastTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/BroadcastTests.cs
@@ -6,7 +6,6 @@ using static Microsoft.Spark.Sql.Functions;
 
 namespace Microsoft.Spark.E2ETest.IpcTests
 {
-    [Serializable]
     public class TestBroadcastVariable
     {
         public int IntValue { get; private set; }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Streaming/DataStreamWriterTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/Streaming/DataStreamWriterTests.cs
@@ -298,7 +298,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             }
         }
 
-        [Serializable]
         private class TestForeachWriter : IForeachWriter
         {
             [NonSerialized]
@@ -354,7 +353,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             }
         }
 
-        [Serializable]
         private class TestForeachWriterOpenFailure : TestForeachWriter
         {
             public override bool Open(long partitionId, long epochId)
@@ -364,7 +362,6 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             }
         }
 
-        [Serializable]
         private class TestForeachWriterProcessFailure : TestForeachWriter
         {
             public override void Process(Row value)

--- a/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
+++ b/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Spark.UnitTest
     [Collection("Spark Unit Tests")]
     public class UdfSerDeTests
     {
-        [Serializable]
         private class TestClass
         {
             private readonly string _str;

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandExecutorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandExecutorTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow;
@@ -21,6 +20,7 @@ using Microsoft.Spark.Worker.Command;
 using Razorvine.Pickle;
 using Xunit;
 using static Microsoft.Spark.UnitTest.TestUtils.ArrowTestUtils;
+using MessagePack;
 
 namespace Microsoft.Spark.Worker.UnitTest
 {
@@ -1050,7 +1050,6 @@ namespace Microsoft.Spark.Worker.UnitTest
             using var inputStream = new MemoryStream();
             using var outputStream = new MemoryStream();
             // Write test data to the input stream.
-            var formatter = new BinaryFormatter();
             var memoryStream = new MemoryStream();
 
             var inputs = new int[] { 0, 1, 2, 3, 4 };
@@ -1059,10 +1058,7 @@ namespace Microsoft.Spark.Worker.UnitTest
             foreach (int input in inputs)
             {
                 memoryStream.Position = 0;
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                // TODO: Replace BinaryFormatter with a new, secure serializer.
-                formatter.Serialize(memoryStream, input);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                MessagePackSerializer.Typeless.Serialize(memoryStream, input);
                 values.Add(memoryStream.ToArray());
             }
 
@@ -1092,12 +1088,9 @@ namespace Microsoft.Spark.Worker.UnitTest
             for (int i = 0; i < inputs.Length; ++i)
             {
                 Assert.True(SerDe.ReadInt32(outputStream) > 0);
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                // TODO: Replace BinaryFormatter with a new, secure serializer.
                 Assert.Equal(
                     mapUdf(i),
-                    formatter.Deserialize(outputStream));
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                    MessagePackSerializer.Typeless.Deserialize(outputStream));
             }
 
             // Validate all the data on the stream is read.

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/Microsoft.Spark.Worker.UnitTest.csproj
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/Microsoft.Spark.Worker.UnitTest.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Spark.Worker\Microsoft.Spark.Worker.csproj" />

--- a/src/csharp/Microsoft.Spark.Worker/Command/RDDCommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/RDDCommandExecutor.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Utils;
+using MessagePack;
 
 namespace Microsoft.Spark.Worker.Command
 {
@@ -19,8 +19,6 @@ namespace Microsoft.Spark.Worker.Command
     {
         [ThreadStatic]
         private static MemoryStream s_writeOutputStream;
-        [ThreadStatic]
-        private static BinaryFormatter s_binaryFormatter;
 
         /// <summary>
         /// Executes the commands on the input data read from input stream
@@ -111,11 +109,7 @@ namespace Microsoft.Spark.Worker.Command
             switch (serializerMode)
             {
                 case CommandSerDe.SerializedMode.Byte:
-                    BinaryFormatter formatter = s_binaryFormatter ??= new BinaryFormatter();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                    // TODO: Replace BinaryFormatter with a new, secure serializer.
-                    formatter.Serialize(stream, message);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                    MessagePackSerializer.Typeless.Serialize(stream, message);
                     break;
                 case CommandSerDe.SerializedMode.None:
                 case CommandSerDe.SerializedMode.String:

--- a/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
+++ b/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
@@ -11,7 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.DependencyManager" Version="10.10.0-beta.20254.4" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Spark\Microsoft.Spark.csproj" />

--- a/src/csharp/Microsoft.Spark.Worker/Processor/BroadcastVariableProcessor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Processor/BroadcastVariableProcessor.cs
@@ -6,9 +6,9 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Network;
+using MessagePack;
 
 namespace Microsoft.Spark.Worker.Processor
 {
@@ -47,7 +47,6 @@ namespace Microsoft.Spark.Worker.Processor
                 }
             }
 
-            var formatter = new BinaryFormatter();
             for (int i = 0; i < broadcastVars.Count; ++i)
             {
                 long bid = SerDe.ReadInt64(stream);
@@ -62,10 +61,7 @@ namespace Microsoft.Spark.Worker.Processor
                                 $"server {readBid} is different from the Broadcast Id received " +
                                 $"from the payload {bid}.");
                         }
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                        // TODO: Replace BinaryFormatter with a new, secure serializer.
-                        object value = formatter.Deserialize(socket.InputStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                        object value = MessagePackSerializer.Typeless.Deserialize(socket.InputStream);
                         BroadcastRegistry.Add(bid, value);
                     }
                     else
@@ -73,10 +69,7 @@ namespace Microsoft.Spark.Worker.Processor
                         string path = SerDe.ReadString(stream);
                         using FileStream fStream = 
                             File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                        // TODO: Replace BinaryFormatter with a new, secure serializer.
-                        object value = formatter.Deserialize(fStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                        object value = MessagePackSerializer.Typeless.Deserialize(fStream);
                         BroadcastRegistry.Add(bid, value);
                     }
                 }

--- a/src/csharp/Microsoft.Spark/Broadcast.cs
+++ b/src/csharp/Microsoft.Spark/Broadcast.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Spark
     /// also attempts to distribute broadcast variables using efficient broadcast algorithms to
     /// reduce communication cost.
     /// </summary>
-    [Serializable]
     public sealed class Broadcast<T> : IJvmObjectReferenceProvider
     {
         [NonSerialized]

--- a/src/csharp/Microsoft.Spark/Broadcast.cs
+++ b/src/csharp/Microsoft.Spark/Broadcast.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Network;
 using Microsoft.Spark.Services;
+using MessagePack;
 
 namespace Microsoft.Spark
 {
@@ -223,8 +223,7 @@ namespace Microsoft.Spark
         /// <param name="stream">Stream to which the object is serialized</param>
         private void Dump(object value, Stream stream)
         {
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(stream, value);
+            MessagePackSerializer.Typeless.Serialize(stream, value);
         }
     }
 

--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -33,7 +33,8 @@
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.18.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Razorvine.Pyrolite" Version="4.26.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark/RDD/Collector.cs
+++ b/src/csharp/Microsoft.Spark/RDD/Collector.cs
@@ -6,11 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Utils;
 using static Microsoft.Spark.Utils.CommandSerDe;
+using MessagePack;
 
 namespace Microsoft.Spark.RDD
 {
@@ -66,15 +66,13 @@ namespace Microsoft.Spark.RDD
         }
 
         /// <summary>
-        /// Deserializer using the BinaryFormatter.
+        /// Deserializer using MessagePack.
         /// </summary>
         private sealed class BinaryDeserializer : IDeserializer
         {
-            private readonly BinaryFormatter _formater = new BinaryFormatter();
-
             public object Deserialize(Stream stream, int length)
             {
-                return _formater.Deserialize(stream);
+                return MessagePackSerializer.Typeless.Deserialize(stream);
             }
         }
 

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -4,11 +4,11 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Hadoop.Conf;
 using Microsoft.Spark.Interop.Internal.Scala;
 using Microsoft.Spark.Interop.Ipc;
 using static Microsoft.Spark.Utils.CommandSerDe;
+using MessagePack;
 
 namespace Microsoft.Spark
 {
@@ -225,13 +225,12 @@ namespace Microsoft.Spark
         /// <returns>RDD representing distributed collection</returns>
         internal RDD<T> Parallelize<T>(IEnumerable<T> seq, int? numSlices = null)
         {
-            var formatter = new BinaryFormatter();
             using var memoryStream = new MemoryStream();
 
             var values = new List<byte[]>();
             foreach (T obj in seq)
             {
-                formatter.Serialize(memoryStream, obj);
+                MessagePackSerializer.Typeless.Serialize(memoryStream, obj);
                 values.Add(memoryStream.ToArray());
                 memoryStream.SetLength(0);
             }

--- a/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Spark.Utils
         ///         * <see cref="RDD{T}.MapPartitionsUdfWrapper{I, O}"/>
         ///         * <see cref="RDD.WorkerFunction.WorkerFuncChainHelper"/>
         /// </summary>
-        [Serializable]
         private sealed class UdfWrapperNode
         {
             /// <summary>
@@ -86,7 +85,6 @@ namespace Microsoft.Spark.Utils
         ///    [ UDF#1, UDF#2, UDF#3 ]
         /// 
         /// </summary>
-        [Serializable]
         private sealed class UdfWrapperData
         {
             /// <summary>

--- a/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
@@ -8,10 +8,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using MessagePack;
 
 namespace Microsoft.Spark.Utils
 {
@@ -159,10 +159,9 @@ namespace Microsoft.Spark.Utils
                 Udfs = udfs.ToArray()
             };
 
-            var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {
-                formatter.Serialize(stream, udfWrapperData);
+                MessagePackSerializer.Typeless.Serialize(stream, udfWrapperData);
 
                 byte[] udfBytes = stream.ToArray();
                 byte[] udfBytesLengthAsBytes = BitConverter.GetBytes(udfBytes.Length);
@@ -291,10 +290,9 @@ namespace Microsoft.Spark.Utils
 
             byte[] serializedCommand = SerDe.ReadBytes(stream);
 
-            var bf = new BinaryFormatter();
             var ms = new MemoryStream(serializedCommand, false);
 
-            return (UdfWrapperData)bf.Deserialize(ms);
+            return (UdfWrapperData)MessagePackSerializer.Typeless.Deserialize(ms);
         }
 
         internal static T Deserialize<T>(

--- a/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
@@ -74,13 +74,13 @@ namespace Microsoft.Spark.Utils
             internal static Metadata Deserialize(string path)
             {
                 using FileStream fileStream = File.OpenRead(path);
-                return (Metadata)MessagePackSerializer.Typeless.Deserialize(fileStream);
+                return MessagePackSerializer.Deserialize<Metadata>(fileStream, MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Options);
             }
 
             internal void Serialize(string path)
             {
                 using FileStream fileStream = File.OpenWrite(path);
-                MessagePackSerializer.Typeless.Serialize(fileStream, this);
+                MessagePackSerializer.Serialize(fileStream, this, MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Options);
             }
 
             private bool Equals(Metadata other)

--- a/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Spark.Utils
         internal static string CreateFileName(long number) =>
             s_filePattern.Replace("*", $"{number:D19}");
 
-        [Serializable]
         internal class NuGetMetadata
         {
             public string FileName { get; set; }
@@ -53,7 +52,6 @@ namespace Microsoft.Spark.Utils
             }
         }
 
-        [Serializable]
         internal class Metadata
         {
             public string[] AssemblyProbingPaths { get; set; }

--- a/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using MessagePack;
 
 namespace Microsoft.Spark.Utils
 {
@@ -74,15 +74,13 @@ namespace Microsoft.Spark.Utils
             internal static Metadata Deserialize(string path)
             {
                 using FileStream fileStream = File.OpenRead(path);
-                var formatter = new BinaryFormatter();
-                return (Metadata)formatter.Deserialize(fileStream);
+                return (Metadata)MessagePackSerializer.Typeless.Deserialize(fileStream);
             }
 
             internal void Serialize(string path)
             {
                 using FileStream fileStream = File.OpenWrite(path);
-                var formatter = new BinaryFormatter();
-                formatter.Serialize(fileStream, this);
+                MessagePackSerializer.Typeless.Serialize(fileStream, this);
             }
 
             private bool Equals(Metadata other)

--- a/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/UdfSerDe.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Spark.Utils
         private static readonly ConcurrentDictionary<TypeData, Type> s_typeCache =
             new ConcurrentDictionary<TypeData, Type>();
 
-        [Serializable]
         internal sealed class TypeData : IEquatable<TypeData>
         {
             public string Name { get; set; }
@@ -50,7 +49,6 @@ namespace Microsoft.Spark.Utils
             }
         }
 
-        [Serializable]
         internal sealed class UdfData
         {
             public TypeData TypeData { get; set; }
@@ -77,7 +75,6 @@ namespace Microsoft.Spark.Utils
             }
         }
 
-        [Serializable]
         internal sealed class TargetData
         {
             public TypeData TypeData { get; set; }
@@ -112,7 +109,6 @@ namespace Microsoft.Spark.Utils
             }
         }
 
-        [Serializable]
         internal sealed class FieldData
         {
             public TypeData TypeData { get; set; }


### PR DESCRIPTION
Fixes #1131 . As explained in my comment #1131 the whole thing is very much pointless due to the nature of Spark being RCE so we must be able to pass arbitrary data/computation around (except for one place where we don't really need the flexibility of deserializing arbitrary types and I've replaced that with a strongly typed deserializer). Nevertheless, using MessagePack's typeless serialization will hopefully saves us the trouble of the ecosystem downstream.