### PR TITLE
Migrated to MessagePack instead of BinaryFormatter

### DIFF
--- a/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj
+++ b/src/csharp/Extensions/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest/Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Spark.Extensions.DotNet.Interactive.UnitTest</RootNamespace>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark.E2ETest.ExternalLibrary/ExternalClass.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest.ExternalLibrary/ExternalClass.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Spark.E2ETest.ExternalLibrary
     [Serializable]
     public class ExternalClass
     {
-        private string _s;
+        private string s;
 
         public ExternalClass(string s)
         {
-            _s = s;
+            this.s = s;
         }
 
         public static string HelloWorld()
@@ -23,7 +23,7 @@ namespace Microsoft.Spark.E2ETest.ExternalLibrary
 
         public string Concat(string s)
         {
-            return _s + s;
+            return this.s + s;
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/BroadcastTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/BroadcastTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using MessagePack;
 using Microsoft.Spark.Sql;
 using Xunit;
 using static Microsoft.Spark.Sql.Functions;
@@ -12,10 +13,11 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         public int IntValue { get; private set; }
         public string StringValue { get; private set; }
 
-        public TestBroadcastVariable(int intVal, string stringVal)
+        [SerializationConstructor]
+        public TestBroadcastVariable(int intValue, string stringValue)
         {
-            IntValue = intVal;
-            StringValue = stringVal;
+            IntValue = intValue;
+            StringValue = stringValue;
         }
     }
 

--- a/src/csharp/Microsoft.Spark.E2ETest/Microsoft.Spark.E2ETest.csproj
+++ b/src/csharp/Microsoft.Spark.E2ETest/Microsoft.Spark.E2ETest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\*">

--- a/src/csharp/Microsoft.Spark.UnitTest/BinarySerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/BinarySerDeTests.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MessagePack;
+using Microsoft.Spark.Utils;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest;
+
+[Collection("Spark Unit Tests")]
+public class BinarySerDeTests
+{
+    [Theory]
+    [InlineData(42)]
+    [InlineData("Test")]
+    [InlineData(99.99)]
+    public void Serialize_ShouldWriteObjectToStream(object input)
+    {
+        using var memoryStream = new MemoryStream();
+        BinarySerDe.Serialize(memoryStream, input);
+        memoryStream.Position = 0;
+
+        var deserializedObject = MessagePackSerializer.Typeless.Deserialize(memoryStream);
+
+        Assert.Equal(input, deserializedObject);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldReturnExpectedObject_WhenTypeMatches()
+    {
+        var employee = new Employee { Id = 101, Name = "John Doe" };
+        using var memoryStream = new MemoryStream();
+        MessagePackSerializer.Typeless.Serialize(memoryStream, employee);
+        memoryStream.Position = 0;
+
+        var result = BinarySerDe.Deserialize<Employee>(memoryStream);
+
+        Assert.Equal(employee.Id, result.Id);
+        Assert.Equal(employee.Name, result.Name);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldThrowInvalidCastEx_WhenTypeDoesNotMatch()
+    {
+        var employee = new Employee { Id = 101, Name = "John Doe" };
+        using var memoryStream = new MemoryStream();
+        MessagePackSerializer.Typeless.Serialize(memoryStream, employee);
+        memoryStream.Position = 0;
+
+        var action = () => BinarySerDe.Deserialize<Department>(memoryStream);
+
+        Assert.Throws<InvalidCastException>(action);
+    }
+
+    [Fact]
+    public void Serialize_CustomFunctionAndObject_ShouldBeSerializable()
+    {
+        var department = new Department { Name = "HR", EmployeeCount = 27 };
+        var employeeStub = new Employee
+        {
+            EmbeddedObject = department,
+            Id = 11,
+            Name = "Derek",
+        };
+        using var memoryStream = new MemoryStream();
+        MessagePackSerializer.Typeless.Serialize(memoryStream, employeeStub);
+        memoryStream.Position = 0;
+
+        var deserializedCalculation = BinarySerDe.Deserialize<Employee>(memoryStream);
+
+        Assert.IsType<Department>(deserializedCalculation.EmbeddedObject);
+        Assert.Equal(27, ((Department)deserializedCalculation.EmbeddedObject).EmployeeCount);
+        Assert.Equal("HR", ((Department)deserializedCalculation.EmbeddedObject).Name);
+    }
+
+    [Fact]
+    public void Serialize_ClassWithoutSerializableAttribute_ShouldThrowException()
+    {
+        var nonSerializableClass = new NonSerializableClass { Value = 123 };
+        using var memoryStream = new MemoryStream();
+        BinarySerDe.Serialize(memoryStream, nonSerializableClass);
+        memoryStream.Position = 0;
+
+        Assert.Throws<MessagePackSerializationException>(() => BinarySerDe.Deserialize<NonSerializableClass>(memoryStream));
+    }
+
+    [Fact]
+    public void Serialize_CollectionAndDictionary_ShouldBeSerializable()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var dictionary = new Dictionary<string, int> { { "one", 1 }, { "two", 2 } };
+
+        using var memoryStream = new MemoryStream();
+        BinarySerDe.Serialize(memoryStream, list);
+        memoryStream.Position = 0;
+        var deserializedList = MessagePackSerializer.Typeless.Deserialize(memoryStream) as List<int>;
+
+        Assert.Equal(list, deserializedList);
+
+        memoryStream.SetLength(0);
+        BinarySerDe.Serialize(memoryStream, dictionary);
+        memoryStream.Position = 0;
+        var deserializedDictionary = MessagePackSerializer.Typeless.Deserialize(memoryStream) as Dictionary<string, int>;
+
+        Assert.Equal(dictionary, deserializedDictionary);
+    }
+
+    [Fact]
+    public void Serialize_PolymorphicObject_ShouldBeSerializable()
+    {
+        Employee manager = new Manager { Id = 1, Name = "Alice", Role = "Account manager" };
+        using var memoryStream = new MemoryStream();
+        BinarySerDe.Serialize(memoryStream, manager);
+        memoryStream.Position = 0;
+
+        var deserializedEmployee = BinarySerDe.Deserialize<Employee>(memoryStream);
+
+        Assert.IsType<Manager>(deserializedEmployee);
+        Assert.Equal("Alice", deserializedEmployee.Name);
+        Assert.Equal("Account manager", ((Manager)deserializedEmployee).Role);
+    }
+
+    [Serializable]
+    private class Employee
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public object EmbeddedObject { get; set; }
+    }
+
+    [Serializable]
+    private class Department
+    {
+        public string Name { get; set; }
+        public int EmployeeCount { get; set; }
+    }
+
+    [Serializable]
+    private class Manager : Employee
+    {
+        public string Role { get; set; }
+    }
+
+    private class NonSerializableClass
+    {
+        public int Value { get; init; }
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
+++ b/src/csharp/Microsoft.Spark.UnitTest/Microsoft.Spark.UnitTest.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Spark.UnitTest</RootNamespace>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/UdfSerDeTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Utils;
 using Xunit;
 
@@ -17,21 +16,21 @@ namespace Microsoft.Spark.UnitTest
         [Serializable]
         private class TestClass
         {
-            private readonly string _str;
+            private readonly string str;
 
-            public TestClass(string s)
+            public TestClass(string str)
             {
-                _str = s;
+                this.str = str;
             }
 
             public string Concat(string s)
             {
-                if (_str == null)
+                if (str == null)
                 {
                     return s + s;
                 }
 
-                return _str + s;
+                return str + s;
             }
 
             public override bool Equals(object obj)
@@ -43,7 +42,7 @@ namespace Microsoft.Spark.UnitTest
                     return false;
                 }
 
-                return _str == that._str;
+                return str == that.str;
             }
 
             public override int GetHashCode()
@@ -149,16 +148,13 @@ namespace Microsoft.Spark.UnitTest
             return Deserialize(Serialize(udf));
         }
 
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-        // TODO: Replace BinaryFormatter with a new, secure serializer.
         private byte[] Serialize(Delegate udf)
         {
             UdfSerDe.UdfData udfData = UdfSerDe.Serialize(udf);
 
             using (var ms = new MemoryStream())
             {
-                var bf = new BinaryFormatter();
-                bf.Serialize(ms, udfData);
+                BinarySerDe.Serialize(ms, udfData);
                 return ms.ToArray();
             }
         }
@@ -167,11 +163,9 @@ namespace Microsoft.Spark.UnitTest
         {
             using (var ms = new MemoryStream(serializedUdf, false))
             {
-                var bf = new BinaryFormatter();
-                UdfSerDe.UdfData udfData = (UdfSerDe.UdfData)bf.Deserialize(ms);
+                var udfData = BinarySerDe.Deserialize<UdfSerDe.UdfData>(ms);
                 return UdfSerDe.Deserialize(udfData);
             }
         }
-#pragma warning restore
     }
 }

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandExecutorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandExecutorTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow;
@@ -1049,10 +1048,8 @@ namespace Microsoft.Spark.Worker.UnitTest
 
             using var inputStream = new MemoryStream();
             using var outputStream = new MemoryStream();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
