### PR TITLE
Add worker reuse support via SPARK_REUSE_WORKER environment variable

### DIFF
--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/SimpleWorkerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/SimpleWorkerTests.cs
@@ -38,5 +38,34 @@ namespace Microsoft.Spark.Worker.UnitTest
 
             Assert.True(clientTask.Wait(5000));
         }
+
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("1", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("true", false)]
+        public void TestSparkReuseWorkerEnvironmentVariable(string envValue, bool expectedReuseWorker)
+        {
+            // Arrange
+            string originalValue = Environment.GetEnvironmentVariable("SPARK_REUSE_WORKER");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("SPARK_REUSE_WORKER", envValue);
+
+                // Act
+                bool reuseWorker = "1".Equals(
+                    Environment.GetEnvironmentVariable("SPARK_REUSE_WORKER"));
+
+                // Assert
+                Assert.Equal(expectedReuseWorker, reuseWorker);
+            }
+            finally
+            {
+                // Cleanup - restore original value
+                Environment.SetEnvironmentVariable("SPARK_REUSE_WORKER", originalValue);
+            }
+        }
     }
 }

--- a/src/csharp/Microsoft.Spark.Worker/SimpleWorker.cs
+++ b/src/csharp/Microsoft.Spark.Worker/SimpleWorker.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Spark.Worker
         {
             try
             {
+                bool reuseWorker =
+                    "1".Equals(Environment.GetEnvironmentVariable("SPARK_REUSE_WORKER"));
+
                 string secret = Utils.SettingUtils.GetWorkerFactorySecret();
 
                 s_logger.LogInfo($"RunSimpleWorker() is starting with port = {port}.");
@@ -47,7 +50,7 @@ namespace Microsoft.Spark.Worker
                     socket.OutputStream.Flush();
                 }
 
-                new TaskRunner(0, socket, false, _version).Run();
+                new TaskRunner(0, socket, reuseWorker, _version).Run();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
When SPARK_REUSE_WORKER=1, the worker will be reused between tasks.
