### PR TITLE
Route PR package resolution through ManagedOSS feed

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -8,6 +8,12 @@ parameters:
 - name: forwardCompatibleRelease
   type: string
   default: ''
+- name: managedOSSMavenFeed
+  type: string
+  default: ''
+- name: managedOSSMavenFeedUrl
+  type: string
+  default: ''
 
 
 stages:
@@ -105,6 +111,31 @@ stages:
 
         - checkout: self
           path: s$(PATH_SEPARATOR)dotnet-spark
+
+        - ${{ if or(and(eq(parameters.managedOSSMavenFeed, ''), ne(parameters.managedOSSMavenFeedUrl, '')), and(ne(parameters.managedOSSMavenFeed, ''), eq(parameters.managedOSSMavenFeedUrl, ''))) }}:
+          - pwsh: throw 'ManagedOSS Maven feed name and URL must be configured together.'
+            displayName: '[ENV] Reject partial package source configuration'
+
+        - ${{ if and(ne(parameters.managedOSSMavenFeed, ''), ne(parameters.managedOSSMavenFeedUrl, '')) }}:
+          - task: MavenAuthenticate@0
+            displayName: '[ENV] Maven Authenticate'
+            inputs:
+              artifactsFeeds: ${{ parameters.managedOSSMavenFeed }}
+
+          - pwsh: |
+              $ivySettingsPath = Join-Path "$(Agent.TempDirectory)" 'managedoss-ivysettings.xml'
+              ./eng/Configure-PackageSources.ps1 `
+                -FeedName "${{ parameters.managedOSSMavenFeed }}" `
+                -FeedUrl "${{ parameters.managedOSSMavenFeedUrl }}" `
+                -IvySettingsPath $ivySettingsPath
+
+              $ivySettings = (Resolve-Path -LiteralPath $ivySettingsPath).Path
+              if ([version]"${{ test.version }}" -ge [version]'3.2.0') {
+                $ivySettings = [Uri]::new($ivySettings).AbsoluteUri
+              }
+              Write-Host "##vso[task.setvariable variable=SPARK_IVY_SETTINGS]$ivySettings"
+            displayName: '[ENV] Configure Maven and Ivy mirrors'
+            workingDirectory: $(Build.SourcesDirectory)$(PATH_SEPARATOR)dotnet-spark
 
         - task: CopyFiles@2
           displayName: Copy jars
@@ -221,6 +252,9 @@ stages:
             HADOOP_HOME: $(Build.BinariesDirectory)$(PATH_SEPARATOR)hadoop
             SPARK_HOME: $(Build.BinariesDirectory)$(PATH_SEPARATOR)spark-${{ test.version }}-bin-hadoop
             DOTNET_WORKER_DIR: $(CURRENT_DOTNET_WORKER_DIR)
+            ${{ if and(ne(parameters.managedOSSMavenFeed, ''), ne(parameters.managedOSSMavenFeedUrl, '')) }}:
+              DOTNET_SPARKFIXTURE_IVY_SETTINGS: $(SPARK_IVY_SETTINGS)
+              DOTNET_SPARKFIXTURE_REPOSITORIES: ${{ parameters.managedOSSMavenFeedUrl }}
 
         - pwsh: |
             echo "Downloading ${env:BACKWARD_COMPATIBLE_WORKER_URL}"
@@ -246,9 +280,13 @@ stages:
             HADOOP_HOME: $(Build.BinariesDirectory)$(PATH_SEPARATOR)hadoop
             SPARK_HOME: $(Build.BinariesDirectory)$(PATH_SEPARATOR)spark-${{ test.version }}-bin-hadoop
             DOTNET_WORKER_DIR: $(BACKWARD_COMPATIBLE_DOTNET_WORKER_DIR)
+            ${{ if and(ne(parameters.managedOSSMavenFeed, ''), ne(parameters.managedOSSMavenFeedUrl, '')) }}:
+              DOTNET_SPARKFIXTURE_IVY_SETTINGS: $(SPARK_IVY_SETTINGS)
+              DOTNET_SPARKFIXTURE_REPOSITORIES: ${{ parameters.managedOSSMavenFeedUrl }}
 
         - checkout: forwardCompatibleRelease
           path: s$(PATH_SEPARATOR)dotnet-spark-${{ parameters.forwardCompatibleRelease }}
+          condition: ${{ test.enableForwardCompatibleTests }}
 
         - task: Maven@3
           displayName: 'Maven build src for forward compatible release v${{ parameters.forwardCompatibleRelease }}'

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -12,6 +12,8 @@ variables:
   _TeamName: DotNetSpark
   MSBUILDSINGLELOADCONTEXT: 1
   ArtifactPath: '$(Build.ArtifactStagingDirectory)\Microsoft.Spark.Binaries'
+  managedOSSMavenFeed: ManagedOSS_PublicPackages
+  managedOSSMavenFeedUrl: https://pkgs.dev.azure.com/msasg/ManagedOSS/_packaging/ManagedOSS_PublicPackages/maven/v1
 
   backwardCompatibleRelease: '2.0.0'
   forwardCompatibleRelease: '2.0.0'
@@ -152,7 +154,13 @@ extends:
         - task: MavenAuthenticate@0
           displayName: '[ENV] Maven Authenticate'
           inputs:
-            artifactsFeeds: central
+            artifactsFeeds: $(managedOSSMavenFeed)
+
+        - pwsh: |
+            ./eng/Configure-PackageSources.ps1 `
+              -FeedName "$(managedOSSMavenFeed)" `
+              -FeedUrl "$(managedOSSMavenFeedUrl)"
+          displayName: '[ENV] Configure Maven mirror'
 
         - task: Maven@3
           displayName: 'Maven build src'
@@ -191,6 +199,8 @@ extends:
       parameters:
         backwardCompatibleRelease: $(backwardCompatibleRelease)
         forwardCompatibleRelease: $(forwardCompatibleRelease)
+        managedOSSMavenFeed: $(managedOSSMavenFeed)
+        managedOSSMavenFeedUrl: $(managedOSSMavenFeedUrl)
         tests:
         - ${{ each version in parameters.listOfE2ETestsSparkVersions }} :
           - version: ${{ version }}

--- a/eng/Configure-PackageSources.ps1
+++ b/eng/Configure-PackageSources.ps1
@@ -1,0 +1,173 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FeedName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNull()]
+    [uri]$FeedUrl,
+
+    [ValidateNotNullOrEmpty()]
+    [string]$MavenSettingsPath = (Join-Path `
+        ([Environment]::GetFolderPath('UserProfile')) '.m2/settings.xml'),
+
+    [string]$IvySettingsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($FeedUrl.Scheme -ne [Uri]::UriSchemeHttps)
+{
+    throw "Package feed must use HTTPS: '$FeedUrl'."
+}
+
+if (-not (Test-Path -LiteralPath $MavenSettingsPath -PathType Leaf))
+{
+    throw "Maven settings file '$MavenSettingsPath' does not exist. Run MavenAuthenticate first."
+}
+
+[xml]$mavenSettings = Get-Content -Raw -LiteralPath $MavenSettingsPath
+$settingsRoot = $mavenSettings.DocumentElement
+if (($null -eq $settingsRoot) -or ($settingsRoot.LocalName -ne 'settings'))
+{
+    throw "Maven settings file '$MavenSettingsPath' has an invalid root element."
+}
+
+$servers = $settingsRoot.SelectSingleNode("*[local-name()='servers']")
+if ($null -eq $servers)
+{
+    throw "MavenAuthenticate did not add a servers element to '$MavenSettingsPath'."
+}
+
+$server = $servers.ChildNodes |
+    Where-Object {
+        $id = $_.SelectSingleNode("*[local-name()='id']")
+        ($_.LocalName -eq 'server') -and
+        ($null -ne $id) -and
+        ($id.InnerText -eq $FeedName)
+    } |
+    Select-Object -First 1
+
+if ($null -eq $server)
+{
+    throw "MavenAuthenticate did not add credentials for feed '$FeedName'."
+}
+
+$usernameElement = $server.SelectSingleNode("*[local-name()='username']")
+$passwordElement = $server.SelectSingleNode("*[local-name()='password']")
+if (($null -eq $usernameElement) -or ($null -eq $passwordElement))
+{
+    throw "Maven credentials for feed '$FeedName' are incomplete."
+}
+
+$username = $usernameElement.InnerText
+$password = $passwordElement.InnerText
+if ([string]::IsNullOrWhiteSpace($username) -or [string]::IsNullOrWhiteSpace($password))
+{
+    throw "Maven credentials for feed '$FeedName' are incomplete."
+}
+
+$namespace = $settingsRoot.NamespaceURI
+$mirrors = $settingsRoot.SelectSingleNode("*[local-name()='mirrors']")
+if ($null -eq $mirrors)
+{
+    $mirrors = $mavenSettings.CreateElement('mirrors', $namespace)
+    $settingsRoot.InsertAfter($mirrors, $servers) | Out-Null
+}
+else
+{
+    $mirrors.RemoveAll()
+}
+
+$mirror = $mavenSettings.CreateElement('mirror', $namespace)
+foreach ($property in ([ordered]@{
+    id = $FeedName
+    name = 'ManagedOSS authenticated Maven mirror'
+    url = $FeedUrl.AbsoluteUri.TrimEnd('/')
+    mirrorOf = '*'
+}).GetEnumerator())
+{
+    $element = $mavenSettings.CreateElement($property.Key, $namespace)
+    $element.InnerText = $property.Value
+    $mirror.AppendChild($element) | Out-Null
+}
+$mirrors.AppendChild($mirror) | Out-Null
+$mavenSettings.Save($MavenSettingsPath)
+
+if ([string]::IsNullOrWhiteSpace($IvySettingsPath))
+{
+    Write-Host "Configured Maven to use authenticated feed '$FeedName'."
+    return
+}
+
+$ivyDirectory = Split-Path -Parent $IvySettingsPath
+if (-not (Test-Path -LiteralPath $ivyDirectory -PathType Container))
+{
+    throw "Ivy settings directory '$ivyDirectory' does not exist."
+}
+
+$ivySettings = [Xml.XmlDocument]::new()
+$ivyRoot = $ivySettings.CreateElement('ivysettings')
+$ivySettings.AppendChild($ivyRoot) | Out-Null
+
+$realmResponse = Invoke-WebRequest `
+    -Uri $FeedUrl.AbsoluteUri `
+    -Method Head `
+    -SkipHttpErrorCheck
+$credentialRealm = $null
+foreach ($challenge in @($realmResponse.Headers['WWW-Authenticate']))
+{
+    $realmMatch = [regex]::Match(
+        [string]$challenge,
+        'Basic\s+realm="(?<realm>[^"]+)"',
+        [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($realmMatch.Success)
+    {
+        $credentialRealm = $realmMatch.Groups['realm'].Value
+        break
+    }
+}
+if ([string]::IsNullOrWhiteSpace($credentialRealm))
+{
+    throw "Package feed '$FeedUrl' did not advertise a Basic authentication realm."
+}
+
+$defaultSettings = $ivySettings.CreateElement('settings')
+$defaultSettings.SetAttribute('defaultResolver', $FeedName)
+$ivyRoot.AppendChild($defaultSettings) | Out-Null
+
+$credentials = $ivySettings.CreateElement('credentials')
+$credentials.SetAttribute('realm', $credentialRealm)
+$credentials.SetAttribute('host', $FeedUrl.Host)
+$credentials.SetAttribute('username', $username)
+$credentials.SetAttribute('passwd', $password)
+$ivyRoot.AppendChild($credentials) | Out-Null
+
+$resolvers = $ivySettings.CreateElement('resolvers')
+$resolver = $ivySettings.CreateElement('ibiblio')
+$resolver.SetAttribute('name', $FeedName)
+$resolver.SetAttribute('root', $FeedUrl.AbsoluteUri.TrimEnd('/'))
+$resolver.SetAttribute('m2compatible', 'true')
+$resolver.SetAttribute('usepoms', 'true')
+$resolvers.AppendChild($resolver) | Out-Null
+$ivyRoot.AppendChild($resolvers) | Out-Null
+$ivySettings.Save($IvySettingsPath)
+
+if (-not $IsWindows)
+{
+    chmod 600 $IvySettingsPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Unable to restrict permissions on '$IvySettingsPath'."
+    }
+}
+
+Write-Host "Configured Maven and Ivy to use authenticated feed '$FeedName'."

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixture.cs
@@ -33,6 +33,16 @@ namespace Microsoft.Spark.E2ETest
                 "DOTNET_SPARKFIXTURE_EXTRA_SPARK_SUBMIT_ARGS";
 
             /// <summary>
+            /// This environment variable specifies a custom Ivy settings file for packages.
+            /// </summary>
+            public const string IvySettings = "DOTNET_SPARKFIXTURE_IVY_SETTINGS";
+
+            /// <summary>
+            /// This environment variable overrides repositories passed to spark-submit.
+            /// </summary>
+            public const string Repositories = "DOTNET_SPARKFIXTURE_REPOSITORIES";
+
+            /// <summary>
             /// This environment variable specifies the path where the DotNet worker is installed.
             /// </summary>
             public const string WorkerDir = Services.ConfigurationService.DefaultWorkerDirEnvVarName;
@@ -40,6 +50,8 @@ namespace Microsoft.Spark.E2ETest
 
         private readonly Process _process = new Process();
         private readonly TemporaryDirectory _tempDirectory = new TemporaryDirectory();
+
+        private const string DefaultRepository = "https://repos.spark-packages.org/";
         
         public const string DefaultLogLevel = "ERROR";
 
@@ -144,6 +156,28 @@ namespace Microsoft.Spark.E2ETest
             return $"org.apache.spark:{avroVersion}";
         }
 
+        internal static string GetPackageResolutionOptions(
+            string ivySettings,
+            string repositories)
+        {
+            bool hasIvySettings = !string.IsNullOrWhiteSpace(ivySettings);
+            bool hasRepositories = !string.IsNullOrWhiteSpace(repositories);
+
+            if (hasIvySettings != hasRepositories)
+            {
+                throw new InvalidOperationException(
+                    $"Environment variables '{EnvironmentVariableNames.IvySettings}' and " +
+                    $"'{EnvironmentVariableNames.Repositories}' must be configured together.");
+            }
+
+            if (!hasIvySettings)
+            {
+                return $"--repositories {DefaultRepository}";
+            }
+
+            return $"--conf spark.jars.ivySettings={ivySettings} --repositories {repositories}";
+        }
+
         public void Dispose()
         {
             Spark.Dispose();
@@ -203,10 +237,12 @@ namespace Microsoft.Spark.E2ETest
             string warehouseDir = $"--conf spark.sql.warehouse.dir={warehouseUri}";
 
             // Spark24 < 2.4.8, Spark30 < 3.0.3 and Spark31 < 3.1.2 use bintray as the repository
-            // service for spark-packages. As of  May 1st, 2021 bintray has been sunset and is no
-            // longer available. Specify additional remote repositories to search for the maven
-            // coordinates given with --packages.
-            string repositories = "--repositories https://repos.spark-packages.org/";
+            // service for spark-packages. As of May 1st, 2021 bintray has been sunset and is no
+            // longer available. Community builds keep using spark-packages by default, while CI
+            // can atomically supply a custom Ivy settings file and repository.
+            string packageResolutionOptions = GetPackageResolutionOptions(
+                Environment.GetEnvironmentVariable(EnvironmentVariableNames.IvySettings),
+                Environment.GetEnvironmentVariable(EnvironmentVariableNames.Repositories));
 
             string extraArgs = Environment.GetEnvironmentVariable(
                 EnvironmentVariableNames.ExtraSparkSubmitArgs) ?? "";
@@ -221,7 +257,8 @@ namespace Microsoft.Spark.E2ETest
             string logOption = "--conf spark.driver.extraJavaOptions=-Dlog4j.configuration=" +
                 $"{resourceUri}/log4j.properties";
 
-            args = $"{logOption} {warehouseDir} {AddPackages(extraArgs)} {repositories} {classArg} " +
+            args = $"{logOption} {warehouseDir} {AddPackages(extraArgs)} " +
+                $"{packageResolutionOptions} {classArg} " +
                 $"--master local {jar} debug";
         }
 

--- a/src/csharp/Microsoft.Spark.E2ETest/SparkFixtureConfigurationTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/SparkFixtureConfigurationTests.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Spark.E2ETest
+{
+    public class SparkFixtureConfigurationTests
+    {
+        [Fact]
+        public void GetPackageResolutionOptionsUsesCommunityDefault()
+        {
+            Assert.Equal(
+                "--repositories https://repos.spark-packages.org/",
+                SparkFixture.GetPackageResolutionOptions(null, null));
+        }
+
+        [Theory]
+        [InlineData(
+            "file:///tmp/ivysettings.xml",
+            "--conf spark.jars.ivySettings=file:///tmp/ivysettings.xml " +
+                "--repositories https://pkgs.dev.azure.com/example/maven/v1")]
+        [InlineData(
+            @"D:\a\_temp\ivysettings.xml",
+            @"--conf spark.jars.ivySettings=D:\a\_temp\ivysettings.xml " +
+                "--repositories https://pkgs.dev.azure.com/example/maven/v1")]
+        public void GetPackageResolutionOptionsUsesCustomIvySettingsAndRepository(
+            string ivySettings,
+            string expected)
+        {
+            Assert.Equal(
+                expected,
+                SparkFixture.GetPackageResolutionOptions(
+                    ivySettings,
+                    "https://pkgs.dev.azure.com/example/maven/v1"));
+        }
+
+        [Theory]
+        [InlineData("file:///tmp/ivysettings.xml", null)]
+        [InlineData(null, "https://pkgs.dev.azure.com/example/maven/v1")]
+        public void GetPackageResolutionOptionsRejectsPartialConfiguration(
+            string ivySettings,
+            string repositories)
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => SparkFixture.GetPackageResolutionOptions(ivySettings, repositories));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- configure the PR pipeline to mirror Maven dependency and plugin resolution through the authenticated ManagedOSS feed
- generate authenticated Ivy settings for Spark package resolution, including compatibility for Spark 2.4 through 3.5
- keep the shared E2E template opt-in so community and local builds retain their existing package sources
- fail closed when only part of the CI package-source configuration is supplied

## Validation

- `dotnet test src/csharp/Microsoft.Spark.E2ETest/Microsoft.Spark.E2ETest.csproj --configuration Debug --filter FullyQualifiedName~SparkFixtureConfigurationTests --no-restore -p:Sign=false` (5/5 passed)
- Release configuration tests with local signing disabled (5/5 passed)
- PowerShell parser validation for `eng/Configure-PackageSources.ps1`
- YAML parsing for both modified pipeline files
- `git diff --check`
- Ivy 2.4.0 and 2.5.1 authenticated resolver smoke tests against the ManagedOSS feed

## Remaining validation

A PR pipeline run is required to confirm the network-isolation telemetry no longer reports Maven Central or Spark/Ivy public repository traffic.