+
             // Write test data to the input stream.
-            var formatter = new BinaryFormatter();
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
             var memoryStream = new MemoryStream();
 
             var inputs = new int[] { 0, 1, 2, 3, 4 };
@@ -1061,10 +1058,7 @@ namespace Microsoft.Spark.Worker.UnitTest
             foreach (int input in inputs)
             {
                 memoryStream.Position = 0;
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                // TODO: Replace BinaryFormatter with a new, secure serializer.
-                formatter.Serialize(memoryStream, input);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                BinarySerDe.Serialize(memoryStream, input);
                 values.Add(memoryStream.ToArray());
             }
 
@@ -1094,12 +1088,9 @@ namespace Microsoft.Spark.Worker.UnitTest
             for (int i = 0; i < inputs.Length; ++i)
             {
                 Assert.True(SerDe.ReadInt32(outputStream) > 0);
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                // TODO: Replace BinaryFormatter with a new, secure serializer.
                 Assert.Equal(
                     mapUdf(i),
-                    formatter.Deserialize(outputStream));
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                    BinarySerDe.Deserialize<object>(outputStream));
             }
 
             // Validate all the data on the stream is read.

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/Microsoft.Spark.Worker.UnitTest.csproj
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/Microsoft.Spark.Worker.UnitTest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/src/csharp/Microsoft.Spark.Worker/Command/RDDCommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/RDDCommandExecutor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Utils;
 
