### PR TITLE
Disable warning NU5104 for MessagePack

### DIFF
--- a/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
+++ b/src/csharp/Microsoft.Spark/Microsoft.Spark.csproj
@@ -6,7 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-
+    <!-- Disable warning NU5104
+      NU5104: A stable release of a package should not have a prerelease dependency.
+      This warning is disabled because we have a dependency on a prerelease version of MessagePack.
+      -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <Description>.NET for Apache Spark</Description>
     <PackageReleaseNotes>https://github.com/dotnet/spark/tree/master/docs/release-notes</PackageReleaseNotes>
     <PackageTags>spark;dotnet;csharp</PackageTags>


### PR DESCRIPTION
We use prelease version 3.0.214-rc.1 for MessagePack and it block the Microsoft.Spark to use release version, disable the warning to release Microsoft.Spark.