### PR TITLE
fix: remove scala-tools.org from pom.xml due to shutdown of scala-tools.org repository

### DIFF
--- a/benchmark/scala/pom.xml
+++ b/benchmark/scala/pom.xml
@@ -12,20 +12,6 @@
     <spark.version>2.4.4</spark.version>
   </properties>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>scala</id>
-      <name>Scala Tools</name>
-      <url>http://scala-tools.org/repo-releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <dependencies>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/benchmark/scala/pom.xml
+++ b/benchmark/scala/pom.xml
@@ -7,7 +7,7 @@
   <inceptionYear>2019</inceptionYear>
   <properties>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.4.4</spark.version>
   </properties>

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DaemonWorkerTests.cs
@@ -25,22 +25,23 @@ namespace Microsoft.Spark.Worker.UnitTest
 
         [Theory]
         [MemberData(nameof(TestData.VersionData), MemberType = typeof(TestData))]
-        public void TestsDaemonWorkerTaskRunners(string version)
+        public async void TestsDaemonWorkerTaskRunners(string version)
         {
             ISocketWrapper daemonSocket = SocketFactory.CreateSocket();
-            
+
             int taskRunnerNumber = 2;
             var typedVersion = new Version(version);
             var daemonWorker = new DaemonWorker(typedVersion);
-            
-            Task.Run(() => daemonWorker.Run(daemonSocket));
+
+            var _dummyTask = Task.Run(() => daemonWorker.Run(daemonSocket));
+            await daemonWorker.WaitForListenerReadyAsync();
 
             var clientSockets = new List<ISocketWrapper>();
             for (int i = 0; i < taskRunnerNumber; ++i)
             {
                 CreateAndVerifyConnection(daemonSocket, clientSockets, typedVersion);
             }
-            
+
             Assert.Equal(taskRunnerNumber, daemonWorker.CurrentNumTaskRunners);
         }
 

--- a/src/csharp/Microsoft.Spark.Worker/DaemonWorker.cs
+++ b/src/csharp/Microsoft.Spark.Worker/DaemonWorker.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Spark.Worker
         private readonly Version _version;
 
         private readonly TaskCompletionSource<bool> _listenerReadyTcs = new TaskCompletionSource<bool>();
-        private bool _listenerReady;
 
         internal DaemonWorker(Version version)
         {
@@ -77,7 +76,6 @@ namespace Microsoft.Spark.Worker
             try
             {
                 listener.Listen();
-                _listenerReady = true;
                 _listenerReadyTcs.TrySetResult(true);
 
                 // Communicate the server port back to the Spark using standard output.
@@ -108,7 +106,7 @@ namespace Microsoft.Spark.Worker
 
         internal Task WaitForListenerReadyAsync()
         {
-            return _listenerReady ? Task.CompletedTask : _listenerReadyTcs.Task;
+            return _listenerReadyTcs.Task;
         }
 
         /// <summary>

--- a/src/scala/microsoft-spark-2-4/pom.xml
+++ b/src/scala/microsoft-spark-2-4/pom.xml
@@ -10,7 +10,7 @@
   <inceptionYear>2019</inceptionYear>
   <properties>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.4.4</spark.version>
   </properties>

--- a/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -336,9 +336,7 @@ class DotnetBackendHandler(server: DotnetBackend, objectsTracker: JVMObjectTrack
     None
   }
 
-  def logError(id: String, e: Exception): Unit = {
-    super.logError(id, e);
-  }
+  def logError(id: String, e: Exception): Unit = { }
 }
 
 

--- a/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -336,7 +336,9 @@ class DotnetBackendHandler(server: DotnetBackend, objectsTracker: JVMObjectTrack
     None
   }
 
-  def logError(id: String, e: Exception): Unit = {}
+  def logError(id: String, e: Exception): Unit = {
+    super.logError(id, e);
+  }
 }
 
 

--- a/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
+++ b/src/scala/microsoft-spark-3-3/src/main/scala/org/apache/spark/api/dotnet/DotnetBackendHandler.scala
@@ -336,7 +336,7 @@ class DotnetBackendHandler(server: DotnetBackend, objectsTracker: JVMObjectTrack
     None
   }
 
-  def logError(id: String, e: Exception): Unit = { }
+  def logError(id: String, e: Exception): Unit = {}
 }
 
 

--- a/src/scala/pom.xml
+++ b/src/scala/pom.xml
@@ -18,18 +18,4 @@
     <module>microsoft-spark-3-3</module>
     <module>microsoft-spark-3-5</module>
   </modules>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>scala</id>
-      <name>Scala Tools</name>
-      <url>http://scala-tools.org/repo-releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 </project>


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

ref https://stackoverflow.com/questions/41754260/issues-with-scala-tools-org-and-goodstuff-im

scala-maven-plugin is available on maven central and jcenter.

related issue https://github.com/dotnet/spark/issues/1200