@@ -19,10 +18,6 @@ namespace Microsoft.Spark.Worker.Command
     {
         [ThreadStatic]
         private static MemoryStream s_writeOutputStream;
-        [ThreadStatic]
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-        private static BinaryFormatter s_binaryFormatter;
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
         /// <summary>
         /// Executes the commands on the input data read from input stream
@@ -113,11 +108,7 @@ namespace Microsoft.Spark.Worker.Command
             switch (serializerMode)
             {
                 case CommandSerDe.SerializedMode.Byte:
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                    BinaryFormatter formatter = s_binaryFormatter ??= new BinaryFormatter();
-                    // TODO: Replace BinaryFormatter with a new, secure serializer.
-                    formatter.Serialize(stream, message);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                    BinarySerDe.Serialize(stream, message);
                     break;
                 case CommandSerDe.SerializedMode.None:
                 case CommandSerDe.SerializedMode.String:

--- a/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
+++ b/src/csharp/Microsoft.Spark.Worker/Microsoft.Spark.Worker.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.Spark.Worker</RootNamespace>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/csharp/Microsoft.Spark.Worker/Processor/BroadcastVariableProcessor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Processor/BroadcastVariableProcessor.cs
@@ -5,9 +5,9 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Network;
+using Microsoft.Spark.Utils;
 
 namespace Microsoft.Spark.Worker.Processor
 {
@@ -45,9 +45,7 @@ namespace Microsoft.Spark.Worker.Processor
                         broadcastVars.Secret);
                 }
             }
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-            var formatter = new BinaryFormatter();
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+
             for (int i = 0; i < broadcastVars.Count; ++i)
             {
                 long bid = SerDe.ReadInt64(stream);
@@ -62,21 +60,17 @@ namespace Microsoft.Spark.Worker.Processor
                                 $"server {readBid} is different from the Broadcast Id received " +
                                 $"from the payload {bid}.");
                         }
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                        // TODO: Replace BinaryFormatter with a new, secure serializer.
-                        object value = formatter.Deserialize(socket.InputStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+
+                        var value = BinarySerDe.Deserialize<object>(socket.InputStream);
                         BroadcastRegistry.Add(bid, value);
                     }
                     else
                     {
                         string path = SerDe.ReadString(stream);
-                        using FileStream fStream = 
+                        using FileStream fStream =
                             File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                        // TODO: Replace BinaryFormatter with a new, secure serializer.
-                        object value = formatter.Deserialize(fStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+
+                        var value = BinarySerDe.Deserialize<object>(fStream);
                         BroadcastRegistry.Add(bid, value);
                     }
                 }

