### PR TITLE
Fix grouped DataFrame string output and Arrow exception framing

### DIFF
--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -415,6 +415,213 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             }
         }
 
+        [Theory]
+        [InlineData(10)]
+        [InlineData(150)]
+        public void TestGroupByApplyStringDataFrameColumn(int minimumProductId)
+        {
+            DataFrame input = _spark.CreateDataFrame(
+                new[]
+                {
+                    new GenericRow(new object[] { 10, 2, 5.0, "this is description one" }),
+                    new GenericRow(new object[] { 150, 10, 1.0, "this is description two" }),
+                    new GenericRow(new object[] { 150, 3, 1.0, "this is description three" })
+                },
+                new StructType(new[]
+                {
+                    new StructField("ProductId", new IntegerType()),
+                    new StructField("Quantity", new IntegerType()),
+                    new StructField("Price", new DoubleType()),
+                    new StructField("Description", new StringType())
+                }));
+            var returnType = new StructType(new[]
+            {
+                new StructField("Description", new StringType())
+            });
+
+            DataFrame output = input.GroupBy("ProductId").Apply(
+                returnType,
+                (FxDataFrame group) => DescribeProducts(group, minimumProductId));
+
+            Assert.Equal(returnType, output.Schema());
+            string[] descriptions = output.Collect()
+                .Select(row => row.GetAs<string>("Description"))
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+            string[] expected = minimumProductId == 10
+                ? new[] { "this is description three150", "this is description two150" }
+                : System.Array.Empty<string>();
+            Assert.Equal(expected, descriptions);
+        }
+
+        [Fact]
+        public void TestGroupByApplyStringDataFrameColumnMixedTypes()
+        {
+            var returnType = new StructType(new[]
+            {
+                new StructField("RowId", new IntegerType()),
+                new StructField("Description", new StringType()),
+                new StructField("ArrowDescription", new StringType()),
+                new StructField("Flag", new BooleanType()),
+                new StructField("Int8", new ByteType()),
+                new StructField("Int16", new ShortType()),
+                new StructField("Int32", new IntegerType()),
+                new StructField("Int64", new LongType()),
+                new StructField("Float32", new FloatType()),
+                new StructField("Float64", new DoubleType())
+            });
+            DataFrame output = _spark.Range(1).GroupBy("id").Apply(
+                returnType,
+                (FxDataFrame group) => CreateMixedStringResult());
+
+            Assert.Equal(returnType, output.Schema());
+            Row[] rows = output.Collect().OrderBy(row => row.GetAs<int>("RowId")).ToArray();
+            Assert.Equal(9, rows.Length);
+            string[] expectedStrings = { "alpha", "", null, "中文", "🙂", "five", "six", "seven", "last" };
+            string[] expectedArrowStrings = { "一", null, "", "🚀", "four", "five", "six", "seven", "九" };
+            bool?[] expectedFlags = { true, true, null, true, false, false, true, false, true };
+            for (int i = 0; i < rows.Length; ++i)
+            {
+                Row row = rows[i];
+                Assert.Equal(i, row.GetAs<int>("RowId"));
+                Assert.Equal(expectedStrings[i], row.GetAs<string>("Description"));
+                Assert.Equal(expectedArrowStrings[i], row.GetAs<string>("ArrowDescription"));
+                Assert.Equal(expectedFlags[i], row.GetAs<bool?>("Flag"));
+                if (i == 2)
+                {
+                    foreach (string name in new[] { "Int8", "Int16", "Int32", "Int64", "Float32", "Float64" })
+                    {
+                        Assert.Null(row.Get(name));
+                    }
+                }
+                else
+                {
+                    Assert.Equal((sbyte)(i - 4), row.GetAs<sbyte>("Int8"));
+                    Assert.Equal((short)(i - 1000), row.GetAs<short>("Int16"));
+                    Assert.Equal(i - 100000, row.GetAs<int>("Int32"));
+                    Assert.Equal(5000000000L + i, row.GetAs<long>("Int64"));
+                    Assert.Equal(i + 0.25f, row.GetAs<float>("Float32"));
+                    Assert.Equal(i - 0.5, row.GetAs<double>("Float64"));
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGroupByApplyStringDataFrameColumnNullAndEmpty()
+        {
+            var returnType = new StructType(new[]
+            {
+                new StructField("Description", new StringType()),
+                new StructField("ArrowDescription", new StringType())
+            });
+            DataFrame output = _spark.Range(1).GroupBy("id").Apply(
+                returnType,
+                (FxDataFrame group) => new FxDataFrame(
+                    new StringDataFrameColumn("Description", new string[] { null, "" }),
+                    CreateArrowStringColumn("ArrowDescription", new string[] { "", null })));
+
+            Assert.Equal(returnType, output.Schema());
+            Row[] rows = output.Collect().ToArray();
+            Assert.Equal(2, rows.Length);
+            Assert.Equal("", rows.Single(row => row.Get("Description") == null)
+                .GetAs<string>("ArrowDescription"));
+            Assert.Null(rows.Single(row => row.GetAs<string>("Description") == "")
+                .Get("ArrowDescription"));
+        }
+
+        [Fact]
+        public void TestArrowOutputExceptionPreservesGroupedUdfError()
+        {
+            var returnType = new StructType(new[]
+            {
+                new StructField("Description", new StringType())
+            });
+            DataFrame output = _spark.Range(1).GroupBy("id").Apply(
+                returnType,
+                (FxDataFrame group) => ThrowGroupedUdfError(group));
+
+            Exception error = Assert.ThrowsAny<Exception>(() => output.Collect().ToArray());
+            Assert.Contains("System.InvalidOperationException", error.ToString());
+            Assert.Contains("issue1231-original-grouped-udf-error", error.ToString());
+            Assert.DoesNotContain("java.nio.ByteBuffer.allocate", error.ToString());
+        }
+
+        private static FxDataFrame DescribeProducts(FxDataFrame group, int minimumProductId)
+        {
+            var descriptions = new StringDataFrameColumn("Description");
+            var productIds = (Int32DataFrameColumn)group.Columns["ProductId"];
+            var sourceDescriptions = (ArrowStringDataFrameColumn)group.Columns["Description"];
+            for (long i = 0; i < group.Rows.Count; ++i)
+            {
+                if (productIds[i] > minimumProductId)
+                {
+                    descriptions.Append(sourceDescriptions[i] + productIds[i]);
+                }
+            }
+
+            return new FxDataFrame(descriptions);
+        }
+
+        private static FxDataFrame CreateMixedStringResult()
+        {
+            return new FxDataFrame(
+                new Int32DataFrameColumn("RowId", new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }),
+                new StringDataFrameColumn("Description", new[]
+                {
+                    "alpha", "", null, "中文", "🙂", "five", "six", "seven", "last"
+                }),
+                CreateArrowStringColumn("ArrowDescription", new[]
+                {
+                    "一", null, "", "🚀", "four", "five", "six", "seven", "九"
+                }),
+                new BooleanDataFrameColumn("Flag", new bool?[]
+                {
+                    true, true, null, true, false, false, true, false, true
+                }),
+                new SByteDataFrameColumn("Int8", new sbyte?[]
+                {
+                    -4, -3, null, -1, 0, 1, 2, 3, 4
+                }),
+                new Int16DataFrameColumn("Int16", new short?[]
+                {
+                    -1000, -999, null, -997, -996, -995, -994, -993, -992
+                }),
+                new Int32DataFrameColumn("Int32", new int?[]
+                {
+                    -100000, -99999, null, -99997, -99996, -99995, -99994, -99993, -99992
+                }),
+                new Int64DataFrameColumn("Int64", new long?[]
+                {
+                    5000000000L, 5000000001L, null, 5000000003L, 5000000004L,
+                    5000000005L, 5000000006L, 5000000007L, 5000000008L
+                }),
+                new SingleDataFrameColumn("Float32", new float?[]
+                {
+                    0.25f, 1.25f, null, 3.25f, 4.25f, 5.25f, 6.25f, 7.25f, 8.25f
+                }),
+                new DoubleDataFrameColumn("Float64", new double?[]
+                {
+                    -0.5, 0.5, null, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5
+                }));
+        }
+
+        private static FxDataFrame ThrowGroupedUdfError(FxDataFrame group)
+        {
+            throw new InvalidOperationException("issue1231-original-grouped-udf-error");
+        }
+
+        private static ArrowStringDataFrameColumn CreateArrowStringColumn(string name, string[] values)
+        {
+            using StringArray array = new StringArray.Builder().AppendRange(values).Build();
+            return new ArrowStringDataFrameColumn(
+                name,
+                array.ValueBuffer.Memory.ToArray(),
+                array.ValueOffsetsBuffer.Memory.ToArray(),
+                array.NullBitmapBuffer.Memory.ToArray(),
+                array.Length,
+                array.NullCount);
+        }
+
         private static FxDataFrame CountCharacters(FxDataFrame dataFrame)
         {
             int characterCount = 0;

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowLoggingFailureTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowLoggingFailureTests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using Microsoft.Spark.Interop.Ipc;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    [CollectionDefinition("Arrow logging failures", DisableParallelization = true)]
+    public sealed class ArrowLoggingFailureCollection
+    {
+    }
+
+    [Collection("Arrow logging failures")]
+    public class ArrowLoggingFailureTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DiagnosticFailureDoesNotReplaceTaskFailure(bool failDuringReport)
+        {
+            var primary = new InvalidOperationException("original-task-read-failure");
+            using var input = new FailingInput(primary);
+            using var output = new ReportingOutput(failDuringReport);
+            var runner = new TaskRunner(1231, null, false, new Version(3, 3, 4));
+            MethodInfo process = typeof(TaskRunner).GetMethod(
+                "ProcessStream", BindingFlags.Instance | BindingFlags.NonPublic);
+            TextWriter original = Console.Out;
+            var brokenLogger = new FailingLogWriter(original, failDuringReport);
+            TargetInvocationException observed;
+            try
+            {
+                Console.SetOut(brokenLogger);
+                observed = Assert.Throws<TargetInvocationException>(() => process.Invoke(
+                    runner, new object[] { input, output, new Version(3, 3, 4), false }));
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            Assert.Equal(1, brokenLogger.Failures);
+            Assert.Same(primary, observed.InnerException);
+            if (failDuringReport)
+            {
+                Assert.Equal(2, output.Length);
+                Assert.Equal(1, output.WriteCalls);
+                Assert.Equal(0, output.FlushCalls);
+            }
+            else
+            {
+                output.Position = 0;
+                Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+                Assert.Contains(primary.Message, SerDe.ReadString(output));
+                Assert.Equal(output.Length, output.Position);
+                Assert.Equal(1, output.FlushCalls);
+            }
+        }
+
+        private sealed class FailingInput : MemoryStream
+        {
+            private readonly Exception _failure;
+
+            internal FailingInput(Exception failure) => _failure = failure;
+
+            public override int Read(byte[] buffer, int offset, int count) => throw _failure;
+        }
+
+        private sealed class ReportingOutput : MemoryStream
+        {
+            private readonly bool _fail;
+
+            internal ReportingOutput(bool fail) => _fail = fail;
+
+            internal int WriteCalls { get; private set; }
+
+            internal int FlushCalls { get; private set; }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                ++WriteCalls;
+                if (_fail)
+                {
+                    base.Write(buffer, offset, Math.Min(2, count));
+                    throw new IOException("exception-report-write-failure");
+                }
+
+                base.Write(buffer, offset, count);
+            }
+
+            public override void Flush() => ++FlushCalls;
+        }
+
+        private sealed class FailingLogWriter : TextWriter
+        {
+            private readonly TextWriter _original;
+            private readonly string _failingMessage;
+
+            internal FailingLogWriter(TextWriter original, bool failDuringReport)
+            {
+                _original = original;
+                _failingMessage = failDuringReport ?
+                    "Writing exception to stream" : "ProcessStream() failed";
+            }
+
+            public override Encoding Encoding => Encoding.UTF8;
+
+            internal int Failures { get; private set; }
+
+            public override void WriteLine(string value)
+            {
+                if (value != null && value.Contains("[1231]") && value.Contains(_failingMessage))
+                {
+                    ++Failures;
+                    throw new IOException("logger-output-failure");
+                }
+
+                _original.WriteLine(value);
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowOutputSessionTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowOutputSessionTests.cs
@@ -1,0 +1,417 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Worker.Command;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class ArrowOutputSessionTests
+    {
+        [Theory]
+        [InlineData(true, 0)]
+        [InlineData(false, 0)]
+        [InlineData(true, 3)]
+        [InlineData(false, 3)]
+        public void PreparedBatchesRoundTripWithOneEos(bool legacy, int rowCount)
+        {
+            using RecordBatch first = CreateBatch(rowCount);
+            using RecordBatch second = CreateBatch(rowCount, 100);
+            using var output = new ArrowFaultOutputStream();
+            var context = new ArrowOutputContext();
+            var batches = new TrackingBatches(new[]
+            {
+                PreparedArrowBatch.Borrow(first),
+                PreparedArrowBatch.Borrow(second)
+            });
+
+            new ArrowOutputSession(output, Options(legacy), context).Write(batches);
+
+            Assert.Equal(ArrowOutputPhase.Ended, context.Phase);
+            Assert.True(context.CanWriteException);
+            Assert.Equal(1, batches.DisposeCount);
+            Assert.False(output.IsDisposed);
+            Assert.Equal(ReferenceOutput(legacy, first, second), output.ToArray());
+            output.Position = 0;
+            Assert.Equal((int)SpecialLengths.START_ARROW_STREAM, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            foreach (int start in new[] { 0, 100 })
+            {
+                using RecordBatch result = reader.ReadNextRecordBatch();
+                Assert.NotNull(result);
+                Assert.Equal(rowCount, result.Length);
+                Assert.Equal("value", result.Schema.GetFieldByIndex(0).Name);
+                var values = Assert.IsType<Int32Array>(result.Column(0));
+                for (int i = 0; i < rowCount; ++i)
+                {
+                    Assert.Equal(start + i, values.GetValue(i));
+                }
+            }
+
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(output.Length, output.Position);
+            Assert.All(batches.Batches, batch => Assert.Null(batch.Batch));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void FirstPreparationFailureDoesNotStartArrow(int failureSite)
+        {
+            var primary = new InvalidOperationException("first preparation failed");
+            using var output = new ArrowFaultOutputStream();
+            var context = new ArrowOutputContext();
+            var batches = new TrackingBatches(System.Array.Empty<PreparedArrowBatch>())
+            {
+                GetEnumeratorFailure = failureSite == 0 ? primary : null,
+                MoveNextFailure = failureSite == 1 ? primary : null,
+                CurrentFailure = failureSite == 2 ? primary : null,
+                FailMoveNextAt = 0,
+                PretendFirstBatch = failureSite == 2
+            };
+
+            Exception observed = Record.Exception(() =>
+                new ArrowOutputSession(output, Options(false), context).Write(batches));
+
+            Assert.Same(primary, observed);
+            Assert.Equal(0, output.Length);
+            Assert.Equal(ArrowOutputPhase.NotStarted, context.Phase);
+            Assert.True(context.CanWriteException);
+            Assert.Equal(failureSite == 0 ? 0 : 1, batches.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LaterPreparationFailureEndsArrowBeforeOuterException(bool legacy)
+        {
+            using RecordBatch source = CreateBatch(2);
+            var primary = new InvalidOperationException("later preparation failed");
+            var cleanup = new IOException("enumerator cleanup failed");
+            using var output = new ArrowFaultOutputStream();
+            var context = new ArrowOutputContext();
+            var batches = new TrackingBatches(new[] { PreparedArrowBatch.Borrow(source) })
+            {
+                MoveNextFailure = primary,
+                FailMoveNextAt = 1,
+                DisposeFailure = cleanup
+            };
+
+            Exception observed = Record.Exception(() =>
+                new ArrowOutputSession(output, Options(legacy), context).Write(batches));
+
+            Assert.Same(primary, observed);
+            Assert.Equal(ArrowOutputPhase.Ended, context.Phase);
+            Assert.True(context.CanWriteException);
+            Assert.Equal(ReferenceOutput(legacy, source), output.ToArray());
+            SerDe.Write(output, (int)SpecialLengths.PYTHON_EXCEPTION_THROWN);
+            SerDe.Write(output, observed.ToString());
+            output.Position = 0;
+            Assert.Equal((int)SpecialLengths.START_ARROW_STREAM, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch actual = reader.ReadNextRecordBatch();
+            Assert.Equal(2, actual.Length);
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+            Assert.Contains(primary.Message, SerDe.ReadString(output));
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(1, batches.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public void EveryPartialArrowWriteStopsAllSubsequentProtocolWrites(
+            bool legacy,
+            bool ioException)
+        {
+            using RecordBatch source = CreateBatch(2);
+            byte[] expected = ReferenceOutput(legacy, source);
+            for (int offset = 0; offset < expected.Length; ++offset)
+            {
+                Exception primary = ioException
+                    ? new IOException($"partial write at {offset}")
+                    : new InvalidOperationException($"partial write at {offset}");
+                using var output = new ArrowFaultOutputStream(offset, primary);
+                var context = new ArrowOutputContext();
+                var batches = new TrackingBatches(new[] { PreparedArrowBatch.Borrow(source) });
+
+                Exception observed = Record.Exception(() =>
+                    new ArrowOutputSession(output, Options(legacy), context).Write(batches));
+
+                Assert.Same(primary, observed);
+                Assert.Equal(ArrowOutputPhase.Faulted, context.Phase);
+                Assert.False(context.CanWriteException);
+                Assert.Equal(expected.Take(offset), output.ToArray());
+                Assert.Equal(0, output.ProtocolCallsAfterFailure);
+                Assert.Equal(1, batches.DisposeCount);
+                Assert.Null(batches.Batches[0].Batch);
+                Assert.False(output.IsDisposed);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FailedEosAndCleanupDoNotReplacePreparationFailure(bool legacy)
+        {
+            using RecordBatch source = CreateBatch(2);
+            byte[] healthy = ReferenceOutput(legacy, source);
+            int eosLength = legacy ? 4 : 8;
+            var primary = new InvalidOperationException("second batch preparation");
+            using var output = new ArrowFaultOutputStream(
+                healthy.Length - eosLength + 1,
+                new IOException("partial EOS"));
+            var context = new ArrowOutputContext();
+            var batches = new TrackingBatches(new[] { PreparedArrowBatch.Borrow(source) })
+            {
+                MoveNextFailure = primary,
+                FailMoveNextAt = 1,
+                DisposeFailure = new InvalidOperationException("cleanup")
+            };
+
+            Exception observed = Record.Exception(() =>
+                new ArrowOutputSession(output, Options(legacy), context).Write(batches));
+
+            Assert.Same(primary, observed);
+            Assert.Equal(ArrowOutputPhase.Faulted, context.Phase);
+            Assert.False(context.CanWriteException);
+            Assert.Equal(0, output.ProtocolCallsAfterFailure);
+            Assert.Equal(1, batches.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void BatchCleanupFailureReleasesOtherRootsAndEndsHealthyArrow(bool failWrite)
+        {
+            using RecordBatch source = CreateBatch(2);
+            IArrowArray actual = source.Column(0);
+            var cleanup = new InvalidOperationException("owned array cleanup");
+            var root = new Mock<IArrowArray>();
+            root.SetupGet(array => array.Data).Returns(actual.Data);
+            root.SetupGet(array => array.Length).Returns(actual.Length);
+            root.Setup(array => array.Accept(It.IsAny<IArrowArrayVisitor>()))
+                .Callback<IArrowArrayVisitor>(actual.Accept);
+            root.Setup(array => array.Dispose()).Throws(cleanup);
+            var otherRoot = new Mock<IArrowArray>();
+            var batch = new RecordBatch(source.Schema, new[] { root.Object }, source.Length);
+            var prepared = PreparedArrowBatch.Own(batch);
+            prepared.AddOwned(otherRoot.Object);
+            prepared.Hold(new object());
+            var writeFailure = new IOException("write failed first");
+            using var output = failWrite
+                ? new ArrowFaultOutputStream(2, writeFailure)
+                : new ArrowFaultOutputStream();
+            var context = new ArrowOutputContext();
+
+            Exception observed = Record.Exception(() =>
+                new ArrowOutputSession(output, Options(false), context).Write(new[] { prepared }));
+
+            Assert.Same(failWrite ? writeFailure : cleanup, observed);
+            root.Verify(array => array.Dispose(), Times.Once);
+            otherRoot.Verify(array => array.Dispose(), Times.Once);
+            Assert.Null(prepared.Batch);
+            Assert.Equal(0, prepared.HeldReferenceCount);
+            Assert.Equal(1, prepared.ReleaseFailedRootCount);
+            Assert.Equal(1, prepared.ReleasedRootCount);
+            Assert.Equal(0, output.ProtocolCallsAfterFailure);
+            if (!failWrite)
+            {
+                Assert.Equal(ArrowOutputPhase.Ended, context.Phase);
+                Assert.Equal(ReferenceOutput(false, source), output.ToArray());
+            }
+        }
+
+        [Fact]
+        public void CompletedOrFaultedSessionCannotRestartAndNewContextIsIndependent()
+        {
+            using RecordBatch source = CreateBatch(1);
+            using var output = new ArrowFaultOutputStream();
+            var context = new ArrowOutputContext();
+            var session = new ArrowOutputSession(output, Options(false), context);
+            session.Write(new[] { PreparedArrowBatch.Borrow(source) });
+            long completedLength = output.Length;
+            Assert.Throws<InvalidOperationException>(() =>
+                session.Write(new[] { PreparedArrowBatch.Borrow(source) }));
+            Assert.Equal(completedLength, output.Length);
+            context.BeginSuccessTail();
+            Assert.False(context.CanWriteException);
+            context.BeginSuccessTail();
+            Assert.False(context.CanWriteException);
+
+            var freshContext = new ArrowOutputContext();
+            Assert.True(freshContext.CanWriteException);
+            Assert.False(freshContext.SuccessTailStarted);
+            Assert.Equal(ArrowOutputPhase.NotStarted, freshContext.Phase);
+        }
+
+        internal static IpcOptions Options(bool legacy) =>
+            new IpcOptions { WriteLegacyIpcFormat = legacy };
+
+        internal static RecordBatch CreateBatch(int rowCount, int start = 0)
+        {
+            var schema = new Schema.Builder()
+                .Field(field => field.Name("value").DataType(Int32Type.Default))
+                .Build();
+            var builder = new Int32Array.Builder();
+            for (int i = 0; i < rowCount; ++i)
+            {
+                builder.Append(start + i);
+            }
+
+            return new RecordBatch(schema, new IArrowArray[] { builder.Build() }, rowCount);
+        }
+
+        private static byte[] ReferenceOutput(bool legacy, params RecordBatch[] batches)
+        {
+            using var expected = new MemoryStream();
+            SerDe.Write(expected, (int)SpecialLengths.START_ARROW_STREAM);
+            using var writer = new ArrowStreamWriter(
+                expected, batches[0].Schema, leaveOpen: true, Options(legacy));
+            foreach (RecordBatch batch in batches)
+            {
+                writer.WriteRecordBatch(batch);
+            }
+
+            writer.WriteEnd();
+            return expected.ToArray();
+        }
+
+        private sealed class TrackingBatches : IEnumerable<PreparedArrowBatch>,
+            IEnumerator<PreparedArrowBatch>
+        {
+            private int _index = -1;
+
+            internal TrackingBatches(PreparedArrowBatch[] batches) => Batches = batches;
+
+            internal PreparedArrowBatch[] Batches { get; }
+            internal Exception GetEnumeratorFailure { get; set; }
+            internal Exception MoveNextFailure { get; set; }
+            internal Exception CurrentFailure { get; set; }
+            internal Exception DisposeFailure { get; set; }
+            internal int FailMoveNextAt { get; set; } = -1;
+            internal bool PretendFirstBatch { get; set; }
+            internal int DisposeCount { get; private set; }
+            public PreparedArrowBatch Current => CurrentFailure != null
+                ? throw CurrentFailure
+                : Batches[_index];
+            object IEnumerator.Current => Current;
+
+            public IEnumerator<PreparedArrowBatch> GetEnumerator() =>
+                GetEnumeratorFailure != null ? throw GetEnumeratorFailure : this;
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public bool MoveNext()
+            {
+                ++_index;
+                if (_index == FailMoveNextAt && MoveNextFailure != null)
+                {
+                    throw MoveNextFailure;
+                }
+
+                return _index < Batches.Length || (PretendFirstBatch && _index == 0);
+            }
+
+            public void Reset() => throw new NotSupportedException();
+
+            public void Dispose()
+            {
+                ++DisposeCount;
+                if (DisposeFailure != null)
+                {
+                    throw DisposeFailure;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Retains exactly the byte prefix accepted before a write fails, including partial writes.
+    /// Counts every later write or flush even when the caller catches the injected exception.
+    /// </summary>
+    internal sealed class ArrowFaultOutputStream : Stream
+    {
+        private readonly MemoryStream _bytes = new MemoryStream();
+        private readonly long _failOffset;
+        private readonly Exception _writeFailure;
+
+        internal ArrowFaultOutputStream(long failOffset = long.MaxValue, Exception writeFailure = null)
+        {
+            _failOffset = failOffset;
+            _writeFailure = writeFailure;
+        }
+
+        internal Exception FlushFailure { get; set; }
+        internal int FlushCount { get; private set; }
+        internal bool HasFailed { get; private set; }
+        internal bool IsDisposed { get; private set; }
+        internal int ProtocolCallsAfterFailure { get; private set; }
+        internal byte[] ToArray() => _bytes.ToArray();
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => !IsDisposed;
+        public override long Length => _bytes.Length;
+        public override long Position { get => _bytes.Position; set => _bytes.Position = value; }
+        public override int Read(byte[] buffer, int offset, int count) => _bytes.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _bytes.Seek(offset, origin);
+        public override void SetLength(long value) => _bytes.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            Write(buffer.AsSpan(offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (HasFailed)
+            {
+                ++ProtocolCallsAfterFailure;
+                throw _writeFailure ?? FlushFailure;
+            }
+
+            int accepted = (int)Math.Min(buffer.Length, Math.Max(0, _failOffset - _bytes.Length));
+            _bytes.Write(buffer.Slice(0, accepted));
+            if (accepted != buffer.Length)
+            {
+                HasFailed = true;
+                throw _writeFailure;
+            }
+        }
+
+        public override void Flush()
+        {
+            ++FlushCount;
+            if (HasFailed)
+            {
+                ++ProtocolCallsAfterFailure;
+                throw _writeFailure ?? FlushFailure;
+            }
+
+            if (FlushFailure != null)
+            {
+                HasFailed = true;
+                throw FlushFailure;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowTaskRunnerTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowTaskRunnerTests.cs
@@ -1,0 +1,528 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Network;
+using Microsoft.Spark.Utils;
+using Microsoft.Spark.Worker.Command;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class ArrowTaskRunnerTests
+    {
+        private const string UdfFailureMessage = "Arrow test UDF preparation failed";
+
+        public static IEnumerable<object[]> ArrowPaths()
+        {
+            foreach (string path in new[]
+            {
+                "ArrowScalar", "DataFrameScalar", "ArrowGrouped", "DataFrameGrouped"
+            })
+            {
+                yield return new object[] { path, true };
+                yield return new object[] { path, false };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrowPaths))]
+        public void FirstUdfFailureWritesOuterExceptionWithoutStartingArrow(string path, bool legacy)
+        {
+            using var input = CreateTaskInput(path, legacy, -1);
+            using var output = new ArrowFaultOutputStream();
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(legacy)).Run();
+
+            output.Position = 0;
+            Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+            Assert.Contains(UdfFailureMessage, SerDe.ReadString(output));
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(1, output.FlushCount);
+            Assert.Equal(1, socket.DisposeCount);
+            Assert.True(input.Position < input.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrowPaths))]
+        public void LaterUdfFailureHasReadableArrowEosThenOriginalException(string path, bool legacy)
+        {
+            using var input = CreateTaskInput(path, legacy, 7, -1);
+            using var output = new ArrowFaultOutputStream();
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(legacy)).Run();
+
+            output.Position = 0;
+            AssertArrowBatchAndEnd(output, 7, path.EndsWith("Grouped") && !legacy);
+            Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+            Assert.Contains(UdfFailureMessage, SerDe.ReadString(output));
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(1, output.FlushCount);
+            Assert.Equal(1, socket.DisposeCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrowPaths))]
+        public void SuccessfulPathReturnsReadableDataAndCompleteTaskTrailer(string path, bool legacy)
+        {
+            using var input = CreateTaskInput(path, legacy, 7);
+            using var output = new ArrowFaultOutputStream();
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(legacy)).Run();
+
+            output.Position = 0;
+            AssertArrowBatchAndEnd(output, 7, path.EndsWith("Grouped") && !legacy);
+            AssertSuccessTrailer(output);
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(1, socket.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public void PartialArrowWriteNeverAppendsExceptionOrSuccessfulTrailer(
+            bool legacy,
+            bool ioException)
+        {
+            byte[] inputBytes;
+            byte[] healthy;
+            long arrowEnd;
+            using (var input = CreateTaskInput("ArrowScalar", legacy, 7))
+            using (var output = new ArrowFaultOutputStream())
+            {
+                inputBytes = input.ToArray();
+                new TaskRunner(0, new TestSocket(input, output), true, Version(legacy)).Run();
+                healthy = output.ToArray();
+                output.Position = 0;
+                AssertArrowBatchAndEnd(output, 7, false);
+                arrowEnd = output.Position;
+            }
+
+            // Every byte offset covers START, both IPC length encodings, schema, batch and EOS.
+            for (int offset = 0; offset < arrowEnd; ++offset)
+            {
+                Exception primary = ioException
+                    ? new IOException($"partial Arrow write at {offset}")
+                    : new InvalidOperationException($"partial Arrow write at {offset}");
+                using var input = new MemoryStream(inputBytes);
+                using var output = new ArrowFaultOutputStream(offset, primary);
+                var socket = new TestSocket(input, output);
+
+                new TaskRunner(0, socket, true, Version(legacy)).Run();
+
+                Assert.Equal(healthy.Take(offset), output.ToArray());
+                Assert.True(output.HasFailed);
+                Assert.Equal(0, output.ProtocolCallsAfterFailure);
+                Assert.Equal(0, output.FlushCount);
+                Assert.Equal(1, socket.DisposeCount);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EveryPartialSuccessTrailerWriteClosesSocketWithoutAppendingException(bool ioException)
+        {
+            byte[] inputBytes;
+            long arrowEnd;
+            using (var input = CreateTaskInput("ArrowScalar", false, 7))
+            using (var output = new ArrowFaultOutputStream())
+            {
+                inputBytes = input.ToArray();
+                new TaskRunner(0, new TestSocket(input, output), true, Version(false)).Run();
+                output.Position = 0;
+                AssertArrowBatchAndEnd(output, 7, false);
+                arrowEnd = output.Position;
+                AssertSuccessTrailer(output);
+                Assert.Equal(56, output.Length - arrowEnd);
+            }
+
+            // 44 timing bytes, END_OF_DATA_SECTION, accumulator count and END_OF_STREAM.
+            for (int offset = 0; offset < 56; ++offset)
+            {
+                Exception primary = ioException
+                    ? new IOException($"partial trailer at {offset}")
+                    : new InvalidOperationException($"partial trailer at {offset}");
+                using var input = new MemoryStream(inputBytes);
+                using var output = new ArrowFaultOutputStream(arrowEnd + offset, primary);
+                var socket = new TestSocket(input, output);
+
+                new TaskRunner(0, socket, true, Version(false)).Run();
+
+                Assert.Equal(arrowEnd + offset, output.Length);
+                Assert.True(output.HasFailed);
+                Assert.Equal(0, output.ProtocolCallsAfterFailure);
+                Assert.Equal(0, output.FlushCount);
+                Assert.Equal(1, socket.DisposeCount);
+            }
+        }
+
+        [Fact]
+        public void InputFailureDuringSuccessHandshakeDoesNotAppendException()
+        {
+            using var taskInput = CreateTaskInput("ArrowScalar", false, 7);
+            using var input = new FaultInputStream(
+                taskInput.ToArray(), taskInput.Length - sizeof(int),
+                new InvalidOperationException("handshake read failed"));
+            using var output = new ArrowFaultOutputStream();
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(false)).Run();
+
+            output.Position = 0;
+            AssertArrowBatchAndEnd(output, 7, false);
+            AssertTimingAndAccumulators(output);
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(1, socket.DisposeCount);
+            Assert.Equal(0, output.FlushCount);
+            Assert.True(input.HasFailed);
+        }
+
+        [Fact]
+        public void NewTaskAfterSuccessfulReuseGetsFreshExceptionPermission()
+        {
+            using var taskInput = CreateTaskInput("ArrowScalar", false, 7);
+            using var input = new FaultInputStream(
+                taskInput.ToArray(), taskInput.Length,
+                new InvalidOperationException("next task read failed"));
+            using var output = new ArrowFaultOutputStream();
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(false)).Run();
+
+            output.Position = 0;
+            AssertArrowBatchAndEnd(output, 7, false);
+            AssertSuccessTrailer(output);
+            Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+            Assert.Contains("next task read failed", SerDe.ReadString(output));
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(2, output.FlushCount);
+            Assert.Equal(1, socket.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ExceptionWriteOrFlushFailureIsAttemptedOnceAndPreservesPrimary(bool failFlush)
+        {
+            var primary = new InvalidOperationException("primary input failure");
+            var secondary = new InvalidOperationException("secondary exception report failure");
+            using var input = new FaultInputStream(System.Array.Empty<byte>(), 0, primary);
+            using var output = failFlush
+                ? new ArrowFaultOutputStream { FlushFailure = secondary }
+                : new ArrowFaultOutputStream(2, secondary);
+            var socket = new TestSocket(input, output);
+            var runner = new TaskRunner(0, socket, true, Version(false));
+            MethodInfo process = typeof(TaskRunner).GetMethod(
+                "ProcessStream", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Run catches failures for logging; invoke this private boundary to check identity.
+            var wrapped = Assert.Throws<TargetInvocationException>(() =>
+                process.Invoke(runner, new object[] { input, output, Version(false), false }));
+
+            Assert.Same(primary, wrapped.InnerException);
+            Assert.Equal(failFlush ? 1 : 0, output.FlushCount);
+            Assert.Equal(0, output.ProtocolCallsAfterFailure);
+            if (failFlush)
+            {
+                output.Position = 0;
+                Assert.Equal((int)SpecialLengths.PYTHON_EXCEPTION_THROWN, SerDe.ReadInt32(output));
+                Assert.Contains(primary.Message, SerDe.ReadString(output));
+                Assert.Equal(output.Length, output.Position);
+            }
+            else
+            {
+                Assert.Equal(2, output.Length);
+            }
+
+            using var runInput = new FaultInputStream(System.Array.Empty<byte>(), 0, primary);
+            using var runOutput = failFlush
+                ? new ArrowFaultOutputStream { FlushFailure = secondary }
+                : new ArrowFaultOutputStream(2, secondary);
+            var runSocket = new TestSocket(runInput, runOutput);
+            new TaskRunner(0, runSocket, true, Version(false)).Run();
+            Assert.Equal(1, runSocket.DisposeCount);
+            Assert.Equal(0, runOutput.ProtocolCallsAfterFailure);
+        }
+
+        [Fact]
+        public void SuccessFlushFailureDoesNotAppendAnythingOrReuseSocket()
+        {
+            using var input = CreateTaskInput("ArrowScalar", false, 7);
+            using var output = new ArrowFaultOutputStream
+            {
+                FlushFailure = new InvalidOperationException("success flush failed")
+            };
+            var socket = new TestSocket(input, output);
+
+            new TaskRunner(0, socket, true, Version(false)).Run();
+
+            output.Position = 0;
+            AssertArrowBatchAndEnd(output, 7, false);
+            AssertSuccessTrailer(output);
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal(0, output.ProtocolCallsAfterFailure);
+            Assert.Equal(1, output.FlushCount);
+            Assert.Equal(1, socket.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData("ArrowScalar")]
+        [InlineData("DataFrameScalar")]
+        [InlineData("ArrowGrouped")]
+        [InlineData("DataFrameGrouped")]
+        public void SparkFourStillRejectsArrowBeforeOutput(string path)
+        {
+            Delegate execute = CreateUdf(path);
+            Sql.WorkerFunction worker = execute switch
+            {
+                Sql.ArrowWorkerFunction.ExecuteDelegate arrow => new Sql.ArrowWorkerFunction(arrow),
+                Sql.DataFrameWorkerFunction.ExecuteDelegate frame => new Sql.DataFrameWorkerFunction(frame),
+                Sql.ArrowGroupedMapWorkerFunction.ExecuteDelegate grouped => new Sql.ArrowGroupedMapWorkerFunction(grouped),
+                Sql.DataFrameGroupedMapWorkerFunction.ExecuteDelegate frameGrouped => new Sql.DataFrameGroupedMapWorkerFunction(frameGrouped),
+                _ => throw new InvalidOperationException()
+            };
+            var command = new Worker.CommandPayload
+            {
+                EvalType = path.EndsWith("Grouped")
+                    ? UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
+                    : UdfUtils.PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+                Commands = new[]
+                {
+                    new SqlCommand
+                    {
+                        ArgOffsets = new[] { 0 },
+                        WorkerFunction = worker,
+                        NumChainedFunctions = 1,
+                        SerializerMode = CommandSerDe.SerializedMode.Row,
+                        DeserializerMode = CommandSerDe.SerializedMode.Row
+                    }
+                }
+            };
+            using var input = new MemoryStream();
+            using var output = new MemoryStream();
+
+            Assert.Throws<NotSupportedException>(() =>
+                new CommandExecutor(new Version(4, 0, 4)).Execute(input, output, 0, command));
+
+            Assert.Equal(0, output.Length);
+        }
+
+        private static MemoryStream CreateTaskInput(string path, bool legacy, params int[] values)
+        {
+            var input = new MemoryStream();
+            var writer = new PayloadWriter(
+                Version(legacy),
+                legacy ? new TaskContextWriterV2_4_X() : (ITaskContextWriter)new TaskContextWriterV3_0_X(),
+                new BroadcastVariableWriterV2_4_X(),
+                new ArrowCommandWriter());
+            Payload payload = TestData.GetDefaultPayload();
+            payload.BroadcastVariables.DecryptionServerNeeded = false;
+            writer.Write(input, payload, new CommandPayload
+            {
+                EvalType = path.EndsWith("Grouped")
+                    ? UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
+                    : UdfUtils.PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+                Commands = new[]
+                {
+                    new Command
+                    {
+                        ArgOffsets = new[] { 0 },
+                        ChainedUdfs = new[] { CreateUdf(path) },
+                        SerializerMode = CommandSerDe.SerializedMode.Row,
+                        DeserializerMode = CommandSerDe.SerializedMode.Row
+                    }
+                }
+            });
+
+            using RecordBatch schemaBatch = ArrowOutputSessionTests.CreateBatch(0);
+            using (var arrow = new ArrowStreamWriter(
+                input, schemaBatch.Schema, true, ArrowOutputSessionTests.Options(legacy)))
+            {
+                foreach (int value in values)
+                {
+                    using RecordBatch batch = ArrowOutputSessionTests.CreateBatch(1, value);
+                    arrow.WriteRecordBatch(batch);
+                }
+
+                arrow.WriteEnd();
+            }
+
+            SerDe.Write(input, (int)SpecialLengths.END_OF_STREAM);
+            input.Position = 0;
+            return input;
+        }
+
+        private static Delegate CreateUdf(string path)
+        {
+            switch (path)
+            {
+                case "ArrowScalar":
+                    var arrow = new Sql.ArrowUdfWrapper<Int32Array, Int32Array>(ArrowIdentity);
+                    return new Sql.ArrowWorkerFunction.ExecuteDelegate(arrow.Execute);
+                case "DataFrameScalar":
+                    var frame = new Sql.DataFrameUdfWrapper<Int32DataFrameColumn, Int32DataFrameColumn>(DataFrameIdentity);
+                    return new Sql.DataFrameWorkerFunction.ExecuteDelegate(frame.Execute);
+                case "ArrowGrouped":
+                    var grouped = new Sql.ArrowGroupedMapUdfWrapper(ArrowGroupedIdentity);
+                    return new Sql.ArrowGroupedMapWorkerFunction.ExecuteDelegate(grouped.Execute);
+                case "DataFrameGrouped":
+                    var frameGrouped = new Sql.DataFrameGroupedMapUdfWrapper(DataFrameGroupedIdentity);
+                    return new Sql.DataFrameGroupedMapWorkerFunction.ExecuteDelegate(frameGrouped.Execute);
+                default:
+                    throw new ArgumentException(nameof(path));
+            }
+        }
+
+        private static Int32Array ArrowIdentity(Int32Array values)
+        {
+            if (values.Length > 0 && values.GetValue(0) < 0)
+            {
+                throw new InvalidOperationException(UdfFailureMessage);
+            }
+
+            return values;
+        }
+
+        private static Int32DataFrameColumn DataFrameIdentity(Int32DataFrameColumn values)
+        {
+            if (values.Length > 0 && values[0] < 0)
+            {
+                throw new InvalidOperationException(UdfFailureMessage);
+            }
+
+            return values;
+        }
+
+        private static RecordBatch ArrowGroupedIdentity(RecordBatch batch)
+        {
+            ArrowIdentity((Int32Array)batch.Column(0));
+            return batch;
+        }
+
+        private static DataFrame DataFrameGroupedIdentity(DataFrame frame)
+        {
+            DataFrameIdentity((Int32DataFrameColumn)frame.Columns[0]);
+            return frame;
+        }
+
+        private static Version Version(bool legacy) =>
+            legacy ? new Version(2, 4, 0) : new Version(3, 0, 0);
+
+        private static void AssertArrowBatchAndEnd(Stream output, int expected, bool grouped)
+        {
+            Assert.Equal((int)SpecialLengths.START_ARROW_STREAM, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch batch = reader.ReadNextRecordBatch();
+            Assert.NotNull(batch);
+            Assert.Equal(1, batch.Length);
+            IArrowArray column = grouped
+                ? Assert.IsType<StructArray>(batch.Column(0)).Fields[0]
+                : batch.Column(0);
+            Assert.Equal(expected, Assert.IsType<Int32Array>(column).GetValue(0));
+            Assert.Null(reader.ReadNextRecordBatch());
+        }
+
+        private static void AssertTimingAndAccumulators(Stream output)
+        {
+            Assert.Equal((int)SpecialLengths.TIMING_DATA, SerDe.ReadInt32(output));
+            for (int i = 0; i < 3; ++i)
+            {
+                Assert.True(SerDe.ReadInt64(output) > 0);
+            }
+
+            Assert.Equal(0, SerDe.ReadInt64(output));
+            Assert.Equal(0, SerDe.ReadInt64(output));
+            Assert.Equal((int)SpecialLengths.END_OF_DATA_SECTION, SerDe.ReadInt32(output));
+            Assert.Equal(0, SerDe.ReadInt32(output));
+        }
+
+        private static void AssertSuccessTrailer(Stream output)
+        {
+            AssertTimingAndAccumulators(output);
+            Assert.Equal((int)SpecialLengths.END_OF_STREAM, SerDe.ReadInt32(output));
+        }
+
+        private sealed class ArrowCommandWriter : CommandWriterBase, ICommandWriter
+        {
+            public void Write(Stream stream, CommandPayload payload)
+            {
+                SerDe.Write(stream, (int)payload.EvalType);
+                SerDe.Write(stream, 0); // Arrow configuration count.
+                Write(stream, payload.Commands);
+            }
+        }
+
+        private sealed class FaultInputStream : MemoryStream
+        {
+            private readonly long _failOffset;
+            private readonly Exception _failure;
+
+            internal FaultInputStream(byte[] input, long failOffset, Exception failure)
+                : base(input)
+            {
+                _failOffset = failOffset;
+                _failure = failure;
+            }
+
+            internal bool HasFailed { get; private set; }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (Position >= _failOffset)
+                {
+                    HasFailed = true;
+                    throw _failure;
+                }
+
+                return base.Read(buffer, offset, (int)Math.Min(count, _failOffset - Position));
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                if (Position >= _failOffset)
+                {
+                    HasFailed = true;
+                    throw _failure;
+                }
+
+                return base.Read(buffer.Slice(0, (int)Math.Min(buffer.Length, _failOffset - Position)));
+            }
+        }
+
+        private sealed class TestSocket : ISocketWrapper
+        {
+            internal TestSocket(Stream input, Stream output)
+            {
+                InputStream = input;
+                OutputStream = output;
+            }
+
+            internal int DisposeCount { get; private set; }
+            public Stream InputStream { get; }
+            public Stream OutputStream { get; }
+            public EndPoint LocalEndPoint => null;
+            public EndPoint RemoteEndPoint => null;
+            public void Dispose() => ++DisposeCount;
+            public ISocketWrapper Accept() => throw new NotSupportedException();
+            public void Connect(IPAddress remoteaddr, int port, string secret = null) =>
+                throw new NotSupportedException();
+            public void Listen(int backlog = 16) => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DataFrameArrowBatchAdapterTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DataFrameArrowBatchAdapterTests.cs
@@ -1,0 +1,459 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Worker.Command;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class DataFrameArrowBatchAdapterTests
+    {
+        [Fact]
+        public void MixedColumnsPreserveValuesAndInput()
+        {
+            string[] text = { null, "", "中文", "🙂", "abc", "\ud800" };
+            string[] arrowText = { "arrow-0", null, "", "已有字符串", "🙂", "last" };
+            bool?[] flags = { true, true, null, false, true, false };
+            var frame = new DataFrame(
+                new StringDataFrameColumn("description", text),
+                new SByteDataFrameColumn("i8", new sbyte?[] { 1, null, -3, 4, 5, 6 }),
+                MakeArrowColumn("arrow", arrowText),
+                new Int16DataFrameColumn("i16", new short?[] { 10, 20, null, -40, 50, 60 }),
+                new BooleanDataFrameColumn("flag", flags),
+                new Int32DataFrameColumn("i32", new int?[] { 100, 200, 300, null, -500, 600 }),
+                new Int64DataFrameColumn("i64", new long?[] { 1000, 2000, 3000, 4000, null, -6000 }),
+                new SingleDataFrameColumn("f32", new float?[] { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, null }),
+                new DoubleDataFrameColumn("f64", new double?[] { null, 2.25, 3.25, 4.25, 5.25, 6.25 }));
+            object[][] input = ReadFrame(frame);
+            var output = new List<object[]>();
+            foreach (PreparedArrowBatch prepared in DataFrameArrowBatchAdapter.Convert(frame, 3, 64, NewBuffer))
+            {
+                Assert.Equal(frame.Columns.Select(column => column.Name),
+                    prepared.Batch.Schema.FieldsList.Select(field => field.Name));
+                output.AddRange(RoundTrip(prepared.Batch));
+            }
+
+            // Encoding.UTF8's normal replacement fallback is preserved for invalid UTF-16.
+            object[][] expected = input.Select(row => (object[])row.Clone()).ToArray();
+            expected[5][0] = "�";
+            AssertRows(expected, output);
+            AssertRows(input, ReadFrame(frame));
+        }
+
+        [Fact]
+        public void EmptyResultsHaveTypedSchemaAndOneZeroStringOffset()
+        {
+            var frame = new DataFrame(
+                new StringDataFrameColumn("s"), new ArrowStringDataFrameColumn("a"),
+                new BooleanDataFrameColumn("b"), new SByteDataFrameColumn("i8"),
+                new Int16DataFrameColumn("i16"), new Int32DataFrameColumn("i32"),
+                new Int64DataFrameColumn("i64"), new SingleDataFrameColumn("f32"),
+                new DoubleDataFrameColumn("f64"));
+            using IEnumerator<PreparedArrowBatch> batches = DataFrameArrowBatchAdapter.Convert(frame).GetEnumerator();
+            Assert.True(batches.MoveNext());
+            RecordBatch batch = batches.Current.Batch;
+            Assert.Equal(0, batch.Length);
+            Assert.Equal(new[]
+            {
+                ArrowTypeId.String, ArrowTypeId.String, ArrowTypeId.Boolean, ArrowTypeId.Int8,
+                ArrowTypeId.Int16, ArrowTypeId.Int32, ArrowTypeId.Int64, ArrowTypeId.Float, ArrowTypeId.Double
+            }, batch.Schema.FieldsList.Select(field => field.DataType.TypeId));
+            foreach (StringArray array in batch.Arrays.OfType<StringArray>())
+            {
+                Assert.Equal(new byte[4], array.ValueOffsetsBuffer.Memory.ToArray());
+            }
+
+            Assert.Empty(RoundTrip(batch));
+            Assert.False(batches.MoveNext());
+        }
+
+        [Theory]
+        [InlineData(65_535)]
+        [InlineData(65_536)]
+        [InlineData(65_537)]
+        public void RowLimitPreservesEveryRowAcrossWindows(int rows)
+        {
+            var text = Enumerable.Range(0, rows).Select(i => "row-" + i).ToArray();
+            var flags = Enumerable.Range(0, rows).Select(i => i % 5 == 0 ? (bool?)null : i % 3 != 0).ToArray();
+            var frame = new DataFrame(
+                new StringDataFrameColumn("s", text),
+                new PrimitiveDataFrameColumn<int>("i", Enumerable.Range(0, rows)),
+                new BooleanDataFrameColumn("b", flags));
+            int processed = 0;
+            int batchCount = 0;
+            foreach (PreparedArrowBatch prepared in DataFrameArrowBatchAdapter.Convert(frame))
+            {
+                ++batchCount;
+                Assert.InRange(prepared.Batch.Length, 1, DataFrameArrowBatchAdapter.MaxRowsPerBatch);
+                foreach (object[] row in RoundTrip(prepared.Batch))
+                {
+                    Assert.Equal(text[processed], row[0]);
+                    Assert.Equal(processed, row[1]);
+                    Assert.Equal(flags[processed], row[2]);
+                    ++processed;
+                }
+            }
+
+            Assert.Equal(rows, processed);
+            Assert.Equal(rows > DataFrameArrowBatchAdapter.MaxRowsPerBatch ? 2 : 1, batchCount);
+        }
+
+        [Fact]
+        public void StringBudgetSplitsWindowsWithoutLosingNullEmptyOrArrowValues()
+        {
+            string[] text = { null, "", "你好", "a", "b", "", null, "c", "d", "e", "f", "g" };
+            string[] arrow = { "first", "", null, "🙂", "", "", "", "h", "i", "j", "k", "last" };
+            var frame = new DataFrame(new StringDataFrameColumn("s", text), MakeArrowColumn("a", arrow),
+                new BooleanDataFrameColumn("b", Enumerable.Range(0, text.Length).Select(i => i % 3 != 0)),
+                new Int64DataFrameColumn("n", Enumerable.Range(0, text.Length).Select(i => (long)i * 31)));
+            var output = new List<object[]>();
+            int batchCount = 0;
+            foreach (PreparedArrowBatch prepared in DataFrameArrowBatchAdapter.Convert(frame, 9, 8, NewBuffer))
+            {
+                ++batchCount;
+                Assert.InRange(prepared.Batch.Arrays.OfType<StringArray>().Sum(array => array.ValueBuffer.Length), 0, 8);
+                Assert.InRange(prepared.Batch.Length, 1, 9);
+                output.AddRange(RoundTrip(prepared.Batch));
+            }
+
+            Assert.True(batchCount > 1);
+            AssertRows(ReadFrame(frame), output);
+        }
+
+        [Fact]
+        public void AllNullAndEmptyValuesAdvanceWithoutPayloadBytes()
+        {
+            string[] strings = Enumerable.Range(0, 34).Select(i => i % 2 == 0 ? null : "").ToArray();
+            var frame = new DataFrame(new StringDataFrameColumn("s", strings), MakeArrowColumn("a", strings));
+            int processed = 0;
+            foreach (PreparedArrowBatch prepared in DataFrameArrowBatchAdapter.Convert(frame, 9, 1, NewBuffer))
+            {
+                foreach (StringArray array in prepared.Batch.Arrays)
+                {
+                    Assert.Equal(0, array.ValueBuffer.Length);
+                    Assert.Equal(new byte[(prepared.Batch.Length + 1) * 4], array.ValueOffsetsBuffer.Memory.ToArray());
+                }
+
+                foreach (object[] row in RoundTrip(prepared.Batch))
+                {
+                    Assert.Equal(strings[processed], row[0]);
+                    Assert.Equal(strings[processed], row[1]);
+                    ++processed;
+                }
+            }
+
+            Assert.Equal(strings.Length, processed);
+        }
+
+        [Theory]
+        [InlineData(7, 8)]
+        [InlineData(8, 8)]
+        [InlineData(9, 8)]
+        [InlineData(8 * 1024 * 1024 - 1, 8 * 1024 * 1024)]
+        [InlineData(8 * 1024 * 1024, 8 * 1024 * 1024)]
+        [InlineData(8 * 1024 * 1024 + 1, 8 * 1024 * 1024)]
+        public void StringByteLimitIsCheckedBeforeEncodingAllocations(int bytes, int limit)
+        {
+            var frame = new DataFrame(new StringDataFrameColumn("s", new[] { new string('x', bytes) }));
+            int allocations = 0;
+            IEnumerable<PreparedArrowBatch> batches = DataFrameArrowBatchAdapter.Convert(frame, 10, limit,
+                length => { ++allocations; return new byte[length]; });
+            if (bytes > limit)
+            {
+                InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => batches.First());
+                Assert.Contains("Row 0", error.Message);
+                Assert.Contains($"{bytes} UTF-8 string bytes", error.Message);
+                Assert.Equal(0, allocations);
+            }
+            else
+            {
+                foreach (PreparedArrowBatch prepared in batches)
+                {
+                    Assert.Equal(new string('x', bytes), RoundTrip(prepared.Batch)[0][0]);
+                    Assert.Equal(bytes, ((StringArray)prepared.Batch.Column(0)).ValueBuffer.Length);
+                }
+            }
+        }
+
+        [Fact]
+        public void StringBudgetIncludesEveryColumnInOneRow()
+        {
+            var frame = new DataFrame(new StringDataFrameColumn("s", new[] { "你好" }),
+                MakeArrowColumn("a", new[] { "🙂" }));
+            int allocations = 0;
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+                DataFrameArrowBatchAdapter.Convert(frame, 10, 9,
+                    length => { ++allocations; return new byte[length]; }).First());
+            Assert.Contains("10 UTF-8 string bytes", error.Message);
+            Assert.Equal(0, allocations);
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(6)]
+        public void BufferAllocationFailurePreservesInputAndOriginalError(int failAt)
+        {
+            var frame = new DataFrame(new StringDataFrameColumn("s", new[] { "hello", null }),
+                MakeArrowColumn("a", new[] { "world", "🙂" }));
+            object[][] before = ReadFrame(frame);
+            var primary = new InvalidOperationException("injected-buffer-failure");
+            int allocations = 0;
+            Exception thrown = Assert.Throws<InvalidOperationException>(() =>
+                DataFrameArrowBatchAdapter.Convert(frame, 4, 32,
+                    length => ++allocations == failAt ? throw primary : new byte[length]).First());
+            Assert.Same(primary, thrown);
+            Assert.Equal(failAt, allocations);
+            AssertRows(before, ReadFrame(frame));
+            foreach (PreparedArrowBatch prepared in DataFrameArrowBatchAdapter.Convert(frame))
+            {
+                AssertRows(before, RoundTrip(prepared.Batch));
+            }
+        }
+
+        [Fact]
+        public void EarlyEnumeratorDisposalReleasesItsWindow()
+        {
+            var frame = new DataFrame(new StringDataFrameColumn("s", new[] { "one", "two" }));
+            IEnumerator<PreparedArrowBatch> iterator = DataFrameArrowBatchAdapter.Convert(frame, 1, 32, NewBuffer).GetEnumerator();
+            Assert.True(iterator.MoveNext());
+            PreparedArrowBatch first = iterator.Current;
+            Assert.Equal(1, first.OwnedRootCount);
+            Assert.Equal(3, first.HeldReferenceCount);
+            iterator.Dispose();
+            Assert.Equal(0, first.OwnedRootCount);
+            Assert.Equal(0, first.HeldReferenceCount);
+            Assert.Equal(1, first.ReleasedRootCount);
+            Assert.Equal(0, first.ReleaseFailedRootCount);
+            Assert.Null(first.Batch);
+            first.Dispose();
+            Assert.Equal(1, first.ReleasedRootCount);
+            Assert.Equal("one", frame.Columns[0][0]);
+        }
+
+        [Fact]
+        public void MovingToTheNextWindowReleasesThePreviousLease()
+        {
+            var frame = new DataFrame(new StringDataFrameColumn("s", new[] { "one", "two" }));
+            using IEnumerator<PreparedArrowBatch> iterator =
+                DataFrameArrowBatchAdapter.Convert(frame, 1, 32, NewBuffer).GetEnumerator();
+            Assert.True(iterator.MoveNext());
+            PreparedArrowBatch first = iterator.Current;
+            Assert.True(iterator.MoveNext());
+            Assert.Null(first.Batch);
+            Assert.Equal(0, first.HeldReferenceCount);
+            Assert.Equal(1, first.ReleasedRootCount);
+            Assert.Equal("two", ((StringArray)iterator.Current.Batch.Column(0)).GetString(0));
+        }
+
+        [Fact]
+        public void UnsupportedMixedTypesAreRejectedBeforeAllocationOrCustomClone()
+        {
+            DataFrameColumn[] unsupported =
+            {
+                new ByteDataFrameColumn("x", new byte[] { 1 }),
+                new UInt16DataFrameColumn("x", new ushort[] { 1 }),
+                new UInt32DataFrameColumn("x", new uint[] { 1 }),
+                new UInt64DataFrameColumn("x", new ulong[] { 1 }),
+                new DateTimeDataFrameColumn("x", new[] { DateTime.UnixEpoch }),
+                new CharDataFrameColumn("x", new[] { 'x' }),
+                new DecimalDataFrameColumn("x", new[] { 1m }),
+                new CustomIntColumn("x"),
+                new CustomStringColumn("x")
+            };
+            foreach (DataFrameColumn column in unsupported)
+            {
+                var frame = new DataFrame(new StringDataFrameColumn("s", new[] { "value" }), column);
+                int allocations = 0;
+                NotSupportedException error = Assert.Throws<NotSupportedException>(() =>
+                    DataFrameArrowBatchAdapter.Convert(frame, 8, 32,
+                        length => { ++allocations; return new byte[length]; }).First());
+                Assert.Contains(column.GetType().FullName, error.Message);
+                Assert.Equal(0, allocations);
+            }
+        }
+
+        [Fact]
+        public void LegacyExportIsKeptWhenThereAreNoRegularStrings()
+        {
+            var frame = new DataFrame(new UInt32DataFrameColumn("legacy", new uint[] { 1, uint.MaxValue }));
+            using IEnumerator<PreparedArrowBatch> batches = DataFrameArrowBatchAdapter.Convert(frame).GetEnumerator();
+            Assert.True(batches.MoveNext());
+            Assert.Equal(ArrowTypeId.UInt32, batches.Current.Batch.Schema.GetFieldByIndex(0).DataType.TypeId);
+            Assert.Equal(uint.MaxValue, ((UInt32Array)batches.Current.Batch.Column(0)).GetValue(1));
+            Assert.False(batches.MoveNext());
+        }
+
+        [Fact]
+        public void NullAndColumnlessResultsFailDescriptively()
+        {
+            Assert.Contains("null DataFrame", Assert.Throws<ArgumentException>(() =>
+                DataFrameArrowBatchAdapter.Convert(null).First()).Message);
+            Assert.Contains("no columns", Assert.Throws<ArgumentException>(() =>
+                DataFrameArrowBatchAdapter.Convert(new DataFrame()).First()).Message);
+        }
+
+        [Fact]
+        public void RowMappingUsesLongPositionsAndCheckedAllocationArithmetic()
+        {
+            long start = (long)int.MaxValue + 123;
+            Int64DataFrameColumn map = DataFrameArrowBatchAdapter.CreateRowMap(start, 3);
+            Assert.Equal(new long?[] { start, start + 1, start + 2 }, map);
+            Assert.Throws<OverflowException>(() => DataFrameArrowBatchAdapter.CreateRowMap(long.MaxValue, 1));
+            Assert.Throws<OverflowException>(() => DataFrameArrowBatchAdapter.OffsetBufferLength(int.MaxValue));
+            Assert.Throws<OverflowException>(() => DataFrameArrowBatchAdapter.OffsetBufferLength(int.MaxValue / 4));
+        }
+
+        [Fact]
+        public void ArrowCursorCrossesPhysicalBuffersAndUsesLocalNullBits()
+        {
+            var values = new ReadOnlyMemory<byte>[]
+            {
+                Encoding.UTF8.GetBytes("a🙂"), ReadOnlyMemory<byte>.Empty, Encoding.UTF8.GetBytes("二z")
+            };
+            var offsets = new ReadOnlyMemory<int>[]
+            {
+                new[] { 0, 1, 1, 5 }, new[] { 0 }, new[] { 0, 3, 4 }
+            };
+            var validity = new ReadOnlyMemory<byte>[] { new byte[] { 5 }, ReadOnlyMemory<byte>.Empty, new byte[] { 3 } };
+            using var cursor = new DataFrameArrowBatchAdapter.ArrowStringCursor(values, offsets, validity, false);
+            string[] expected = { "a", null, "🙂", "二", "z" };
+            foreach (string text in expected)
+            {
+                ReadOnlyMemory<byte> bytes = cursor.Peek(out bool valid);
+                Assert.Equal(text != null, valid);
+                Assert.Equal(text == null ? System.Array.Empty<byte>() : Encoding.UTF8.GetBytes(text), bytes.ToArray());
+                Assert.Equal(bytes.ToArray(), cursor.Peek(out bool _).ToArray());
+                cursor.Advance();
+            }
+        }
+
+        [Fact]
+        public void MissingNullBitmapIsAllowedOnlyForAnAllValidArrowColumn()
+        {
+            var values = new ReadOnlyMemory<byte>[] { Encoding.UTF8.GetBytes("x") };
+            var offsets = new ReadOnlyMemory<int>[] { new[] { 0, 1 } };
+            var validity = new ReadOnlyMemory<byte>[] { ReadOnlyMemory<byte>.Empty };
+            using var valid = new DataFrameArrowBatchAdapter.ArrowStringCursor(values, offsets, validity, true);
+            Assert.Equal(new byte[] { (byte)'x' }, valid.Peek(out bool isValid).ToArray());
+            Assert.True(isValid);
+            using var absent = new DataFrameArrowBatchAdapter.ArrowStringCursor(
+                values, offsets, System.Array.Empty<ReadOnlyMemory<byte>>(), true);
+            Assert.Equal(new byte[] { (byte)'x' }, absent.Peek(out bool absentValid).ToArray());
+            Assert.True(absentValid);
+            using var invalid = new DataFrameArrowBatchAdapter.ArrowStringCursor(values, offsets, validity, false);
+            Assert.Throws<InvalidOperationException>(() => invalid.Peek(out bool _));
+        }
+
+        private static byte[] NewBuffer(int length) => new byte[length];
+
+        private static ArrowStringDataFrameColumn MakeArrowColumn(string name, string[] values)
+        {
+            using var stream = new MemoryStream();
+            var offsets = new byte[4 * (values.Length + 1)];
+            var valid = new byte[(values.Length + 7) / 8];
+            int nullCount = 0;
+            for (int i = 0; i < values.Length; ++i)
+            {
+                if (values[i] == null)
+                {
+                    ++nullCount;
+                }
+                else
+                {
+                    valid[i / 8] |= (byte)(1 << (i & 7));
+                    byte[] value = Encoding.UTF8.GetBytes(values[i]);
+                    stream.Write(value, 0, value.Length);
+                }
+
+                byte[] offset = BitConverter.GetBytes(checked((int)stream.Length));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    System.Array.Reverse(offset);
+                }
+
+                System.Array.Copy(offset, 0, offsets, (i + 1) * 4, 4);
+            }
+
+            return new ArrowStringDataFrameColumn(name, stream.ToArray(), offsets, valid, values.Length, nullCount);
+        }
+
+        private static object[][] ReadFrame(DataFrame frame) => Enumerable.Range(0, checked((int)frame.Rows.Count))
+            .Select(row => frame.Columns.Select(column => column[row]).ToArray()).ToArray();
+
+        private static void AssertRows(IEnumerable<object[]> expected, IEnumerable<object[]> actual)
+        {
+            object[][] expectedRows = expected.ToArray();
+            object[][] actualRows = actual.ToArray();
+            Assert.Equal(expectedRows.Length, actualRows.Length);
+            for (int i = 0; i < expectedRows.Length; ++i)
+            {
+                Assert.Equal(expectedRows[i], actualRows[i]);
+            }
+        }
+
+        private static List<object[]> RoundTrip(RecordBatch batch)
+        {
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+            using var reader = new ArrowStreamReader(stream);
+            using RecordBatch read = reader.ReadNextRecordBatch();
+            Assert.NotNull(read);
+            Assert.Equal(batch.Length, read.Length);
+            var rows = new List<object[]>();
+            for (int row = 0; row < read.Length; ++row)
+            {
+                rows.Add(read.Arrays.Select(array => ReadValue(array, row)).ToArray());
+            }
+
+            Assert.Null(reader.ReadNextRecordBatch());
+            return rows;
+        }
+
+        private static object ReadValue(IArrowArray array, int row)
+        {
+            if (array.IsNull(row)) { return null; }
+            switch (array)
+            {
+                // Arrow 14 GetString treats a default empty value buffer as null,
+                // so use the independent validity bitmap and UTF-8 bytes as the oracle.
+                case StringArray value: return Encoding.UTF8.GetString(value.GetBytes(row));
+                case BooleanArray value: return value.GetValue(row);
+                case Int8Array value: return value.GetValue(row);
+                case Int16Array value: return value.GetValue(row);
+                case Int32Array value: return value.GetValue(row);
+                case Int64Array value: return value.GetValue(row);
+                case FloatArray value: return value.GetValue(row);
+                case DoubleArray value: return value.GetValue(row);
+                default: throw new InvalidOperationException($"Unexpected test array: {array.GetType()}");
+            }
+        }
+
+        private sealed class CustomIntColumn : Int32DataFrameColumn
+        {
+            internal CustomIntColumn(string name) : base(name, new[] { 1 }) { }
+        }
+
+        private sealed class CustomStringColumn : StringDataFrameColumn
+        {
+            internal CustomStringColumn(string name) : base(name, new[] { "custom" }) { }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/DataFrameGroupedMapOutputTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/DataFrameGroupedMapOutputTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Utils;
+using Microsoft.Spark.Worker.Command;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class DataFrameGroupedMapOutputTests
+    {
+        [Theory]
+        [InlineData(2, false)]
+        [InlineData(2, true)]
+        [InlineData(3, false)]
+        [InlineData(3, true)]
+        public void GroupedStringsKeepSchemaAcrossEmptyAndNullGroups(int major, bool emptyFirst)
+        {
+            var options = new IpcOptions { WriteLegacyIpcFormat = major == 2 };
+            var version = new Version(major, 3, 0);
+            var originalArrow = new StringArray.Builder().Append("原值🙂").Build();
+            using var originalBatch = new RecordBatch(
+                new Schema(new[] { new Field("Description", StringType.Default, false) }, null),
+                new[] { originalArrow }, 1);
+            var outputs = new List<DataFrame>
+            {
+                new DataFrame(new StringDataFrameColumn("Description",
+                    emptyFirst ? new string[0] : new[] { "this is description two150" })),
+                DataFrame.FromArrowRecordBatch(originalBatch),
+                new DataFrame(new StringDataFrameColumn("Description", new[] { (string)null, "" }))
+            };
+            int call = 0;
+            var command = new SqlCommand
+            {
+                ArgOffsets = new[] { 0 },
+                NumChainedFunctions = 1,
+                WorkerFunction = new Sql.DataFrameGroupedMapWorkerFunction(_ => outputs[call++]),
+                SerializerMode = CommandSerDe.SerializedMode.Row,
+                DeserializerMode = CommandSerDe.SerializedMode.Row
+            };
+
+            using var input = CreateInput(3, options);
+            using var output = new MemoryStream();
+            var context = new ArrowOutputContext();
+            CommandExecutorStat stat = SqlCommandExecutor.Execute(
+                version, input, output, UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+                new[] { command }, context);
+
+            Assert.Equal(3, call);
+            Assert.Equal(emptyFirst ? 3 : 4, stat.NumEntriesProcessed);
+            Assert.Equal(ArrowOutputPhase.Ended, context.Phase);
+            output.Position = 0;
+            Assert.Equal((int)SpecialLengths.START_ARROW_STREAM, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            for (int group = 0; group < outputs.Count; ++group)
+            {
+                using RecordBatch batch = reader.ReadNextRecordBatch();
+                Assert.NotNull(batch);
+                Field field;
+                StringArray values;
+                if (major == 3)
+                {
+                    Assert.Single(batch.Schema.FieldsList);
+                    Assert.Equal("Struct", batch.Schema.GetFieldByIndex(0).Name);
+                    var wrapped = Assert.IsType<StructArray>(batch.Column(0));
+                    values = Assert.IsType<StringArray>(wrapped.Fields[0]);
+                    field = ((StructType)wrapped.Data.DataType).Fields[0];
+                }
+                else
+                {
+                    field = batch.Schema.GetFieldByIndex(0);
+                    values = Assert.IsType<StringArray>(batch.Column(0));
+                }
+
+                Assert.Equal("Description", field.Name);
+                Assert.True(field.IsNullable);
+                Assert.Equal(ArrowTypeId.String, field.DataType.TypeId);
+                DataFrameColumn expected = outputs[group].Columns[0];
+                Assert.Equal(expected.Length, (long)values.Length);
+                for (int row = 0; row < values.Length; ++row)
+                {
+                    Assert.Equal(expected[row] == null, values.IsNull(row));
+                    // Arrow 14 GetString confuses an empty data buffer with a null value.
+                    // Verify the wire validity and UTF-8 payload independently instead.
+                    string actual = values.IsNull(row) ? null :
+                        Encoding.UTF8.GetString(values.GetBytes(row).ToArray());
+                    Assert.Equal(expected[row], actual);
+                }
+            }
+
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(output.Length, output.Position);
+            Assert.Equal("原值🙂", outputs[1].Columns[0][0]);
+            Assert.Null(outputs[2].Columns[0][0]);
+        }
+
+        [Fact]
+        public void GroupedConversionErrorAfterOneGroupClosesArrowBeforeRethrowing()
+        {
+            var failureFrame = new DataFrame(
+                new StringDataFrameColumn("text", new[] { "value" }),
+                new UInt32DataFrameColumn("unsupported", new uint[] { uint.MaxValue }));
+            int calls = 0;
+            var command = new SqlCommand
+            {
+                ArgOffsets = new[] { 0 },
+                WorkerFunction = new Sql.DataFrameGroupedMapWorkerFunction(_ =>
+                    ++calls == 1 ?
+                        new DataFrame(new StringDataFrameColumn("text", new[] { "first" })) :
+                        failureFrame),
+                SerializerMode = CommandSerDe.SerializedMode.Row,
+                DeserializerMode = CommandSerDe.SerializedMode.Row
+            };
+            var options = new IpcOptions();
+            using var input = CreateInput(3, options);
+            using var output = new MemoryStream();
+            var context = new ArrowOutputContext();
+            NotSupportedException error = Assert.Throws<NotSupportedException>(() =>
+                SqlCommandExecutor.Execute(new Version(3, 3, 4), input, output,
+                    UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+                    new[] { command }, context));
+            Assert.Contains("unsupported", error.Message);
+            Assert.Equal(2, calls);
+            Assert.True(context.CanWriteException);
+            Assert.Equal(ArrowOutputPhase.Ended, context.Phase);
+            output.Position = 0;
+            Assert.Equal((int)SpecialLengths.START_ARROW_STREAM, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch first = reader.ReadNextRecordBatch();
+            var fields = Assert.IsType<StructArray>(first.Column(0));
+            Assert.Equal("first", Assert.IsType<StringArray>(fields.Fields[0]).GetString(0));
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(output.Length, output.Position);
+        }
+
+        [Fact]
+        public void Spark4ArrowRemainsUnsupportedBeforeOutput()
+        {
+            bool called = false;
+            var command = new SqlCommand
+            {
+                WorkerFunction = new Sql.DataFrameGroupedMapWorkerFunction(_ =>
+                {
+                    called = true;
+                    return new DataFrame(new StringDataFrameColumn("text"));
+                }),
+                SerializerMode = CommandSerDe.SerializedMode.Row,
+                DeserializerMode = CommandSerDe.SerializedMode.Row
+            };
+            using var input = new MemoryStream();
+            using var output = new MemoryStream();
+            var context = new ArrowOutputContext();
+            Assert.Throws<NotSupportedException>(() => SqlCommandExecutor.Execute(
+                new Version(4, 0, 0), input, output,
+                UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF, new[] { command }, context));
+            Assert.False(called);
+            Assert.Equal(0, output.Length);
+            Assert.True(context.CanWriteException);
+        }
+
+        private static MemoryStream CreateInput(int groups, IpcOptions options)
+        {
+            var stream = new MemoryStream();
+            var schema = new Schema(new[] { new Field("id", Int32Type.Default, false) }, null);
+            using (var writer = new ArrowStreamWriter(stream, schema, leaveOpen: true, options))
+            {
+                for (int group = 0; group < groups; ++group)
+                {
+                    var array = new Int32Array.Builder().Append(group).Build();
+                    using var batch = new RecordBatch(schema, new[] { array }, 1);
+                    writer.WriteRecordBatch(batch);
+                }
+
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/PreparedArrowBatchTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/PreparedArrowBatchTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using Microsoft.Spark.Worker.Command;
+using Xunit;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class PreparedArrowBatchTests
+    {
+        [Fact]
+        public void DuplicateRootsAndSchemaViewsDoNotCreateAdditionalOwners()
+        {
+            var root = new TrackingStringArray();
+            RecordBatch original = Batch(root, root);
+            PreparedArrowBatch prepared = PreparedArrowBatch.Own(original);
+            var structType = new StructType(original.Schema.FieldsList);
+            var wrapper = new StructArray(structType, 1, original.Arrays, ArrowBuffer.Empty);
+            prepared.ReplaceBatch(new RecordBatch(new Schema(new[] { new Field("group", structType, false) }, null),
+                new[] { wrapper }, 1));
+            prepared.Hold(new byte[1]);
+            Assert.Equal(1, prepared.OwnedRootCount);
+            prepared.Dispose();
+            prepared.Dispose();
+            Assert.Equal(1, root.DisposeCalls);
+            Assert.Equal(1, prepared.ReleasedRootCount);
+            Assert.Equal(0, prepared.ReleaseFailedRootCount);
+            Assert.Equal(0, prepared.HeldReferenceCount);
+            Assert.Null(prepared.Batch);
+        }
+
+        [Fact]
+        public void BorrowedCallerArraysRemainOwnedByCaller()
+        {
+            var root = new TrackingStringArray();
+            RecordBatch batch = Batch(root);
+            PreparedArrowBatch prepared = PreparedArrowBatch.Borrow(batch);
+            prepared.Dispose();
+            Assert.Equal(0, root.DisposeCalls);
+            Assert.Equal("x", root.GetString(0));
+            root.Dispose();
+            Assert.Equal(1, root.DisposeCalls);
+        }
+
+        [Fact]
+        public void CleanupAttemptsEveryDistinctRootAndNeverRetriesUncertainRelease()
+        {
+            var primary = new InvalidOperationException("first-cleanup-failure");
+            var first = new TrackingStringArray(primary);
+            var second = new TrackingStringArray();
+            var third = new TrackingStringArray(new InvalidOperationException("second-cleanup-failure"));
+            PreparedArrowBatch prepared = PreparedArrowBatch.Own(Batch(first, second, third, first));
+            prepared.Hold(new object());
+            Assert.Same(primary, Assert.Throws<InvalidOperationException>(() => prepared.Dispose()));
+            Assert.Equal(1, first.DisposeCalls);
+            Assert.Equal(1, second.DisposeCalls);
+            Assert.Equal(1, third.DisposeCalls);
+            Assert.Equal(1, prepared.ReleasedRootCount);
+            Assert.Equal(2, prepared.ReleaseFailedRootCount);
+            Assert.Equal(0, prepared.OwnedRootCount);
+            Assert.Equal(0, prepared.HeldReferenceCount);
+            Assert.Null(prepared.Batch);
+            prepared.Dispose();
+            Assert.Equal(1, first.DisposeCalls);
+            Assert.Throws<ObjectDisposedException>(() => prepared.ReplaceBatch(Batch(second)));
+        }
+
+        [Fact]
+        public void CleanupAfterPreparationFailureDoesNotThrowAReplacementError()
+        {
+            var root = new TrackingStringArray(new InvalidOperationException("cleanup"));
+            PreparedArrowBatch prepared = PreparedArrowBatch.Own(Batch(root));
+            prepared.DisposeAfterFailure();
+            Assert.Equal(1, prepared.ReleaseFailedRootCount);
+            Assert.Equal(0, prepared.OwnedRootCount);
+            Assert.Null(prepared.Batch);
+        }
+
+        private static RecordBatch Batch(params IArrowArray[] arrays)
+        {
+            var fields = new Field[arrays.Length];
+            for (int i = 0; i < arrays.Length; ++i)
+            {
+                fields[i] = new Field("s" + i, StringType.Default, false);
+            }
+
+            return new RecordBatch(new Schema(fields, null), arrays, 1);
+        }
+
+        private sealed class TrackingStringArray : StringArray, IArrowArray
+        {
+            private readonly Exception _error;
+
+            internal TrackingStringArray(Exception error = null)
+                : base(1, new ArrowBuffer(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }),
+                    new ArrowBuffer(new byte[] { (byte)'x' }), ArrowBuffer.Empty, 0, 0)
+            {
+                _error = error;
+            }
+
+            internal int DisposeCalls { get; private set; }
+
+            public new void Dispose()
+            {
+                ++DisposeCalls;
+                base.Dispose();
+                if (_error != null)
+                {
+                    throw _error;
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputContext.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputContext.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Spark.Worker.Command
+{
+    internal enum ArrowOutputPhase
+    {
+        NotStarted,
+        Writing,
+        AtBatchBoundary,
+        Ended,
+        Faulted
+    }
+
+    /// <summary>
+    /// Tracks output framing for one TaskRunner.ProcessStream invocation.
+    /// The Arrow session owns Phase; TaskRunner owns the success trailer.
+    /// </summary>
+    internal sealed class ArrowOutputContext
+    {
+        internal ArrowOutputPhase Phase { get; set; }
+
+        internal bool SuccessTailStarted { get; private set; }
+
+        internal bool CanWriteException =>
+            !SuccessTailStarted &&
+            (Phase == ArrowOutputPhase.NotStarted || Phase == ArrowOutputPhase.Ended);
+
+        internal void BeginSuccessTail() => SuccessTailStarted = true;
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputSession.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputSession.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.ExceptionServices;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Services;
+
+namespace Microsoft.Spark.Worker.Command
+{
+    /// <summary>
+    /// Writes prepared batches and closes Arrow framing only at a complete batch boundary.
+    /// A failed write makes the connection unusable, regardless of the exception type.
+    /// </summary>
+    internal sealed class ArrowOutputSession
+    {
+        private static readonly ILoggerService s_logger =
+            LoggerServiceFactory.GetLogger(typeof(ArrowOutputSession));
+
+        private readonly Stream _output;
+        private readonly IpcOptions _ipcOptions;
+        private readonly ArrowOutputContext _context;
+        private ArrowStreamWriter _writer;
+
+        internal ArrowOutputSession(
+            Stream output,
+            IpcOptions ipcOptions,
+            ArrowOutputContext context)
+        {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+            _ipcOptions = ipcOptions ?? throw new ArgumentNullException(nameof(ipcOptions));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        internal void Write(IEnumerable<PreparedArrowBatch> batches)
+        {
+            if (_context.Phase != ArrowOutputPhase.NotStarted || _context.SuccessTailStarted)
+            {
+                throw new InvalidOperationException("An Arrow output session cannot be restarted.");
+            }
+
+            Exception failure = null;
+            IEnumerator<PreparedArrowBatch> iterator = null;
+            try
+            {
+                iterator = batches.GetEnumerator();
+                while (iterator.MoveNext())
+                {
+                    PreparedArrowBatch prepared = iterator.Current;
+                    try
+                    {
+                        if (prepared == null)
+                        {
+                            throw new InvalidDataException("Arrow output contains a null batch.");
+                        }
+
+                        WriteBatch(prepared.Batch);
+                    }
+                    catch (Exception ex)
+                    {
+                        failure = ex;
+                    }
+                    finally
+                    {
+                        Cleanup(prepared, ref failure);
+                    }
+
+                    if (failure != null)
+                    {
+                        break;
+                    }
+                }
+
+                if (failure == null && _context.Phase == ArrowOutputPhase.NotStarted)
+                {
+                    throw new InvalidDataException("Arrow output did not provide a result schema.");
+                }
+            }
+            catch (Exception ex)
+            {
+                KeepFirstFailure(ex, ref failure);
+            }
+            finally
+            {
+                // Iterator cleanup is preparation work too: an intact stream can still end
+                // before the original failure is reported through the outer task protocol.
+                Cleanup(iterator, ref failure);
+                if (_context.Phase == ArrowOutputPhase.AtBatchBoundary)
+                {
+                    try
+                    {
+                        WriteEnd();
+                    }
+                    catch (Exception ex)
+                    {
+                        KeepFirstFailure(ex, ref failure);
+                    }
+                }
+
+                // Arrow 14 Dispose does not write EOS. The task retains socket ownership.
+                Cleanup(_writer, ref failure);
+                _writer = null;
+            }
+
+            if (failure != null)
+            {
+                ExceptionDispatchInfo.Capture(failure).Throw();
+            }
+        }
+
+        private void WriteBatch(RecordBatch batch)
+        {
+            // Construction and the complete first batch must succeed before START is sent.
+            bool starting = _context.Phase == ArrowOutputPhase.NotStarted;
+            if (starting)
+            {
+                _writer = new ArrowStreamWriter(
+                    _output, batch.Schema, leaveOpen: true, _ipcOptions);
+            }
+
+            _context.Phase = ArrowOutputPhase.Writing;
+            try
+            {
+                if (starting)
+                {
+                    SerDe.Write(_output, (int)SpecialLengths.START_ARROW_STREAM);
+                }
+
+                _writer.WriteRecordBatch(batch);
+                _context.Phase = ArrowOutputPhase.AtBatchBoundary;
+            }
+            catch
+            {
+                _context.Phase = ArrowOutputPhase.Faulted;
+                throw;
+            }
+        }
+
+        private void WriteEnd()
+        {
+            _context.Phase = ArrowOutputPhase.Writing;
+            try
+            {
+                if (!_ipcOptions.WriteLegacyIpcFormat)
+                {
+                    SerDe.Write(_output, -1);
+                }
+
+                SerDe.Write(_output, 0);
+                _context.Phase = ArrowOutputPhase.Ended;
+            }
+            catch
+            {
+                _context.Phase = ArrowOutputPhase.Faulted;
+                throw;
+            }
+        }
+
+        private static void Cleanup(IDisposable resource, ref Exception failure)
+        {
+            try
+            {
+                resource?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                KeepFirstFailure(ex, ref failure);
+            }
+        }
+
+        private static void KeepFirstFailure(Exception error, ref Exception failure)
+        {
+            if (failure == null)
+            {
+                failure = error;
+            }
+            else
+            {
+                try
+                {
+                    s_logger.LogError($"Arrow output cleanup failed: {error}");
+                }
+                catch (Exception)
+                {
+                    // Logging a secondary failure must not replace the original exception.
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/CommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/CommandExecutor.cs
@@ -40,12 +40,14 @@ namespace Microsoft.Spark.Worker.Command
         /// <param name="outputStream">Output stream to write results to</param>
         /// <param name="splitIndex">Split index for this task</param>
         /// <param name="commandPayload">Contains the commands to execute</param>
+        /// <param name="outputContext">Output framing for the current task</param>
         /// <returns>Statistics captured during the Execute() run</returns>
         internal CommandExecutorStat Execute(
             Stream inputStream,
             Stream outputStream,
             int splitIndex,
-            CommandPayload commandPayload)
+            CommandPayload commandPayload,
+            ArrowOutputContext outputContext = null)
         {
             if (commandPayload.EvalType == Spark.Utils.UdfUtils.PythonEvalType.NON_UDF)
             {
@@ -82,7 +84,8 @@ namespace Microsoft.Spark.Worker.Command
                 inputStream,
                 outputStream,
                 commandPayload.EvalType,
-                commandPayload.Commands.Cast<SqlCommand>().ToArray());
+                commandPayload.Commands.Cast<SqlCommand>().ToArray(),
+                outputContext ?? new ArrowOutputContext());
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.Worker/Command/DataFrameArrowBatchAdapter.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/DataFrameArrowBatchAdapter.cs
@@ -1,0 +1,541 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using Microsoft.Data.Analysis;
+
+namespace Microsoft.Spark.Worker.Command
+{
+    /// <summary>
+    /// Adds bounded Arrow conversion for regular string columns without mutating UDF results.
+    /// </summary>
+    internal static class DataFrameArrowBatchAdapter
+    {
+        internal const int MaxRowsPerBatch = 65_536;
+        internal const int MaxStringBytesPerBatch = 8 * 1024 * 1024;
+
+        internal static IEnumerable<PreparedArrowBatch> Convert(DataFrame result) =>
+            Convert(result, MaxRowsPerBatch, MaxStringBytesPerBatch, length => new byte[length]);
+
+        internal static IEnumerable<PreparedArrowBatch> Convert(
+            DataFrame result,
+            int maxRows,
+            int maxStringBytes,
+            Func<int, byte[]> allocateBuffer)
+        {
+            if (result == null)
+            {
+                throw new ArgumentException("The grouped UDF returned a null DataFrame.", nameof(result));
+            }
+
+            if (result.Columns.Count == 0)
+            {
+                throw new ArgumentException("The grouped UDF returned a DataFrame with no columns.", nameof(result));
+            }
+
+            if (maxRows <= 0 || maxRows > MaxRowsPerBatch)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxRows));
+            }
+
+            if (maxStringBytes <= 0 || maxStringBytes > MaxStringBytesPerBatch)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxStringBytes));
+            }
+
+            if (allocateBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(allocateBuffer));
+            }
+
+            bool hasRegularString = false;
+            foreach (DataFrameColumn column in result.Columns)
+            {
+                if (column.Length != result.Rows.Count)
+                {
+                    throw new ArgumentException($"Column '{column.Name}' has an inconsistent length.", nameof(result));
+                }
+
+                hasRegularString |= column is StringDataFrameColumn;
+            }
+
+            if (!hasRegularString)
+            {
+                // Preserve existing export behavior for results outside the new mixed-string path.
+                foreach (RecordBatch batch in result.ToArrowRecordBatches())
+                {
+                    using (PreparedArrowBatch prepared = PreparedArrowBatch.Own(batch))
+                    {
+                        prepared.Hold(result);
+                        yield return prepared;
+                    }
+                }
+
+                yield break;
+            }
+
+            var strings = new List<StringColumn>();
+            var numericIndices = new List<int>();
+            try
+            {
+                for (int i = 0; i < result.Columns.Count; ++i)
+                {
+                    DataFrameColumn column = result.Columns[i];
+                    Type type = column.GetType();
+                    if (type == typeof(StringDataFrameColumn) || type == typeof(ArrowStringDataFrameColumn))
+                    {
+                        strings.Add(new StringColumn(i, column));
+                    }
+                    else if (IsBuiltInPrimitive<bool, BooleanDataFrameColumn>(type))
+                    {
+                        // Booleans need bit-packed buffers, unlike MDA's byte-per-value storage.
+                    }
+                    else if (GetNumericType(type) != null)
+                    {
+                        numericIndices.Add(i);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            $"Column '{column.Name}' of type '{type.FullName}' cannot be exported " +
+                            "with a StringDataFrameColumn. Supported primitive types are " +
+                            "Boolean, SByte, Int16, Int32, Int64, Single and Double.");
+                    }
+                }
+
+                long start = 0;
+                do
+                {
+                    var byteCounts = new int[strings.Count];
+                    int count = PlanWindow(result.Rows.Count, start, strings, byteCounts, maxRows, maxStringBytes);
+                    using (PreparedArrowBatch prepared = PrepareWindow(
+                        result, start, count, strings, byteCounts, numericIndices, allocateBuffer))
+                    {
+                        yield return prepared;
+                    }
+
+                    start = checked(start + count);
+                }
+                while (start < result.Rows.Count);
+            }
+            finally
+            {
+                foreach (StringColumn column in strings)
+                {
+                    column.Dispose();
+                }
+            }
+        }
+
+        internal static int OffsetBufferLength(int count) => checked(checked(count + 1) * sizeof(int));
+
+        internal static Int64DataFrameColumn CreateRowMap(long start, int count)
+        {
+            if (start < 0 || count < 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            checked
+            {
+                _ = start + count;
+            }
+
+            var map = new Int64DataFrameColumn("__arrow_window_indices", count);
+            for (int i = 0; i < count; ++i)
+            {
+                map[i] = checked(start + i);
+            }
+
+            return map;
+        }
+
+        private static int PlanWindow(
+            long totalRows,
+            long start,
+            List<StringColumn> strings,
+            int[] byteCounts,
+            int maxRows,
+            int maxBytes)
+        {
+            int count = 0;
+            long totalBytes = 0;
+            var rowBytes = new int[strings.Count];
+            while (count < maxRows && count < totalRows - start)
+            {
+                long row = checked(start + count);
+                long rowTotal = 0;
+                for (int i = 0; i < strings.Count; ++i)
+                {
+                    rowBytes[i] = strings[i].GetByteCount(row);
+                    rowTotal = checked(rowTotal + rowBytes[i]);
+                }
+
+                if (rowTotal > maxBytes)
+                {
+                    throw new InvalidOperationException(
+                        $"Row {row} requires {rowTotal} UTF-8 string bytes, exceeding the " +
+                        $"Arrow batch limit of {maxBytes} bytes.");
+                }
+
+                if (totalBytes + rowTotal > maxBytes)
+                {
+                    break;
+                }
+
+                for (int i = 0; i < strings.Count; ++i)
+                {
+                    byteCounts[i] = checked(byteCounts[i] + rowBytes[i]);
+                    strings[i].AdvancePreflight();
+                }
+
+                totalBytes += rowTotal;
+                ++count;
+            }
+
+            return count;
+        }
+
+        private static PreparedArrowBatch PrepareWindow(
+            DataFrame result,
+            long start,
+            int count,
+            List<StringColumn> strings,
+            int[] byteCounts,
+            List<int> numericIndices,
+            Func<int, byte[]> allocateBuffer)
+        {
+            var prepared = new PreparedArrowBatch();
+            try
+            {
+                var arrays = new IArrowArray[result.Columns.Count];
+                var fields = new Field[result.Columns.Count];
+                for (int i = 0; i < strings.Count; ++i)
+                {
+                    StringColumn column = strings[i];
+                    StringArray array = BuildStringArray(column, start, count, byteCounts[i], allocateBuffer, prepared);
+                    prepared.AddOwned(array);
+                    arrays[column.Index] = array;
+                }
+
+                for (int i = 0; i < result.Columns.Count; ++i)
+                {
+                    if (IsBuiltInPrimitive<bool, BooleanDataFrameColumn>(result.Columns[i].GetType()))
+                    {
+                        BooleanArray array = BuildBooleanArray(
+                            (PrimitiveDataFrameColumn<bool>)result.Columns[i], start, count, allocateBuffer, prepared);
+                        prepared.AddOwned(array);
+                        arrays[i] = array;
+                    }
+                }
+
+                if (numericIndices.Count != 0)
+                {
+                    if (count == 0)
+                    {
+                        // MDA Clone on an empty primitive source accesses a nonexistent buffer.
+                        foreach (int index in numericIndices)
+                        {
+                            IArrowArray array = ArrowArrayFactory.BuildArray(new ArrayData(
+                                GetNumericType(result.Columns[index].GetType()), 0, 0, 0,
+                                new[] { ArrowBuffer.Empty, ArrowBuffer.Empty }));
+                            prepared.AddOwned(array);
+                            arrays[index] = array;
+                        }
+                    }
+                    else
+                    {
+                        Int64DataFrameColumn map = CreateRowMap(start, count);
+                        var columns = new List<DataFrameColumn>(numericIndices.Count);
+                        foreach (int index in numericIndices)
+                        {
+                            columns.Add(result.Columns[index].Clone(map));
+                        }
+
+                        var numericFrame = new DataFrame(columns);
+                        prepared.Hold(numericFrame);
+                        using (IEnumerator<RecordBatch> batches = numericFrame.ToArrowRecordBatches().GetEnumerator())
+                        {
+                            if (!batches.MoveNext())
+                            {
+                                throw new InvalidOperationException("The numeric Arrow window produced no batch.");
+                            }
+
+                            RecordBatch numericBatch = batches.Current;
+                            for (int i = 0; i < numericIndices.Count; ++i)
+                            {
+                                IArrowArray array = numericBatch.Column(i);
+                                prepared.AddOwned(array);
+                                arrays[numericIndices[i]] = array;
+                            }
+
+                            bool extraBatch = batches.MoveNext();
+                            if (extraBatch)
+                            {
+                                foreach (IArrowArray array in batches.Current.Arrays)
+                                {
+                                    prepared.AddOwned(array);
+                                }
+                            }
+
+                            if (numericBatch.Length != count || extraBatch)
+                            {
+                                throw new InvalidOperationException("The numeric Arrow window did not produce exactly one complete batch.");
+                            }
+                        }
+                    }
+                }
+
+                for (int i = 0; i < arrays.Length; ++i)
+                {
+                    fields[i] = new Field(result.Columns[i].Name, arrays[i].Data.DataType, arrays[i].NullCount != 0);
+                }
+
+                prepared.ReplaceBatch(new RecordBatch(new Schema(fields, null), arrays, count));
+                return prepared;
+            }
+            catch
+            {
+                prepared.DisposeAfterFailure();
+                throw;
+            }
+        }
+
+        private static StringArray BuildStringArray(
+            StringColumn column,
+            long start,
+            int count,
+            int byteCount,
+            Func<int, byte[]> allocateBuffer,
+            PreparedArrowBatch prepared)
+        {
+            byte[] values = Allocate(byteCount, allocateBuffer, prepared);
+            byte[] offsets = Allocate(OffsetBufferLength(count), allocateBuffer, prepared);
+            byte[] validity = Allocate((count + 7) / 8, allocateBuffer, prepared);
+            int offset = 0;
+            int nullCount = 0;
+            for (int i = 0; i < count; ++i)
+            {
+                bool valid;
+                int written = column.Encode(checked(start + i), values, offset, out valid);
+                if (valid)
+                {
+                    SetBit(validity, i);
+                }
+                else
+                {
+                    ++nullCount;
+                }
+
+                offset = checked(offset + written);
+                WriteOffset(offsets, i + 1, offset);
+            }
+
+            if (offset != byteCount)
+            {
+                throw new InvalidOperationException("The string column changed during Arrow conversion.");
+            }
+
+            return new StringArray(count, new ArrowBuffer(offsets), new ArrowBuffer(values),
+                new ArrowBuffer(validity), nullCount, 0);
+        }
+
+        private static BooleanArray BuildBooleanArray(
+            PrimitiveDataFrameColumn<bool> column,
+            long start,
+            int count,
+            Func<int, byte[]> allocateBuffer,
+            PreparedArrowBatch prepared)
+        {
+            int bitmapLength = (count + 7) / 8;
+            byte[] values = Allocate(bitmapLength, allocateBuffer, prepared);
+            byte[] validity = Allocate(bitmapLength, allocateBuffer, prepared);
+            int nullCount = 0;
+            for (int i = 0; i < count; ++i)
+            {
+                bool? value = column[checked(start + i)];
+                if (value.HasValue)
+                {
+                    SetBit(validity, i);
+                    if (value.Value)
+                    {
+                        SetBit(values, i);
+                    }
+                }
+                else
+                {
+                    ++nullCount;
+                }
+            }
+
+            return new BooleanArray(new ArrowBuffer(values), new ArrowBuffer(validity), count, nullCount, 0);
+        }
+
+        private static byte[] Allocate(int length, Func<int, byte[]> allocateBuffer, PreparedArrowBatch prepared)
+        {
+            byte[] buffer = allocateBuffer(length);
+            if (buffer == null || buffer.Length != length)
+            {
+                throw new InvalidOperationException("The Arrow buffer factory returned an invalid buffer.");
+            }
+
+            prepared.Hold(buffer);
+            return buffer;
+        }
+
+        private static void SetBit(byte[] bitmap, int index) => bitmap[index / 8] |= (byte)(1 << (index & 7));
+
+        private static void WriteOffset(byte[] offsets, int index, int value)
+        {
+            int position = checked(index * sizeof(int));
+            offsets[position] = (byte)value;
+            offsets[position + 1] = (byte)(value >> 8);
+            offsets[position + 2] = (byte)(value >> 16);
+            offsets[position + 3] = (byte)(value >> 24);
+        }
+
+        private static bool IsBuiltInPrimitive<T, TColumn>(Type type) where T : unmanaged =>
+            type == typeof(TColumn) || type == typeof(PrimitiveDataFrameColumn<T>);
+
+        private static IArrowType GetNumericType(Type type)
+        {
+            if (IsBuiltInPrimitive<sbyte, SByteDataFrameColumn>(type)) { return Int8Type.Default; }
+            if (IsBuiltInPrimitive<short, Int16DataFrameColumn>(type)) { return Int16Type.Default; }
+            if (IsBuiltInPrimitive<int, Int32DataFrameColumn>(type)) { return Int32Type.Default; }
+            if (IsBuiltInPrimitive<long, Int64DataFrameColumn>(type)) { return Int64Type.Default; }
+            if (IsBuiltInPrimitive<float, SingleDataFrameColumn>(type)) { return FloatType.Default; }
+            if (IsBuiltInPrimitive<double, DoubleDataFrameColumn>(type)) { return DoubleType.Default; }
+            return null;
+        }
+
+        private sealed class StringColumn : IDisposable
+        {
+            private readonly StringDataFrameColumn _regular;
+            private readonly ArrowStringCursor _preflight;
+            private readonly ArrowStringCursor _encode;
+
+            internal StringColumn(int index, DataFrameColumn column)
+            {
+                Index = index;
+                _regular = column as StringDataFrameColumn;
+                if (_regular == null)
+                {
+                    _preflight = new ArrowStringCursor((ArrowStringDataFrameColumn)column);
+                    _encode = new ArrowStringCursor((ArrowStringDataFrameColumn)column);
+                }
+            }
+
+            internal int Index { get; }
+
+            internal int GetByteCount(long row)
+            {
+                if (_regular != null)
+                {
+                    string value = _regular[row];
+                    return value == null ? 0 : Encoding.UTF8.GetByteCount(value);
+                }
+
+                return _preflight.Peek(out bool _).Length;
+            }
+
+            internal void AdvancePreflight() => _preflight?.Advance();
+
+            internal int Encode(long row, byte[] destination, int offset, out bool valid)
+            {
+                if (_regular != null)
+                {
+                    string value = _regular[row];
+                    valid = value != null;
+                    return valid ? Encoding.UTF8.GetBytes(value, 0, value.Length, destination, offset) : 0;
+                }
+
+                ReadOnlyMemory<byte> bytes = _encode.Peek(out valid);
+                bytes.Span.CopyTo(destination.AsSpan(offset));
+                _encode.Advance();
+                return bytes.Length;
+            }
+
+            public void Dispose()
+            {
+                _preflight?.Dispose();
+                _encode?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sequentially borrows one source buffer at a time. It never decodes Arrow UTF-8 strings.
+        /// </summary>
+        internal sealed class ArrowStringCursor : IDisposable
+        {
+            private readonly IEnumerator<ReadOnlyMemory<byte>> _values;
+            private readonly IEnumerator<ReadOnlyMemory<int>> _offsets;
+            private readonly IEnumerator<ReadOnlyMemory<byte>> _validity;
+            private readonly bool _allValid;
+            private int _row;
+            private bool _loaded;
+
+            internal ArrowStringCursor(ArrowStringDataFrameColumn column)
+                : this(column.GetReadOnlyDataBuffers(), column.GetReadOnlyOffsetsBuffers(),
+                    column.GetReadOnlyNullBitMapBuffers(), column.NullCount == 0)
+            {
+            }
+
+            internal ArrowStringCursor(
+                IEnumerable<ReadOnlyMemory<byte>> values,
+                IEnumerable<ReadOnlyMemory<int>> offsets,
+                IEnumerable<ReadOnlyMemory<byte>> validity,
+                bool allValid)
+            {
+                _values = values.GetEnumerator();
+                _offsets = offsets.GetEnumerator();
+                _validity = validity.GetEnumerator();
+                _allValid = allValid;
+            }
+
+            internal ReadOnlyMemory<byte> Peek(out bool valid)
+            {
+                while (!_loaded || _row == _offsets.Current.Length - 1)
+                {
+                    if (!_offsets.MoveNext() || !_values.MoveNext() || _offsets.Current.Length == 0)
+                    {
+                        throw new InvalidOperationException("The Arrow string column contains inconsistent buffers.");
+                    }
+
+                    if (!_validity.MoveNext() && !_allValid)
+                    {
+                        throw new InvalidOperationException("The Arrow string column is missing its validity buffer.");
+                    }
+
+                    _loaded = true;
+                    _row = 0;
+                }
+
+                ReadOnlySpan<int> offsets = _offsets.Current.Span;
+                int first = offsets[_row];
+                int last = offsets[_row + 1];
+                if (first < 0 || last < first || last > _values.Current.Length ||
+                    (!_allValid && _row / 8 >= _validity.Current.Length))
+                {
+                    throw new InvalidOperationException("The Arrow string column contains invalid offsets or validity bits.");
+                }
+
+                valid = _allValid || (_validity.Current.Span[_row / 8] & (1 << (_row & 7))) != 0;
+                return valid ? _values.Current.Slice(first, last - first) : ReadOnlyMemory<byte>.Empty;
+            }
+
+            internal void Advance() => ++_row;
+
+            public void Dispose()
+            {
+                _values.Dispose();
+                _offsets.Dispose();
+                _validity.Dispose();
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/PreparedArrowBatch.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/PreparedArrowBatch.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Runtime.CompilerServices;
+using Apache.Arrow;
+using Microsoft.Spark.Services;
+
+namespace Microsoft.Spark.Worker.Command
+{
+    /// <summary>
+    /// Owns array roots independently of the schema and struct views used to write a batch.
+    /// </summary>
+    internal sealed class PreparedArrowBatch : IDisposable
+    {
+        private static readonly ILoggerService s_logger =
+            LoggerServiceFactory.GetLogger(typeof(PreparedArrowBatch));
+
+        private readonly HashSet<IArrowArray> _roots =
+            new HashSet<IArrowArray>(ArrayReferenceComparer.Instance);
+        private readonly List<object> _references = new List<object>();
+        private bool _disposed;
+
+        internal RecordBatch Batch { get; private set; }
+
+        internal int OwnedRootCount => _roots.Count;
+
+        internal int HeldReferenceCount => _references.Count;
+
+        internal int ReleasedRootCount { get; private set; }
+
+        internal int ReleaseFailedRootCount { get; private set; }
+
+        internal static PreparedArrowBatch Borrow(RecordBatch batch)
+        {
+            var prepared = new PreparedArrowBatch();
+            prepared.ReplaceBatch(batch);
+            return prepared;
+        }
+
+        internal static PreparedArrowBatch Own(RecordBatch batch)
+        {
+            var prepared = Borrow(batch);
+            try
+            {
+                foreach (IArrowArray array in batch.Arrays)
+                {
+                    prepared.AddOwned(array);
+                }
+
+                return prepared;
+            }
+            catch
+            {
+                // Registration itself can fail. No roots have been disposed yet; clean
+                // the original batch by identity without allocating another root set.
+                prepared._disposed = true;
+                prepared._roots.Clear();
+                prepared.Batch = null;
+                for (int i = 0; i < batch.ColumnCount; ++i)
+                {
+                    IArrowArray root = batch.Column(i);
+                    bool duplicate = false;
+                    for (int j = 0; j < i; ++j)
+                    {
+                        duplicate |= ReferenceEquals(root, batch.Column(j));
+                    }
+
+                    if (!duplicate)
+                    {
+                        try
+                        {
+                            root.Dispose();
+                        }
+                        catch (Exception error)
+                        {
+                            LogCleanupError(error);
+                        }
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        internal void ReplaceBatch(RecordBatch batch)
+        {
+            ThrowIfDisposed();
+            Batch = batch ?? throw new ArgumentNullException(nameof(batch));
+        }
+
+        internal void AddOwned(IArrowArray array)
+        {
+            ThrowIfDisposed();
+            _roots.Add(array ?? throw new ArgumentNullException(nameof(array)));
+        }
+
+        internal void Hold(object reference)
+        {
+            ThrowIfDisposed();
+            _references.Add(reference);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            // A failed release has uncertain outcome and must never be retried.
+            _disposed = true;
+            Exception firstError = null;
+            foreach (IArrowArray root in _roots)
+            {
+                try
+                {
+                    root.Dispose();
+                    ++ReleasedRootCount;
+                }
+                catch (Exception error)
+                {
+                    ++ReleaseFailedRootCount;
+                    if (firstError == null)
+                    {
+                        firstError = error;
+                    }
+                    else
+                    {
+                        LogCleanupError(error);
+                    }
+                }
+            }
+
+            _roots.Clear();
+            _references.Clear();
+            Batch = null;
+            if (firstError != null)
+            {
+                ExceptionDispatchInfo.Capture(firstError).Throw();
+            }
+        }
+
+        internal void DisposeAfterFailure()
+        {
+            try
+            {
+                Dispose();
+            }
+            catch (Exception cleanupError)
+            {
+                LogCleanupError(cleanupError);
+            }
+        }
+
+        private static void LogCleanupError(Exception error)
+        {
+            // Diagnostics cannot replace the exception which caused preparation to fail.
+            try
+            {
+                s_logger.LogError($"Arrow batch cleanup failed: {error}");
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PreparedArrowBatch));
+            }
+        }
+
+        private sealed class ArrayReferenceComparer : IEqualityComparer<IArrowArray>
+        {
+            internal static readonly ArrayReferenceComparer Instance = new ArrayReferenceComparer();
+
+            public bool Equals(IArrowArray left, IArrowArray right) => ReferenceEquals(left, right);
+
+            public int GetHashCode(IArrowArray value) => RuntimeHelpers.GetHashCode(value);
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/SqlCommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/SqlCommandExecutor.cs
@@ -35,13 +35,15 @@ namespace Microsoft.Spark.Worker.Command
         /// <param name="outputStream">Output stream to write results to</param>
         /// <param name="evalType">Evaluation type for the current commands</param>
         /// <param name="commands">Contains the commands to execute</param>
+        /// <param name="outputContext">Output framing for the current task</param>
         /// <returns>Statistics captured during the Execute() run</returns>
         internal static CommandExecutorStat Execute(
             Version version,
             Stream inputStream,
             Stream outputStream,
             UdfUtils.PythonEvalType evalType,
-            SqlCommand[] commands)
+            SqlCommand[] commands,
+            ArrowOutputContext outputContext = null)
         {
             if (commands.Length <= 0)
             {
@@ -62,11 +64,11 @@ namespace Microsoft.Spark.Worker.Command
             }
             else if (evalType == UdfUtils.PythonEvalType.SQL_SCALAR_PANDAS_UDF)
             {
-                executor = new ArrowOrDataFrameSqlCommandExecutor(version);
+                executor = new ArrowOrDataFrameSqlCommandExecutor(version, outputContext);
             }
             else if (evalType == UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
             {
-                executor = new ArrowOrDataFrameGroupedMapCommandExecutor(version);
+                executor = new ArrowOrDataFrameGroupedMapCommandExecutor(version, outputContext);
             }
             else
             {
@@ -387,7 +389,14 @@ namespace Microsoft.Spark.Worker.Command
 
     internal abstract class ArrowBasedCommandExecutor : SqlCommandExecutor
     {
-        protected Version _version;
+        protected readonly Version _version;
+        protected readonly ArrowOutputContext _outputContext;
+
+        protected ArrowBasedCommandExecutor(Version version, ArrowOutputContext outputContext)
+        {
+            _version = version;
+            _outputContext = outputContext ?? new ArrowOutputContext();
+        }
 
         protected IpcOptions ArrowIpcOptions() =>
             new IpcOptions
@@ -428,22 +437,15 @@ namespace Microsoft.Spark.Worker.Command
             }
         }
 
-        protected void WriteEnd(Stream stream, IpcOptions ipcOptions)
-        {
-            if (!ipcOptions.WriteLegacyIpcFormat)
-            {
-                SerDe.Write(stream, -1);
-            }
-
-            SerDe.Write(stream, 0);
-        }
     }
 
     internal class ArrowOrDataFrameSqlCommandExecutor : ArrowBasedCommandExecutor
     {
-        internal ArrowOrDataFrameSqlCommandExecutor(Version version)
+        internal ArrowOrDataFrameSqlCommandExecutor(
+            Version version,
+            ArrowOutputContext outputContext = null)
+            : base(version, outputContext)
         {
-            _version = version;
         }
 
         protected internal override CommandExecutorStat ExecuteCore(
@@ -485,35 +487,25 @@ namespace Microsoft.Spark.Worker.Command
             var stat = new CommandExecutorStat();
             ICommandRunner commandRunner = CreateCommandRunner(commands);
 
-            SerDe.Write(outputStream, (int)SpecialLengths.START_ARROW_STREAM);
-
-            IpcOptions ipcOptions = ArrowIpcOptions();
-            ArrowStreamWriter writer = null;
-            Schema resultSchema = null;
-            foreach (ReadOnlyMemory<IArrowArray> input in GetArrowInputIterator(inputStream))
+            IEnumerable<PreparedArrowBatch> PrepareResults()
             {
-                IArrowArray[] results = commandRunner.Run(input);
-
-                // Assumes all columns have the same length, so uses 0th for num entries.
-                int numEntries = results[0].Length;
-                stat.NumEntriesProcessed += numEntries;
-
-                if (writer == null)
+                Schema resultSchema = null;
+                foreach (ReadOnlyMemory<IArrowArray> input in GetArrowInputIterator(inputStream))
                 {
-                    Debug.Assert(resultSchema == null);
-                    resultSchema = BuildSchema(results);
+                    IArrowArray[] results = commandRunner.Run(input);
 
-                    writer =
-                        new ArrowStreamWriter(outputStream, resultSchema, leaveOpen: true, ipcOptions);
+                    // The scalar UDF contract requires equal column lengths.
+                    int numEntries = results[0].Length;
+                    stat.NumEntriesProcessed += numEntries;
+                    resultSchema ??= BuildSchema(results);
+
+                    yield return PreparedArrowBatch.Borrow(
+                        new RecordBatch(resultSchema, results, numEntries));
                 }
-
-                var recordBatch = new RecordBatch(resultSchema, results, numEntries);
-
-                writer.WriteRecordBatch(recordBatch);
             }
 
-            WriteEnd(outputStream, ipcOptions);
-            writer?.Dispose();
+            new ArrowOutputSession(outputStream, ArrowIpcOptions(), _outputContext)
+                .Write(PrepareResults());
 
             return stat;
         }
@@ -526,40 +518,29 @@ namespace Microsoft.Spark.Worker.Command
             var stat = new CommandExecutorStat();
             ICommandRunner commandRunner = CreateCommandRunner(commands);
 
-            SerDe.Write(outputStream, (int)SpecialLengths.START_ARROW_STREAM);
-
-            IpcOptions ipcOptions = ArrowIpcOptions();
-            ArrowStreamWriter writer = null;
-            foreach (RecordBatch input in GetInputIterator(inputStream))
+            IEnumerable<PreparedArrowBatch> PrepareResults()
             {
-                FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(input);
-                var inputColumns = new DataFrameColumn[input.ColumnCount];
-                for (int i = 0; i < dataFrame.Columns.Count; ++i)
+                foreach (RecordBatch input in GetInputIterator(inputStream))
                 {
-                    inputColumns[i] = dataFrame.Columns[i];
-                }
-
-                DataFrameColumn[] results = commandRunner.Run(inputColumns);
-
-                var resultDataFrame = new FxDataFrame(results);
-                IEnumerable<RecordBatch> recordBatches = resultDataFrame.ToArrowRecordBatches();
-
-                foreach (RecordBatch result in recordBatches)
-                {
-                    stat.NumEntriesProcessed += result.Length;
-
-                    if (writer == null)
+                    FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(input);
+                    var inputColumns = new DataFrameColumn[input.ColumnCount];
+                    for (int i = 0; i < dataFrame.Columns.Count; ++i)
                     {
-                        writer =
-                            new ArrowStreamWriter(outputStream, result.Schema, leaveOpen: true, ipcOptions);
+                        inputColumns[i] = dataFrame.Columns[i];
                     }
 
-                    writer.WriteRecordBatch(result);
+                    DataFrameColumn[] results = commandRunner.Run(inputColumns);
+                    var resultDataFrame = new FxDataFrame(results);
+                    foreach (RecordBatch result in resultDataFrame.ToArrowRecordBatches())
+                    {
+                        stat.NumEntriesProcessed += result.Length;
+                        yield return PreparedArrowBatch.Own(result);
+                    }
                 }
             }
 
-            WriteEnd(outputStream, ipcOptions);
-            writer?.Dispose();
+            new ArrowOutputSession(outputStream, ArrowIpcOptions(), _outputContext)
+                .Write(PrepareResults());
 
             return stat;
         }
@@ -784,8 +765,10 @@ namespace Microsoft.Spark.Worker.Command
 
     internal class ArrowOrDataFrameGroupedMapCommandExecutor : ArrowOrDataFrameSqlCommandExecutor
     {
-        internal ArrowOrDataFrameGroupedMapCommandExecutor(Version version)
-            : base(version)
+        internal ArrowOrDataFrameGroupedMapCommandExecutor(
+            Version version,
+            ArrowOutputContext outputContext = null)
+            : base(version, outputContext)
         {
         }
 
@@ -856,29 +839,20 @@ namespace Microsoft.Spark.Worker.Command
             var stat = new CommandExecutorStat();
             var worker = (ArrowGroupedMapWorkerFunction)commands[0].WorkerFunction;
 
-            SerDe.Write(outputStream, (int)SpecialLengths.START_ARROW_STREAM);
-
-            IpcOptions ipcOptions = ArrowIpcOptions();
-            ArrowStreamWriter writer = null;
-            foreach (RecordBatch input in GetInputIterator(inputStream))
+            IEnumerable<PreparedArrowBatch> PrepareResults()
             {
-                RecordBatch batch = worker.Func(input);
-
-                RecordBatch final = WrapColumnsInStructIfApplicable(batch);
-                int numEntries = final.Length;
-                stat.NumEntriesProcessed += numEntries;
-
-                if (writer == null)
+                foreach (RecordBatch input in GetInputIterator(inputStream))
                 {
-                    writer =
-                        new ArrowStreamWriter(outputStream, final.Schema, leaveOpen: true, ipcOptions);
-                }
+                    RecordBatch batch = worker.Func(input);
+                    RecordBatch final = WrapColumnsInStructIfApplicable(batch);
+                    stat.NumEntriesProcessed += final.Length;
 
-                writer.WriteRecordBatch(final);
+                    yield return PreparedArrowBatch.Borrow(final);
+                }
             }
 
-            WriteEnd(outputStream, ipcOptions);
-            writer?.Dispose();
+            new ArrowOutputSession(outputStream, ArrowIpcOptions(), _outputContext)
+                .Write(PrepareResults());
 
             return stat;
         }
@@ -894,34 +868,41 @@ namespace Microsoft.Spark.Worker.Command
             var stat = new CommandExecutorStat();
             var worker = (DataFrameGroupedMapWorkerFunction)commands[0].WorkerFunction;
 
-            SerDe.Write(outputStream, (int)SpecialLengths.START_ARROW_STREAM);
-
-            IpcOptions ipcOptions = ArrowIpcOptions();
-            ArrowStreamWriter writer = null;
-            foreach (RecordBatch input in GetInputIterator(inputStream))
+            IEnumerable<PreparedArrowBatch> PrepareResults()
             {
-                FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(input);
-                FxDataFrame resultDataFrame = worker.Func(dataFrame);
-
-                IEnumerable<RecordBatch> recordBatches = resultDataFrame.ToArrowRecordBatches();
-
-                foreach (RecordBatch batch in recordBatches)
+                foreach (RecordBatch input in GetInputIterator(inputStream))
                 {
-                    RecordBatch final = WrapColumnsInStructIfApplicable(batch);
-                    stat.NumEntriesProcessed += final.Length;
+                    FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(input);
+                    FxDataFrame resultDataFrame = worker.Func(dataFrame);
 
-                    if (writer == null)
+                    foreach (PreparedArrowBatch prepared in
+                        DataFrameArrowBatchAdapter.Convert(resultDataFrame))
                     {
-                        writer =
-                            new ArrowStreamWriter(outputStream, final.Schema, leaveOpen: true, ipcOptions);
-                    }
+                        try
+                        {
+                            RecordBatch batch = prepared.Batch;
+                            // MDA infers physical nullability from each group's values. A stable
+                            // nullable field allows later groups to contain nulls or no rows.
+                            Field[] fields = batch.Schema.FieldsList.Select(field =>
+                                new Field(field.Name, field.DataType, true, field.Metadata)).ToArray();
+                            var normalized = new RecordBatch(
+                                new Schema(fields, batch.Schema.Metadata), batch.Arrays, batch.Length);
+                            prepared.ReplaceBatch(WrapColumnsInStructIfApplicable(normalized));
+                        }
+                        catch
+                        {
+                            prepared.DisposeAfterFailure();
+                            throw;
+                        }
 
-                    writer.WriteRecordBatch(final);
+                        stat.NumEntriesProcessed += prepared.Batch.Length;
+                        yield return prepared;
+                    }
                 }
             }
 
-            WriteEnd(outputStream, ipcOptions);
-            writer?.Dispose();
+            new ArrowOutputSession(outputStream, ArrowIpcOptions(), _outputContext)
+                .Write(PrepareResults());
 
             return stat;
         }

--- a/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
+++ b/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Spark.Worker
             out bool readComplete)
         {
             readComplete = false;
+            var outputContext = new ArrowOutputContext();
 
             try
             {
@@ -155,10 +156,14 @@ namespace Microsoft.Spark.Worker
                     inputStream,
                     outputStream,
                     payload.SplitIndex,
-                    payload.Command);
+                    payload.Command,
+                    outputContext);
 
                 DateTime finishTime = DateTime.UtcNow;
 
+                // After any success-trailer byte, the peer is reading that trailer's payload,
+                // not another outer exception marker. This remains true during the handshake.
+                outputContext.BeginSuccessTail();
                 WriteDiagnosticsInfo(outputStream, bootTime, initTime, finishTime);
 
                 // Mark the beginning of the accumulators section of the output
@@ -193,24 +198,39 @@ namespace Microsoft.Spark.Worker
             }
             catch (Exception e)
             {
-                s_logger.LogError($"[{TaskId}] ProcessStream() failed with exception: {e}");
+                LogException(
+                    $"ProcessStream() failed at ArrowPhase={outputContext.Phase}, " +
+                    $"SuccessTailStarted={outputContext.SuccessTailStarted}", e);
 
-                try
+                if (outputContext.CanWriteException)
                 {
-                    SerDe.Write(outputStream, (int)SpecialLengths.PYTHON_EXCEPTION_THROWN);
-                    SerDe.Write(outputStream, e.ToString());
-                }
-                catch (IOException)
-                {
-                    // JVM closed the socket.
-                }
-                catch (Exception ex)
-                {
-                    s_logger.LogError(
-                        $"[{TaskId}] Writing exception to stream failed with exception: {ex}");
+                    try
+                    {
+                        SerDe.Write(outputStream, (int)SpecialLengths.PYTHON_EXCEPTION_THROWN);
+                        SerDe.Write(outputStream, e.ToString());
+                        outputStream.Flush();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Reporting is best effort; preserve the original task failure.
+                        LogException("Writing exception to stream failed with exception", ex);
+                    }
                 }
 
                 throw;
+            }
+        }
+
+        private void LogException(string message, Exception error)
+        {
+            try
+            {
+                s_logger.LogError($"[{TaskId}] {message}: {error}");
+            }
+            catch (Exception)
+            {
+                // A failed diagnostic sink must not hide the task failure or prevent its
+                // permitted best-effort report to the JVM.
             }
         }
 


### PR DESCRIPTION
Fixes #1231

Grouped DataFrame UDFs returning `StringDataFrameColumn` can fail during Arrow conversion. If the failure occurs after the Arrow stream starts, the JVM may misinterpret the exception payload as Arrow data and report a misleading `ByteBuffer.allocate` error.

This change:
- Adds bounded Arrow conversion for ordinary string columns, preserving nulls, empty strings, Unicode, empty results, and supported mixed primitive types.
- Keeps grouped output schemas consistent across empty and non-empty groups.
- Updates all four Arrow UDF output paths to prepare the first batch before starting the stream, close intact streams before reporting errors, and stop writing after a partial write failure.
- Preserves the original .NET exception even when cleanup or diagnostic logging fails.

Validation:
- Worker builds passed for `net472`, `net48`, and `net8.0`.
- Worker unit tests: 224 passed; one Linux-only test skipped on Windows.
- Spark 3.3.4 + Java 11 + .NET 8 E2E: 9 passed, including the issue reproduction, empty/mixed/null cases, original exception propagation, and existing four-path Arrow regressions.

