### PR TITLE
Remove obsolete DotNet-VSTS-Bot reference

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -36,7 +36,6 @@ jobs:
   displayName: Run SDL tool
   condition: and(succeededOrFailed(), eq( ${{ parameters.enable }}, 'true'))
   variables:
-    - group: DotNet-VSTS-Bot
     - name: AzDOProjectName
       value: ${{ parameters.AzDOProjectName }}
     - name: AzDOPipelineId


### PR DESCRIPTION
Remove Spark's stale Arcade copy of the DotNet-VSTS-Bot variable-group declaration. The group contains only the expired dn-bot-dotnet-build-rw-code-rw PAT and must be deleted before the Key Vault secret can be removed.

The V1 SDL template no longer carries this declaration in Arcade; this synchronizes that specific cleanup without requiring a broad Arcade upgrade.

Tracking: AB#11023