--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -10,7 +10,6 @@
     <Description>.NET for Apache Spark</Description>
     <PackageReleaseNotes>https://github.com/dotnet/spark/tree/master/docs/release-notes</PackageReleaseNotes>
     <PackageTags>spark;dotnet;csharp</PackageTags>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.Arrow" Version="14.0.2" />
+    <PackageReference Include="MessagePack" Version="3.0.214-rc.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.21.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/csharp/Microsoft.Spark/RDD/Collector.cs
+++ b/src/csharp/Microsoft.Spark/RDD/Collector.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Utils;
@@ -70,12 +69,8 @@ namespace Microsoft.Spark.RDD
         /// </summary>
         private sealed class BinaryDeserializer : IDeserializer
         {
-            private readonly BinaryFormatter _formater = new BinaryFormatter();
-
-            public object Deserialize(Stream stream, int length)
-            {
-                return _formater.Deserialize(stream);
-            }
+            public object Deserialize(Stream stream, int length) =>
+                BinarySerDe.Deserialize(stream, length);
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark/SparkContext.cs
+++ b/src/csharp/Microsoft.Spark/SparkContext.cs
@@ -4,10 +4,10 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Spark.Hadoop.Conf;
 using Microsoft.Spark.Interop.Internal.Scala;
 using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Utils;
 using static Microsoft.Spark.Utils.CommandSerDe;
 
 namespace Microsoft.Spark
@@ -225,13 +225,12 @@ namespace Microsoft.Spark
         /// <returns>RDD representing distributed collection</returns>
         internal RDD<T> Parallelize<T>(IEnumerable<T> seq, int? numSlices = null)
         {
-            var formatter = new BinaryFormatter();
             using var memoryStream = new MemoryStream();
 
             var values = new List<byte[]>();
             foreach (T obj in seq)
             {
-                formatter.Serialize(memoryStream, obj);
+                BinarySerDe.Serialize(memoryStream, obj);
                 values.Add(memoryStream.ToArray());
                 memoryStream.SetLength(0);
             }

--- a/src/csharp/Microsoft.Spark/Utils/BinarySerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/BinarySerDe.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.Spark.Interop.Ipc;
+
+namespace Microsoft.Spark.Utils;
+
+// If deserialization of untrusted data is required, extend this functionality to
+// incorporate techniques such as using a Message Authentication Code (MAC)
+// or whitelisting allowed types to mitigate security risks.
+
+/// <summary>
+/// BinarySerDe (Serialization/Deserialization) is a utility class designed to handle
+/// serialization and deserialization of objects to and from binary formats.
+///
+/// <para>
+/// This implementation uses the MessagePack `Typeless` API, which embeds type
+/// information into the serialized data. It adds overhead of 1-2 bytes for primitive
+/// types, and serializes 'System.Type' entirely for complex objects.
+/// Does not serialize type definition, so in order to deserialize a complex object,
+/// declaring library should be available in app domain or at probing locations.
+/// </para>
+/// </summary>
+internal static class BinarySerDe
+{
+    private static MessagePackSerializerOptions _options =
+        new AllowStandardOrSerializableMessagePackSerializerOptions(
+            TypelessContractlessStandardResolver.Instance
+        ).WithSecurity(MessagePackSecurity.UntrustedData);
+
+    /// <summary>
+    /// Deserializes a stream of binary data into an object of type T.
+    /// When using or shared streams, prefer the overloaded version
+    /// that accepts a `length` parameter to ensure no excess data is consumed.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the deserialized object.</typeparam>
+    /// <param name="stream">The stream containing the serialized data.</param>
+    /// <returns>An object of type T.</returns>
+    internal static T Deserialize<T>(Stream stream)
+    {
+        return (T)MessagePackSerializer.Typeless.Deserialize(stream, _options);
+    }
+
+    /// <summary>
+    /// Deserializes an object from stream, ensuring no excess data is read.
+    /// </summary>
+    /// <param name="stream">The stream containing the serialized data.</param>
+    /// <param name="length">The length of byte section to deserialize.</param>
+    /// <returns>The deserialized object.</returns>
+    internal static object Deserialize(Stream stream, int length)
+    {
+        ReadOnlyMemory<byte> memory = SerDe.ReadBytes(stream, length);
+
+        return MessagePackSerializer.Typeless.Deserialize(memory, _options);
+    }
+
+    /// <summary>
+    /// Serializes an object into a binary stream
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="stream">The target stream where the data will be written.</param>
+    /// <param name="graph">The object to serialize.</param>
+    internal static void Serialize<T>(Stream stream, T graph)
+    {
+        MessagePackSerializer.Typeless.Serialize(stream, graph, _options);
+    }
+}
+
+/// <summary>
+/// Additional security for MessagePack typeless serialization, that only allows
+/// standard classes or classes marked with the 'System.Serializable' attribute.
+/// </summary>
+internal class AllowStandardOrSerializableMessagePackSerializerOptions
+    : MessagePackSerializerOptions
+{
+    public AllowStandardOrSerializableMessagePackSerializerOptions(IFormatterResolver resolver)
+        : base(resolver) { }
+
+    protected AllowStandardOrSerializableMessagePackSerializerOptions(
+        MessagePackSerializerOptions copyFrom
+    )
+        : base(copyFrom) { }
+
+    public override void ThrowIfDeserializingTypeIsDisallowed(Type type)
+    {
+        // Check against predefined blacklist
+        base.ThrowIfDeserializingTypeIsDisallowed(type);
+
+        // Check if MessagePack can handle this type safely
+        var formatter = StandardResolver.Instance.GetFormatterDynamic(type);
+
+        if (
+            formatter == null
+            && type.GetCustomAttributes(typeof(System.SerializableAttribute), true).Length == 0
+        )
+        {
+            throw new MessagePackSerializationException(
+                $"Deserialization attempted to create the type {type.FullName} which is not allowed." +
+                $" Add 'System.Serializable' attribute to allow serialization"
+            );
+        }
+    }
+
+    protected override MessagePackSerializerOptions Clone()
+    {
+        return new AllowStandardOrSerializableMessagePackSerializerOptions(this);
+    }
+}

--- a/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
@@ -159,10 +158,9 @@ namespace Microsoft.Spark.Utils
                 Udfs = udfs.ToArray()
             };
 
-            var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {
-                formatter.Serialize(stream, udfWrapperData);
+                BinarySerDe.Serialize(stream, udfWrapperData);
 
                 byte[] udfBytes = stream.ToArray();
                 byte[] udfBytesLengthAsBytes = BitConverter.GetBytes(udfBytes.Length);
@@ -291,10 +289,9 @@ namespace Microsoft.Spark.Utils
 
             byte[] serializedCommand = SerDe.ReadBytes(stream);
 
-            var bf = new BinaryFormatter();
             var ms = new MemoryStream(serializedCommand, false);
 
-            return (UdfWrapperData)bf.Deserialize(ms);
+            return BinarySerDe.Deserialize<UdfWrapperData>(ms);
         }
 
         internal static T Deserialize<T>(

--- a/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
+++ b/src/csharp/Microsoft.Spark/Utils/DependencyProviderUtils.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Microsoft.Spark.Utils
 {
@@ -74,15 +73,13 @@ namespace Microsoft.Spark.Utils
             internal static Metadata Deserialize(string path)
             {
                 using FileStream fileStream = File.OpenRead(path);
-                var formatter = new BinaryFormatter();
-                return (Metadata)formatter.Deserialize(fileStream);
+                return BinarySerDe.Deserialize<Metadata>(fileStream);
             }
 
             internal void Serialize(string path)
             {
                 using FileStream fileStream = File.OpenWrite(path);
-                var formatter = new BinaryFormatter();
-                formatter.Serialize(fileStream, this);
+                BinarySerDe.Serialize(fileStream, this);
             }
 
             private bool Equals(Metadata other)


### PR DESCRIPTION
### Overview  
This PR replaces `BinaryFormatter` serialization with the `MessagePack` library.  
I was unable to contribute to https://github.com/dotnet/spark/pull/1166, so I’ve opened a new one.  

Replacing `BinaryFormatter` addresses a range of issues, including:  
- **.NET 9 compatibility:** Upgrading to .NET 9 requires a separate NuGet package, but this package is incompatible with .NET Framework 4.8, which is also targeted by the project.  
- **Dotnet.Interactive incompatibility:** Using Dotnet.Interactive result in a smth like BinarySerializationDisabled exception. The only workaround currently is adding:  
  ```csharp
  AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
  ``` 
  to the beginning of the notebook.  It doesn't work each time, it's hard to troubleshoot Dotnet.Interactive, since these exceptions constantly arise and prevent UDFs from execution.
- **Deprecation:** `BinaryFormatter` has been abandoned and is officially deprecated.  

### Compatibility Considerations
To ensure better compatibility with existing .NET types and reduce coupling with MessagePack, I opted to retain the `Serializable` and `NonSerialized` attributes.

One limitation of MessagePack is its handling of types with constructors containing parameters. If parameter names do not match the corresponding property or field names (e.g., a property `_value` and a constructor argument `value`), the parameters will not be automatically matched.

In such cases a default, parameterless constructor is required. If no default constructor is found, MessagePack throws a descriptive exception.

This PR fixes #1131.  

---

### Security Considerations  
Using `MessagePack` improves serialization security by addressing common vulnerabilities associated with `BinaryFormatter`. Key points include:  

1. **Safe Deserialization:**  
   - `MessagePack` does not support arbitrary executable code. It can only serialize and deserialize objects and their properties. Delegates are not supported by design.
   - Data exchange occurs exclusively between the Driver and Worker, ensuring that the input being deserialized is the same as what was serialized by the application.  

2. **Typeless Mode:**  
   - `Typeless` mode is only used for deserializing custom objects. For primitives, an optimized serialization format is used, which adds a single byte for type information rather than serializing the entire `System.Type`.  

3. **Restricted Type Resolution:**  
   - The binary payload includes only type descriptions, not definitions.  
   - This ensures that only types known to the application domain or located in the deserializing side’s probing paths can be deserialized, preventing malicious derived types from executing custom logic.  

4. **Mitigation of RCE (Remote Code Execution) Risks:**  
   - `MessagePack` Enhanced Security Mode is enabled to filter object types and disallow known vulnerable ones.  
   - A custom filter is implemented to restrict deserialization to:  
     - Simple types (primitives, collections, etc.)  
     - Types explicitly marked with the `[Serializable]` attribute.  

For reference, here’s an overview paper on potential RCE attack vectors with typeless `MessagePack` deserialization:  
[Generating Deserialization Payloads for MessagePack-C# Typeless Mode](https://blog.netwrix.com/2023/04/10/generating-deserialization-payloads-for-messagepack-cs-typeless-mode/)