### PR TITLE
Migrate pipeline templates from 1ES PT to WebXT PT

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -103,13 +103,13 @@ resources:
     name: dotnet/spark
     ref: refs/tags/v$(forwardCompatibleRelease)
   
-  - repository: 1ESPipelineTemplates
+  - repository: "WebXT.Pipeline.Templates"
     type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    name: Engineering Fundamentals/WebXT.Pipeline.Templates
+    ref: refs/heads/main
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/WebXT.Official.EntryPoint.yml@WebXT.Pipeline.Templates
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -28,13 +28,13 @@ resources:
     name: dotnet/spark
     ref: refs/tags/v$(forwardCompatibleRelease)
   
-  - repository: 1ESPipelineTemplates
+  - repository: "WebXT.Pipeline.Templates"
     type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    name: Engineering Fundamentals/WebXT.Pipeline.Templates
+    ref: refs/heads/main
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/WebXT.Official.EntryPoint.yml@WebXT.Pipeline.Templates
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true


### PR DESCRIPTION
Update azure-pipelines-pr.yml and azure-pipelines-release.yml to use WebXT Pipeline Templates instead of 1ES Pipeline Templates, per compliance requirements (ADO PR #6435065).

Changes:
- Repository: 1ESPipelineTemplates → WebXT.Pipeline.Templates
- Template: v1/1ES.Official.PipelineTemplate.yml → v1/WebXT.Official.EntryPoint.yml
- Ref: refs/tags/release → refs/heads/main

We are excited to review your PR.

So we can do the best job, please check:

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

