### PR TITLE
Fix VersionPrefix for 2.3.1 rc1 E2E test JAR resolution 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>2.3.1</VersionPrefix>
-    <VersionSuffix>rc1</VersionSuffix>
+    <VersionPrefix>2.3.1-rc1</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Fix E2E test pipeline failure caused by version mismatch between .NET AssemblyInformationalVersion and Maven JAR filename
- Put full version `2.3.1-rc1` into `VersionPrefix` instead of splitting into `VersionPrefix=2.3.1` + `VersionSuffix=rc1`

## Root Cause
The split `VersionPrefix`/`VersionSuffix` format caused the Arcade SDK to produce an `AssemblyInformationalVersion` of `2.3.1` (without `-rc1`), so the E2E test `SparkFixture` looked for `microsoft-spark-*-2.3.1.jar` instead of `microsoft-spark-*-2.3.1-rc1.jar`.

This only affects the E2E test pipeline — released NuGet packages and worker ZIPs are not impacted.

## Test plan
- [ ] Verify `spark.net` PR pipeline E2E tests pass