### PR TITLE
Add Spark 4.0 scalar Arrow UDF and grouped-map support

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -232,7 +232,7 @@ extends:
             - ${{ each pool in parameters.listOfE2ETestsPoolTypes }}:
               - pool: ${{ pool }}
                 ${{ if startsWith(version, '4.0.') }}:
-                  testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+                  testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
                 ${{ else }}:
                   testOptions: ""
                 backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_${{ pool }}_${{ split(version, '.')[0] }}_${{ split(version, '.')[1] }})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -487,11 +487,11 @@ stages:
       enableBackwardCompatibleTests: false
       jobOptions:
       - pool: 'Windows'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Windows_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Windows_4_0)
       - pool: 'Linux'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Linux_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Linux_4_0)
     - version: '4.0.1'
@@ -499,11 +499,11 @@ stages:
       enableBackwardCompatibleTests: false
       jobOptions:
       - pool: 'Windows'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Windows_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Windows_4_0)
       - pool: 'Linux'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Linux_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Linux_4_0)
     - version: '4.0.2'
@@ -511,11 +511,11 @@ stages:
       enableBackwardCompatibleTests: false
       jobOptions:
       - pool: 'Windows'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Windows_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Windows_4_0)
       - pool: 'Linux'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Linux_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Linux_4_0)
     - version: '4.0.3'
@@ -523,11 +523,11 @@ stages:
       enableBackwardCompatibleTests: false
       jobOptions:
       - pool: 'Windows'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Windows_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Windows_4_0)
       - pool: 'Linux'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Linux_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Linux_4_0)
     - version: '4.0.4'
@@ -535,10 +535,10 @@ stages:
       enableBackwardCompatibleTests: false
       jobOptions:
       - pool: 'Windows'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Windows_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Windows_4_0)
       - pool: 'Linux'
-        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast"'
+        testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
         backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_Linux_4_0)
         forwardCompatibleTestOptions: $(forwardCompatibleTestOptions_Linux_4_0)

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/ArrowUdfCompatibilityTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/ArrowUdfCompatibilityTests.cs
@@ -1,0 +1,448 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Apache.Arrow;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.E2ETest.Utils;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
+using Xunit;
+using Column = Microsoft.Spark.Sql.Column;
+using DataFrame = Microsoft.Spark.Sql.DataFrame;
+using FxDataFrame = Microsoft.Data.Analysis.DataFrame;
+
+namespace Microsoft.Spark.E2ETest.IpcTests
+{
+    [Collection("Spark E2E Tests")]
+    [Trait("Category", "ArrowUdf")]
+    public class ArrowUdfCompatibilityTests
+    {
+        private readonly SparkSession _spark;
+
+        public ArrowUdfCompatibilityTests(SparkFixture fixture)
+        {
+            _spark = fixture.Spark;
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V3_0_0, Versions.V4_1_0)]
+        public void ScalarUdfsPreserveNullsAcrossBatchesAndChains()
+        {
+            WithSqlConfig("spark.sql.execution.arrow.maxRecordsPerBatch", "2", () =>
+            {
+                foreach (bool useDataFrame in new[] { false, true })
+                {
+                    DataFrame input = _spark.Range(0, 7, 1, 1).SelectExpr(
+                        "id", "case when id % 2 = 0 then cast(null as string) " +
+                        "else concat('row-', cast(id as string)) end as label");
+                    Func<Column, Column> increment = useDataFrame ?
+                        DataFrameFunctions.VectorUdf<Int64DataFrameColumn, Int64DataFrameColumn>(
+                            values => IncrementBatch(values)) :
+                        ArrowFunctions.VectorUdf<Int64Array, Int64Array>(
+                            values => IncrementBatch(values));
+                    Func<Column, Column> identity = useDataFrame ?
+                        DataFrameFunctions.VectorUdf<ArrowStringDataFrameColumn,
+                            ArrowStringDataFrameColumn>(values => values) :
+                        ArrowFunctions.VectorUdf<StringArray, StringArray>(values => values);
+
+                    Row[] rows = input.Select(input["id"],
+                        increment(increment(input["id"])), identity(input["label"]))
+                        .Collect().ToArray();
+
+                    Assert.Equal(7, rows.Length);
+                    for (int i = 0; i < rows.Length; ++i)
+                    {
+                        Assert.Equal((long)i, rows[i].GetAs<long>(0));
+                        Assert.Equal(i + 2L, rows[i].GetAs<long>(1));
+                        Assert.Equal(i % 2 == 0 ? null : $"row-{i}",
+                            rows[i].GetAs<string>(2));
+                    }
+                }
+            });
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V3_0_0, Versions.V4_1_0)]
+        public void ScalarUdfsAcceptTenArguments()
+        {
+            DataFrame input = _spark.Range(0, 3, 1, 1).SelectExpr(
+                Enumerable.Range(0, 10).Select(i => $"id + {i} as c{i}").ToArray());
+            Column[] columns = input.Columns().Select(name => input[name]).ToArray();
+            var arrow = ArrowFunctions.VectorUdf<Int64Array, Int64Array, Int64Array,
+                Int64Array, Int64Array, Int64Array, Int64Array, Int64Array,
+                Int64Array, Int64Array, Int64Array>(
+                (a, b, c, d, e, f, g, h, i, j) => SumColumns(a, b, c, d, e, f, g, h, i, j));
+            var dataFrame = DataFrameFunctions.VectorUdf<Int64DataFrameColumn,
+                Int64DataFrameColumn, Int64DataFrameColumn, Int64DataFrameColumn,
+                Int64DataFrameColumn, Int64DataFrameColumn, Int64DataFrameColumn,
+                Int64DataFrameColumn, Int64DataFrameColumn, Int64DataFrameColumn,
+                Int64DataFrameColumn>(
+                (a, b, c, d, e, f, g, h, i, j) => SumColumns(a, b, c, d, e, f, g, h, i, j));
+
+            // Keep the representations in separate tasks: mixing them is unsupported.
+            foreach (Column result in new[]
+            {
+                arrow(columns[0], columns[1], columns[2], columns[3], columns[4],
+                    columns[5], columns[6], columns[7], columns[8], columns[9]),
+                dataFrame(columns[0], columns[1], columns[2], columns[3], columns[4],
+                    columns[5], columns[6], columns[7], columns[8], columns[9])
+            })
+            {
+                Assert.Equal(new long[] { 45, 55, 65 }, input.Select(result).Collect()
+                    .Select(row => row.GetAs<long>(0)).ToArray());
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void EmptyInputDoesNotInvokeScalarOrGroupedUdfs()
+        {
+            DataFrame empty = _spark.Range(0, 0, 1, 2);
+            var arrow = ArrowFunctions.VectorUdf<Int64Array, Int64Array>(values =>
+                throw new InvalidOperationException("An empty input must not invoke the UDF."));
+            var dataFrame = DataFrameFunctions.VectorUdf<Int64DataFrameColumn,
+                Int64DataFrameColumn>(values =>
+                throw new InvalidOperationException("An empty input must not invoke the UDF."));
+            Assert.Empty(empty.Select(arrow(empty["id"])).Collect());
+            Assert.Empty(empty.Select(dataFrame(empty["id"])).Collect());
+            Assert.Empty(empty.GroupBy("id").Apply(empty.Schema(),
+                (RecordBatch batch) => throw new InvalidOperationException(
+                    "An empty input must not create a synthetic group.")).Collect());
+            Assert.Empty(empty.GroupBy("id").Apply(empty.Schema(),
+                (FxDataFrame batch) => throw new InvalidOperationException(
+                    "An empty input must not create a synthetic group.")).Collect());
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void GroupedUdfsProjectOriginalColumnsForOverlappingAndComputedKeys()
+        {
+            DataFrame input = _spark.Range(0, 6, 1, 1).SelectExpr(
+                new[] { "cast(id % 2 as int) as c0" }.Concat(
+                    Enumerable.Range(1, 11).Select(i => $"cast(id + {i} as int) as c{i}"))
+                    .ToArray());
+            Row[] expected = input.OrderBy("c1").Collect().ToArray();
+
+            foreach (bool useDataFrame in new[] { false, true })
+            {
+                foreach (Column key in new[] { input["c0"], Functions.Expr("c1 % 3") })
+                {
+                    RelationalGroupedDataset grouped = input.GroupBy(key);
+                    DataFrame result = useDataFrame ?
+                        grouped.Apply(input.Schema(), (FxDataFrame batch) => CheckWideGroup(batch)) :
+                        grouped.Apply(input.Schema(), (RecordBatch batch) => CheckWideGroup(batch));
+                    Row[] actual = result.OrderBy("c1").Collect().ToArray();
+                    Assert.Equal(expected.Length, actual.Length);
+                    for (int row = 0; row < actual.Length; ++row)
+                    {
+                        for (int column = 0; column < 12; ++column)
+                        {
+                            Assert.Equal(expected[row].GetAs<int>(column),
+                                actual[row].GetAs<int>(column));
+                        }
+                    }
+                }
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void GroupedUdfsAllowZeroRowsAndNoGroupingKeys()
+        {
+            DataFrame input = _spark.Range(0, 3, 1, 1).SelectExpr("cast(id as int) as value");
+            foreach (RelationalGroupedDataset grouped in new[]
+            {
+                input.GroupBy("value"), input.GroupBy()
+            })
+            {
+                Assert.Empty(grouped.Apply(input.Schema(), (RecordBatch batch) =>
+                    new RecordBatch(batch.Schema,
+                        new IArrowArray[] { new Int32Array.Builder().Build() }, 0)).Collect());
+                Assert.Empty(grouped.Apply(input.Schema(), (FxDataFrame batch) =>
+                    new FxDataFrame(new Int32DataFrameColumn("value"))).Collect());
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void ZeroColumnGroupedInputPreservesRowCount()
+        {
+            RelationalGroupedDataset grouped = _spark.Range(0, 3, 1, 1)
+                .Select(System.Array.Empty<Column>()).GroupBy();
+            var schema = new StructType(new[]
+            {
+                new StructField("count", new LongType(), false)
+            });
+
+            DataFrame arrow = grouped.Apply(schema, (RecordBatch batch) =>
+            {
+                if (batch.ColumnCount != 0)
+                {
+                    throw new InvalidOperationException("Expected a zero-column Arrow group.");
+                }
+
+                return new RecordBatch(new Schema(new[]
+                {
+                    new Field("count", Apache.Arrow.Types.Int64Type.Default, false)
+                }, null), new IArrowArray[]
+                {
+                    new Int64Array.Builder().Append(batch.Length).Build()
+                }, 1);
+            });
+            DataFrame dataFrame = grouped.Apply(schema, (FxDataFrame batch) =>
+            {
+                if (batch.Columns.Count != 0)
+                {
+                    throw new InvalidOperationException("Expected a zero-column DataFrame group.");
+                }
+
+                return new FxDataFrame(new Int64DataFrameColumn(
+                    "count", new long[] { batch.Rows.Count }));
+            });
+
+            Assert.Equal(3L, Assert.Single(arrow.Collect()).GetAs<long>(0));
+            Assert.Equal(3L, Assert.Single(dataFrame.Collect()).GetAs<long>(0));
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void GroupedArrowTimestampPreservesEpochInSessionTimeZones()
+        {
+            foreach (string timeZone in new[] { "UTC", "America/Los_Angeles" })
+            {
+                WithSqlConfig("spark.sql.session.timeZone", timeZone, () =>
+                {
+                    DataFrame input = _spark.Range(0, 3, 1, 1).SelectExpr(
+                        "id", "timestamp_seconds(1700000000 + id) as eventTime");
+                    DataFrame result = input.GroupBy("id").Apply(input.Schema(),
+                        (RecordBatch batch) => batch);
+                    Row[] rows = result.OrderBy("id").SelectExpr(
+                        "id", "unix_micros(eventTime) as micros").Collect().ToArray();
+                    Assert.Equal(3, rows.Length);
+                    for (int i = 0; i < rows.Length; ++i)
+                    {
+                        Assert.Equal((long)i, rows[i].GetAs<long>(0));
+                        Assert.Equal((1700000000L + i) * 1000000, rows[i].GetAs<long>(1));
+                    }
+                });
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void GroupedUdfsRejectMismatchedSchemasAndAllowNextTask()
+        {
+            var schema = new StructType(new[]
+            {
+                new StructField("a", new IntegerType(), false),
+                new StructField("b", new IntegerType())
+            });
+            foreach (bool useDataFrame in new[] { false, true })
+            {
+                foreach (string mismatch in new[] { "missing", "extra", "type", "null" })
+                {
+                    RelationalGroupedDataset grouped = _spark.Range(1).GroupBy("id");
+                    DataFrame result = useDataFrame ?
+                        grouped.Apply(schema, (FxDataFrame batch) => InvalidDataFrame(mismatch)) :
+                        grouped.Apply(schema, (RecordBatch batch) => InvalidArrowBatch(mismatch));
+                    Exception error = Assert.ThrowsAny<Exception>(() => result.Collect().ToArray());
+                    Assert.Contains("InvalidDataException", error.ToString());
+                    AssertHealthyScalarTask(useDataFrame);
+                }
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void ScalarUdfsRejectWrongResultLengthAndAllowNextTask()
+        {
+            foreach (bool useDataFrame in new[] { false, true })
+            {
+                DataFrame input = _spark.Range(0, 2, 1, 1);
+                Func<Column, Column> shorten = useDataFrame ?
+                    DataFrameFunctions.VectorUdf<Int64DataFrameColumn, Int64DataFrameColumn>(
+                        values => new Int64DataFrameColumn("value")) :
+                    ArrowFunctions.VectorUdf<Int64Array, Int64Array>(
+                        values => new Int64Array.Builder().Build());
+                Exception error = Assert.ThrowsAny<Exception>(() =>
+                    input.Select(shorten(input["id"])).Collect().ToArray());
+                Assert.Contains("InvalidDataException", error.ToString());
+                AssertHealthyScalarTask(useDataFrame);
+            }
+        }
+
+        [SkipIfSparkVersionIsNotInRange(Versions.V4_0_0, Versions.V4_1_0)]
+        public void ScalarFailuresBeforeAndAfterFirstBatchAllowNextTask()
+        {
+            WithSqlConfig("spark.sql.execution.arrow.maxRecordsPerBatch", "2", () =>
+            {
+                foreach (bool useDataFrame in new[] { false, true })
+                {
+                    foreach (long failingValue in new long[] { 0, 2 })
+                    {
+                        DataFrame input = _spark.Range(0, 6, 1, 1);
+                        Func<Column, Column> fail = useDataFrame ?
+                            DataFrameFunctions.VectorUdf<Int64DataFrameColumn, Int64DataFrameColumn>(
+                                values => FailAtBatch(values, failingValue)) :
+                            ArrowFunctions.VectorUdf<Int64Array, Int64Array>(
+                                values => FailAtBatch(values, failingValue));
+                        Exception error = Assert.ThrowsAny<Exception>(() =>
+                            input.Select(fail(input["id"])).Collect().ToArray());
+                        Assert.Contains("Arrow batch delegate failure.", error.ToString());
+                        AssertHealthyScalarTask(useDataFrame);
+                    }
+                }
+            });
+        }
+
+        private void AssertHealthyScalarTask(bool useDataFrame)
+        {
+            DataFrame input = _spark.Range(0, 3, 1, 1);
+            Func<Column, Column> identity = useDataFrame ?
+                DataFrameFunctions.VectorUdf<Int64DataFrameColumn, Int64DataFrameColumn>(
+                    values => values) :
+                ArrowFunctions.VectorUdf<Int64Array, Int64Array>(values => values);
+            Assert.Equal(new long[] { 0, 1, 2 }, input.Select(identity(input["id"]))
+                .Collect().Select(row => row.GetAs<long>(0)).ToArray());
+        }
+
+        private void WithSqlConfig(string key, string value, Action action)
+        {
+            RuntimeConfig config = _spark.Conf();
+            string previous = config.Get(key);
+            try
+            {
+                config.Set(key, value);
+                action();
+            }
+            finally
+            {
+                config.Set(key, previous);
+            }
+        }
+
+        private static Int64Array IncrementBatch(Int64Array values)
+        {
+            CheckBatchLength(values.Length);
+            var output = new Int64Array.Builder();
+            for (int i = 0; i < values.Length; ++i)
+            {
+                output.Append(values.GetValue(i).Value + 1);
+            }
+
+            return output.Build();
+        }
+
+        private static Int64DataFrameColumn IncrementBatch(Int64DataFrameColumn values)
+        {
+            CheckBatchLength(values.Length);
+            var output = new Int64DataFrameColumn("value");
+            for (long i = 0; i < values.Length; ++i)
+            {
+                output.Append(values[i] + 1);
+            }
+
+            return output;
+        }
+
+        private static void CheckBatchLength(long length)
+        {
+            if (length > 2)
+            {
+                throw new InvalidOperationException("The configured Arrow batch limit was not used.");
+            }
+        }
+
+        private static Int64Array SumColumns(params Int64Array[] columns)
+        {
+            var output = new Int64Array.Builder();
+            for (int i = 0; i < columns[0].Length; ++i)
+            {
+                output.Append(columns.Sum(column => column.GetValue(i).Value));
+            }
+
+            return output.Build();
+        }
+
+        private static Int64DataFrameColumn SumColumns(params Int64DataFrameColumn[] columns)
+        {
+            var output = new Int64DataFrameColumn("sum");
+            for (long i = 0; i < columns[0].Length; ++i)
+            {
+                output.Append(columns.Sum(column => column[i].Value));
+            }
+
+            return output;
+        }
+
+        private static RecordBatch CheckWideGroup(RecordBatch batch)
+        {
+            if (batch.ColumnCount != 12 || batch.Schema.GetFieldByIndex(0).Name != "c0" ||
+                batch.Schema.GetFieldByIndex(11).Name != "c11")
+            {
+                throw new InvalidOperationException("The grouped UDF did not receive original columns.");
+            }
+
+            return batch;
+        }
+
+        private static FxDataFrame CheckWideGroup(FxDataFrame batch)
+        {
+            if (batch.Columns.Count != 12 || batch.Columns[0].Name != "c0" ||
+                batch.Columns[11].Name != "c11")
+            {
+                throw new InvalidOperationException("The grouped UDF did not receive original columns.");
+            }
+
+            return batch;
+        }
+
+        private static RecordBatch InvalidArrowBatch(string mismatch)
+        {
+            int count = mismatch == "missing" ? 1 : mismatch == "extra" ? 3 : 2;
+            var fields = new Field[count];
+            var columns = new IArrowArray[count];
+            for (int i = 0; i < count; ++i)
+            {
+                columns[i] = i == 0 && mismatch == "type" ?
+                    (IArrowArray)new Int64Array.Builder().Append(1).Build() :
+                    i == 0 && mismatch == "null" ?
+                    new Int32Array.Builder().AppendNull().Build() :
+                    new Int32Array.Builder().Append(1).Build();
+                fields[i] = new Field($"c{i}", columns[i].Data.DataType, true);
+            }
+
+            return new RecordBatch(new Schema(fields, null), columns, 1);
+        }
+
+        private static FxDataFrame InvalidDataFrame(string mismatch)
+        {
+            int count = mismatch == "missing" ? 1 : mismatch == "extra" ? 3 : 2;
+            var columns = new DataFrameColumn[count];
+            for (int i = 0; i < count; ++i)
+            {
+                columns[i] = i == 0 && mismatch == "type" ?
+                    (DataFrameColumn)new Int64DataFrameColumn($"c{i}", new long[] { 1 }) :
+                    new Int32DataFrameColumn($"c{i}",
+                        new int?[] { i == 0 && mismatch == "null" ? null : (int?)1 });
+            }
+
+            return new FxDataFrame(columns);
+        }
+
+        private static Int64Array FailAtBatch(Int64Array values, long failingValue)
+        {
+            if (values.Length != 0 && values.GetValue(0) == failingValue)
+            {
+                throw new InvalidOperationException("Arrow batch delegate failure.");
+            }
+
+            return values;
+        }
+
+        private static Int64DataFrameColumn FailAtBatch(
+            Int64DataFrameColumn values, long failingValue)
+        {
+            if (values.Length != 0 && values[0] == failingValue)
+            {
+                throw new InvalidOperationException("Arrow batch delegate failure.");
+            }
+
+            return values;
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/Sql/DataFrameTests.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         [Fact]
+        [Trait("Category", "ArrowUdf")]
         public void TestVectorUdf()
         {
             Func<Int32Array, StringArray, StringArray> udf1Func =
@@ -226,6 +227,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         [Fact]
+        [Trait("Category", "ArrowUdf")]
         public void TestDataFrameVectorUdf()
         {
             Func<Int32DataFrameColumn, ArrowStringDataFrameColumn, ArrowStringDataFrameColumn> udf1Func =
@@ -291,6 +293,7 @@ namespace Microsoft.Spark.E2ETest.IpcTests
         }
 
         [Fact]
+        [Trait("Category", "ArrowUdf")]
         public void TestGroupedMapUdf()
         {
             DataFrame df = _spark
@@ -354,6 +357,13 @@ namespace Microsoft.Spark.E2ETest.IpcTests
 
             // Return 1 record, if we were given any. 0, otherwise.
             int returnLength = records.Length > 0 ? 1 : 0;
+            var age = new Int32Array.Builder();
+            var count = new Int32Array.Builder();
+            if (returnLength != 0)
+            {
+                age.Append(((Int32Array)records.Column(ageFieldIndex)).GetValue(0));
+                count.Append(characterCount);
+            }
 
             return new RecordBatch(
                 new Schema.Builder()
@@ -362,13 +372,14 @@ namespace Microsoft.Spark.E2ETest.IpcTests
                     .Build(),
                 new IArrowArray[]
                 {
-                    records.Column(ageFieldIndex),
-                    new Int32Array.Builder().Append(characterCount).Build()
+                    age.Build(),
+                    count.Build()
                 },
                 returnLength);
         }
 
         [Fact]
+        [Trait("Category", "ArrowUdf")]
         public void TestDataFrameGroupedMapUdf()
         {
             DataFrame df = _spark

--- a/src/csharp/Microsoft.Spark.UnitTest/Spark40ArrowCommandSerDeTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Spark40ArrowCommandSerDeTests.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Apache.Arrow;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
+using Microsoft.Spark.Utils;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    [Collection("Spark Unit Tests")]
+    public class Spark40ArrowCommandSerDeTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedSchemaTailPreservesLegacyEnvelopeBytes(bool dataFrame)
+        {
+            Delegate wrapper = GroupedWrapper(dataFrame);
+            byte[] legacy = CommandSerDe.Serialize(wrapper,
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            var schema = new StructType(new[] { new StructField("value", new IntegerType(), false) });
+            byte[] extended = CommandSerDe.SerializeSpark40GroupedMap(wrapper, schema);
+            Assert.Equal(extended, CommandSerDe.SerializeSpark40GroupedMap(wrapper, schema.Json));
+            Assert.Equal(legacy, extended.Take(legacy.Length));
+            using var stream = new MemoryStream(extended);
+            stream.Position = legacy.Length;
+            Assert.Equal(schema.Json, SerDe.ReadString(stream));
+            Assert.Equal(stream.Length, stream.Position);
+            Assert.Equal(dataFrame, CommandSerDe.PreflightSpark40Arrow(extended, 20, true,
+                out StructType parsed, out bool isRepl));
+            Assert.Equal(schema.Json, parsed.Json);
+            Assert.False(isRepl);
+            if (dataFrame)
+            {
+                Assert.NotNull(CommandSerDe.DeserializeSpark40Arrow<
+                    DataFrameGroupedMapWorkerFunction.ExecuteDelegate>(
+                        extended, 20, true, out _, out _));
+            }
+            else
+            {
+                Assert.NotNull(CommandSerDe.DeserializeSpark40Arrow<
+                    ArrowGroupedMapWorkerFunction.ExecuteDelegate>(
+                        extended, 20, true, out _, out _));
+            }
+        }
+
+        [Fact]
+        public void MissingGroupedSchemaIsRejected()
+        {
+            byte[] command = CommandSerDe.Serialize(GroupedWrapper(false),
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            Assert.Throws<InvalidDataException>(() =>
+                CommandSerDe.PreflightSpark40Arrow(command, 1, true, out _, out _));
+        }
+
+        [Fact]
+        public void ColumnMetadataIsNotInterpretedAsADataType()
+        {
+            const string Json = "{\"type\":\"struct\",\"fields\":[{\"name\":\"value\"," +
+                "\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"type\":\"udt\"}}]}";
+            Assert.False(CommandSerDe.PreflightSpark40Arrow(WithSchema(Json), 1, true,
+                out StructType schema, out _));
+            Assert.Equal("udt", (string)schema.Fields[0].Metadata["type"]);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("{")]
+        [InlineData("\"integer\"")]
+        [InlineData("{\"type\":\"struct\",\"fields\":[]}{ }")]
+        [InlineData("{\"type\":\"struct\",\"type\":\"struct\",\"fields\":[]}")]
+        [InlineData("{\"type\":\"struct\",\"fields\":[{\"name\":\"a\",\"type\":\"variant\",\"nullable\":true,\"metadata\":{}}]}")]
+        [InlineData("{\"type\":\"udt\",\"class\":\"anything\",\"sqlType\":{\"type\":\"struct\",\"fields\":[]}}")]
+        public void MalformedOrUnsupportedSchemaIsRejectedBeforeDelegateResolution(string schema)
+        {
+            byte[] command = WithSchema(schema);
+            Assert.Throws<InvalidDataException>(() =>
+                CommandSerDe.PreflightSpark40Arrow(command, 1, true, out _, out _));
+        }
+
+        [Fact]
+        public void GroupedSchemaDepthAndSizeAreBounded()
+        {
+            string nested = "\"integer\"";
+            for (int i = 0; i < 70; ++i)
+            {
+                nested = "{\"type\":\"array\",\"elementType\":" + nested +
+                    ",\"containsNull\":true}";
+            }
+
+            byte[] deep = WithSchema("{\"type\":\"struct\",\"fields\":[{\"name\":\"x\",\"type\":" +
+                nested + ",\"nullable\":true,\"metadata\":{}}]}");
+            Assert.Throws<InvalidDataException>(() =>
+                CommandSerDe.PreflightSpark40Arrow(deep, 1, true, out _, out _));
+            byte[] large = WithSchema(new string(' ', (1024 * 1024) + 1));
+            Assert.Throws<InvalidDataException>(() =>
+                CommandSerDe.PreflightSpark40Arrow(large, 1, true, out _, out _));
+        }
+
+        [Fact]
+        public void GroupedSchemaMustBeCompleteStrictUtf8AndHaveNoTrailingBytes()
+        {
+            byte[] valid = WithSchema("{\"type\":\"struct\",\"fields\":[]}");
+            byte[] truncated = valid.Take(valid.Length - 1).ToArray();
+            byte[] trailing = valid.Concat(new byte[] { 0 }).ToArray();
+            byte[] invalidUtf8 = (byte[])valid.Clone();
+            invalidUtf8[invalidUtf8.Length - 1] = 0xff;
+            foreach (byte[] command in new[] { truncated, trailing, invalidUtf8 })
+            {
+                Assert.Throws<InvalidDataException>(() =>
+                    CommandSerDe.PreflightSpark40Arrow(command, 1, true, out _, out _));
+            }
+        }
+
+        [Fact]
+        public void EvalSpecificWrapperAllowlistsRemainSeparate()
+        {
+            PicklingWorkerFunction.ExecuteDelegate pickling =
+                new PicklingUdfWrapper<int, int>(value => value).Execute;
+            ArrowWorkerFunction.ExecuteDelegate arrow =
+                new ArrowUdfWrapper<Int32Array, Int32Array>(value => value).Execute;
+            byte[] picklingBytes = CommandSerDe.Serialize(pickling,
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            byte[] arrowBytes = CommandSerDe.Serialize(arrow,
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            Assert.Throws<InvalidDataException>(() =>
+                CommandSerDe.PreflightSpark40Arrow(picklingBytes, 1, false, out _, out _));
+            Assert.Throws<InvalidDataException>(() => CommandSerDe.PreflightSpark40(arrowBytes, 1));
+            Assert.Throws<InvalidDataException>(() => CommandSerDe.PreflightSpark40Arrow(
+                WithSchema("{\"type\":\"struct\",\"fields\":[]}", arrow),
+                1, true, out _, out _));
+            Assert.Throws<InvalidDataException>(() => CommandSerDe.PreflightSpark40Arrow(
+                WithSchema("{\"type\":\"struct\",\"fields\":[]}"),
+                1, false, out _, out _));
+            Assert.False(CommandSerDe.PreflightSpark40Arrow(
+                arrowBytes, 1, false, out _, out _));
+            Assert.Throws<InvalidDataException>(() => CommandSerDe.PreflightSpark40Arrow(
+                arrowBytes, 2, false, out _, out _));
+        }
+
+        [Fact]
+        public void ReplIsPreflightedWithoutResolvingItsUserTypes()
+        {
+            ArrowWorkerFunction.ExecuteDelegate wrapper =
+                new ArrowUdfWrapper<Int32Array, Int32Array>(value => value).Execute;
+            byte[] normal = CommandSerDe.Serialize(wrapper,
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            using var stream = new MemoryStream();
+            stream.Write(normal, 0, 18);
+            stream.WriteByte((byte)'R');
+            SerDe.Write(stream, "compilation-directory");
+            stream.Write(normal, 19, normal.Length - 19);
+            byte[] command = stream.ToArray();
+            Assert.False(CommandSerDe.PreflightSpark40Arrow(command, 1, false,
+                out _, out bool isRepl));
+            Assert.True(isRepl);
+            Assert.Throws<NotSupportedException>(() =>
+                CommandSerDe.DeserializeSpark40Arrow<ArrowWorkerFunction.ExecuteDelegate>(
+                    command, 1, false, out _, out _));
+        }
+
+        private static Delegate GroupedWrapper(bool dataFrame) => dataFrame ?
+            (Delegate)(DataFrameGroupedMapWorkerFunction.ExecuteDelegate)
+                new DataFrameGroupedMapUdfWrapper(value => value).Execute :
+            (ArrowGroupedMapWorkerFunction.ExecuteDelegate)
+                new ArrowGroupedMapUdfWrapper(value => value).Execute;
+
+        private static byte[] WithSchema(string schema, Delegate wrapper = null)
+        {
+            byte[] original = CommandSerDe.Serialize(wrapper ?? GroupedWrapper(false),
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            using var stream = new MemoryStream();
+            stream.Write(original, 0, original.Length);
+            SerDe.Write(stream, schema);
+            return stream.ToArray();
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.UnitTest/Sql/RelationalGroupedDatasetTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Sql/RelationalGroupedDatasetTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Sql;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    public class RelationalGroupedDatasetTests
+    {
+        [Theory]
+        [InlineData("2.4.0", false)]
+        [InlineData("3.5.3", false)]
+        [InlineData("4.0.0", true)]
+        [InlineData("4.0.4", true)]
+        public void GroupedMapUsesVersionSpecificJvmArgument(string version, bool usesColumn)
+        {
+            var jvm = new Mock<IJvmBridge>(MockBehavior.Strict);
+            var groupReference = new JvmObjectReference("grouped", jvm.Object);
+            var columnReference = new JvmObjectReference("column", jvm.Object);
+            var expressionReference = new JvmObjectReference("expression", jvm.Object);
+            var resultReference = new JvmObjectReference("result", jvm.Object);
+            var column = new Column(columnReference);
+            var grouped = new RelationalGroupedDataset(groupReference, null);
+            object actualArgument = null;
+            if (!usesColumn)
+            {
+                jvm.Setup(bridge => bridge.CallNonStaticJavaMethod(
+                    columnReference, "expr", It.IsAny<object[]>())).Returns(expressionReference);
+            }
+
+            jvm.Setup(bridge => bridge.CallNonStaticJavaMethod(
+                groupReference, "flatMapGroupsInPandas", It.IsAny<object>()))
+                .Callback<JvmObjectReference, string, object>((_, __, argument) => actualArgument = argument)
+                .Returns(resultReference);
+
+            DataFrame result = grouped.ApplyGroupedMap(column, new Version(version));
+
+            Assert.Same(resultReference, result.Reference);
+            Assert.Same(usesColumn ? (object)column : expressionReference, actualArgument);
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowOutputValidatorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/ArrowOutputValidatorTests.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using Microsoft.Spark.Worker.Command;
+using Xunit;
+using SparkTypes = Microsoft.Spark.Sql.Types;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class ArrowOutputValidatorTests
+    {
+        [Fact]
+        public void UsesPositionAndActualNullsInsteadOfFieldNamesOrNullableMetadata()
+        {
+            using RecordBatch batch = Batch(new Int32Array.Builder().Append(3).Build());
+            ArrowOutputValidator.Validate(batch, Declared(new SparkTypes.IntegerType(), false));
+            Assert.Equal("actual", batch.Schema.GetFieldByIndex(0).Name);
+            Assert.True(batch.Schema.GetFieldByIndex(0).IsNullable);
+        }
+
+        [Fact]
+        public void RejectsMissingExtraAndWrongLengthColumns()
+        {
+            using RecordBatch batch = Batch(new Int32Array.Builder().Append(3).Build());
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch,
+                new SparkTypes.StructType(System.Array.Empty<SparkTypes.StructField>())));
+            var twoFields = new SparkTypes.StructType(new[]
+            {
+                new SparkTypes.StructField("a", new SparkTypes.IntegerType()),
+                new SparkTypes.StructField("b", new SparkTypes.IntegerType())
+            });
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch, twoFields));
+            using var wrongLength = new RecordBatch(batch.Schema, batch.Arrays, 0);
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(wrongLength,
+                Declared(new SparkTypes.IntegerType())));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(null, twoFields));
+        }
+
+        [Fact]
+        public void RejectsNullAndTypeCoercion()
+        {
+            using RecordBatch nulls = Batch(new Int32Array.Builder().AppendNull().Build());
+            ArrowOutputValidator.Validate(nulls, Declared(new SparkTypes.IntegerType()));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(nulls,
+                Declared(new SparkTypes.IntegerType(), false)));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(nulls,
+                Declared(new SparkTypes.LongType())));
+            using RecordBatch unsigned = Batch(new UInt8Array.Builder().Append(255).Build());
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(unsigned,
+                Declared(new SparkTypes.ByteType())));
+        }
+
+        [Fact]
+        public void ValidatesPhysicalColumnTypeEvenIfResultSchemaClaimsCorrectType()
+        {
+            using var array = new Int64Array.Builder().Append(1).Build();
+            var schema = new Schema.Builder().Field(new Field("a", Int32Type.Default, true)).Build();
+            using var batch = new RecordBatch(schema, new IArrowArray[] { array }, 1);
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch,
+                Declared(new SparkTypes.IntegerType())));
+        }
+
+        [Fact]
+        public void ChecksNestedNullsOnlyUnderValidParentsIncludingSlices()
+        {
+            var child = new Int32Array.Builder().AppendNull().Append(7).AppendNull().Build();
+            var type = new StructType(new[] { new Field("nested", Int32Type.Default, true) });
+            var validity = new ArrowBuffer.BitmapBuilder().Append(false).Append(true).Append(true).Build();
+            using var array = new StructArray(type, 3, new[] { child }, validity, 1);
+            var expected = new SparkTypes.StructType(new[]
+            {
+                new SparkTypes.StructField("different", new SparkTypes.IntegerType(), false)
+            });
+            using RecordBatch firstTwo = Batch(array.Slice(0, 2));
+            ArrowOutputValidator.Validate(firstTwo, Declared(expected));
+            using RecordBatch second = Batch(array.Slice(1, 1));
+            ArrowOutputValidator.Validate(second, Declared(expected));
+            using RecordBatch third = Batch(array.Slice(2, 1));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(third,
+                Declared(expected)));
+        }
+
+        [Fact]
+        public void ChecksListElementsAndSkipsNullLists()
+        {
+            var child = new Int32Array.Builder().AppendNull().Append(5).Build();
+            var offsets = new ArrowBuffer.Builder<int>().Append(0).Append(1).Append(2).Build();
+            var validity = new ArrowBuffer.BitmapBuilder().Append(false).Append(true).Build();
+            using var array = new ListArray(new ListType(Int32Type.Default), 2,
+                offsets, child, validity, 1);
+            using RecordBatch batch = Batch(array);
+            ArrowOutputValidator.Validate(batch,
+                Declared(new SparkTypes.ArrayType(new SparkTypes.IntegerType(), false)));
+
+            var builder = new ListArray.Builder(Int32Type.Default);
+            builder.Append();
+            ((Int32Array.Builder)builder.ValueBuilder).AppendNull();
+            using RecordBatch invalid = Batch(builder.Build());
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(invalid,
+                Declared(new SparkTypes.ArrayType(new SparkTypes.IntegerType(), false))));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ChecksMapKeyAndValueNulls(bool nullKey)
+        {
+            var builder = new MapArray.Builder(new MapType(StringType.Default, Int32Type.Default, false));
+            builder.Append();
+            var keys = (StringArray.Builder)builder.KeyBuilder;
+            var values = (Int32Array.Builder)builder.ValueBuilder;
+            if (nullKey)
+            {
+                keys.AppendNull();
+                values.Append(1);
+            }
+            else
+            {
+                keys.Append("a");
+                values.AppendNull();
+            }
+
+            using RecordBatch batch = Batch(builder.Build());
+            var declared = new SparkTypes.MapType(new SparkTypes.StringType(),
+                new SparkTypes.IntegerType(), false);
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch, Declared(declared)));
+            if (!nullKey)
+            {
+                ArrowOutputValidator.Validate(batch, Declared(new SparkTypes.MapType(
+                    new SparkTypes.StringType(), new SparkTypes.IntegerType(), true)));
+            }
+        }
+
+        [Theory]
+        [InlineData("UTC")]
+        [InlineData("America/Los_Angeles")]
+        [InlineData("+08:00")]
+        public void AcceptsMicrosecondTimestampWithoutConvertingEpoch(string timezone)
+        {
+            var type = new TimestampType(TimeUnit.Microsecond, timezone);
+            using RecordBatch batch = Batch(new TimestampArray.Builder(type)
+                .Append(DateTimeOffset.UnixEpoch.AddSeconds(1)).Build());
+            ArrowOutputValidator.Validate(batch, Declared(new SparkTypes.TimestampType()));
+            Assert.Equal(1000000L, ((TimestampArray)batch.Column(0)).Values[0]);
+        }
+
+        [Theory]
+        [InlineData(TimeUnit.Millisecond, "UTC")]
+        [InlineData(TimeUnit.Microsecond, "")]
+        public void RejectsWrongTimestampUnitOrMissingTimezone(TimeUnit unit, string timezone)
+        {
+            using RecordBatch batch = Batch(new TimestampArray.Builder(unit, timezone)
+                .Append(DateTimeOffset.UnixEpoch).Build());
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch,
+                Declared(new SparkTypes.TimestampType())));
+        }
+
+        [Fact]
+        public void ValidatesDecimalPrecisionAndScale()
+        {
+            using RecordBatch batch = Batch(new Decimal128Array.Builder(new Decimal128Type(8, 2))
+                .Append(12.34m).Build());
+            ArrowOutputValidator.Validate(batch, Declared(new SparkTypes.DecimalType(8, 2)));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch,
+                Declared(new SparkTypes.DecimalType(9, 2))));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.Validate(batch,
+                Declared(new SparkTypes.DecimalType(8, 3))));
+        }
+
+        [Fact]
+        public void RequiresStablePhysicalSchemaAcrossBatches()
+        {
+            Schema first = Schema(new TimestampType(TimeUnit.Microsecond, "UTC"));
+            ArrowOutputValidator.ValidateSchema(first, Schema(new TimestampType(TimeUnit.Microsecond, "UTC")));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.ValidateSchema(first,
+                Schema(new TimestampType(TimeUnit.Millisecond, "UTC"))));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.ValidateSchema(first,
+                Schema(new TimestampType(TimeUnit.Microsecond, "Asia/Shanghai"))));
+            Assert.Throws<InvalidDataException>(() => ArrowOutputValidator.ValidateSchema(first,
+                Schema(new TimestampType(TimeUnit.Microsecond, "UTC"), "renamed")));
+        }
+
+        private static Schema Schema(IArrowType type, string name = "actual") =>
+            new Schema.Builder().Field(new Field(name, type, true)).Build();
+
+        private static RecordBatch Batch(IArrowArray array) =>
+            new RecordBatch(Schema(array.Data.DataType), new[] { array }, array.Length);
+
+        private static SparkTypes.StructType Declared(SparkTypes.DataType type, bool nullable = true) =>
+            new SparkTypes.StructType(new[] { new SparkTypes.StructField("declared", type, nullable) });
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandProcessorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/CommandProcessorTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Spark.Worker.UnitTest
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
+        [InlineData(200)]
+        [InlineData(201)]
         public void Spark40EvalTypeGateAllowsSupportedTypes(int rawEvalType)
         {
             using MemoryStream stream = CreateEvalTypeStream(rawEvalType);
@@ -29,8 +31,6 @@ namespace Microsoft.Spark.Worker.UnitTest
 
         [Theory]
         [InlineData(101)]
-        [InlineData(200)]
-        [InlineData(201)]
         [InlineData(202)]
         [InlineData(203)]
         [InlineData(204)]

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/Spark40ArrowCommandExecutorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/Spark40ArrowCommandExecutorTests.cs
@@ -1,0 +1,600 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Network;
+using Microsoft.Spark.Utils;
+using Microsoft.Spark.Worker.Command;
+using Moq;
+using Xunit;
+using SqlTypes = Microsoft.Spark.Sql.Types;
+using FxDataFrame = Microsoft.Data.Analysis.DataFrame;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    public class Spark40ArrowCommandExecutorTests
+    {
+        private const int Sentinel = 0x12345678;
+        private static readonly Version s_version = new Version(4, 0, 4);
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ScalarRoundTripsNullsMultipleBatchesAndAliasedResults(bool dataFrame)
+        {
+            using var batch = IntBatch(new int?[] { 2, null, 5 });
+            using var input = Input(batch, batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Scalar(dataFrame);
+            CommandExecutorStat stat = Execute(input, output, false, command, command);
+            Assert.Equal(6, stat.NumEntriesProcessed);
+            Assert.Equal(Sentinel, SerDe.ReadInt32(input));
+            Assert.Equal(input.Length, input.Position);
+            SerDe.Write(output, Sentinel);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            for (int i = 0; i < 2; ++i)
+            {
+                using RecordBatch result = reader.ReadNextRecordBatch();
+                Assert.Equal(2, result.ColumnCount);
+                foreach (Int32Array column in result.Arrays)
+                {
+                    Assert.Equal(2, column.GetValue(0));
+                    Assert.True(column.IsNull(1));
+                    Assert.Equal(5, column.GetValue(2));
+                }
+            }
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(Sentinel, SerDe.ReadInt32(output));
+            Assert.Equal(output.Length, output.Position);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void SchemaOnlyInputDoesNotInvokeUserCodeOrStartOutput(bool dataFrame, bool grouped)
+        {
+            using var batch = IntBatch(new int?[] { 1 });
+            using var input = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(input, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteStart();
+                writer.WriteEnd();
+            }
+            SerDe.Write(input, Sentinel);
+            input.Position = 0;
+            using var output = new MemoryStream();
+            SqlCommand command = grouped ? Group(dataFrame) : Scalar(dataFrame);
+            if (grouped)
+            {
+                command.WorkerFunction = dataFrame ?
+                    new Sql.DataFrameGroupedMapWorkerFunction(_ => throw new Exception("must not run")) :
+                    (Sql.WorkerFunction)new Sql.ArrowGroupedMapWorkerFunction(_ => throw new Exception("must not run"));
+            }
+            else
+            {
+                command.WorkerFunction = dataFrame ?
+                    new Sql.DataFrameWorkerFunction((_, __) => throw new Exception("must not run")) :
+                    (Sql.WorkerFunction)new Sql.ArrowWorkerFunction((_, __) => throw new Exception("must not run"));
+            }
+            Assert.Equal(0, Execute(input, output, grouped, command).NumEntriesProcessed);
+            Assert.Equal(0, output.Length);
+            Assert.Equal(Sentinel, SerDe.ReadInt32(input));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RealEmptyScalarBatchIsStillInvoked(bool dataFrame)
+        {
+            using var batch = IntBatch(System.Array.Empty<int?>());
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            Execute(input, output, false, Scalar(dataFrame));
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch result = reader.ReadNextRecordBatch();
+            Assert.Equal(0, result.Length);
+            Assert.Null(reader.ReadNextRecordBatch());
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void InvalidScalarOutputFailsBeforeStart(bool dataFrame, bool nullResult)
+        {
+            using var batch = IntBatch(new int?[] { 2, 3 });
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Scalar(dataFrame);
+            command.WorkerFunction = dataFrame ?
+                new Sql.DataFrameWorkerFunction((_, __) => nullResult ? null : new Int32DataFrameColumn("short", 1)) :
+                (Sql.WorkerFunction)new Sql.ArrowWorkerFunction((_, __) => nullResult ? null :
+                    new Int32Array.Builder().Append(1).Build());
+            Assert.Throws<InvalidDataException>(() => Execute(input, output, false, command));
+            Assert.Equal(0, output.Length);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedMapProjectsValuesAndPreservesOrder(bool dataFrame)
+        {
+            using var batch = IntBatch(new int?[] { 10, 20 }, new int?[] { 1, 2 }, new int?[] { 7, 8 });
+            using var input = Input(batch, batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(dataFrame, 2);
+            command.GroupingKeyOffsets = new[] { 0, 0 };
+            command.ArgOffsets = new[] { 2, 1 };
+            Execute(input, output, true, command);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            for (int i = 0; i < 2; ++i)
+            {
+                using RecordBatch result = reader.ReadNextRecordBatch();
+                var value = Assert.IsType<StructArray>(result.Column(0));
+                Assert.Equal(7, ((Int32Array)value.Fields[0]).GetValue(0));
+                Assert.Equal(1, ((Int32Array)value.Fields[1]).GetValue(0));
+            }
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(Sentinel, SerDe.ReadInt32(input));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedMapAcceptsWideTablesAndNoGroupingKeys(bool dataFrame)
+        {
+            int?[][] values = Enumerable.Range(0, 12).Select(i => new int?[] { i }).ToArray();
+            using var batch = IntBatch(values);
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            Execute(input, output, true, Group(dataFrame, 12));
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch result = reader.ReadNextRecordBatch();
+            var value = Assert.IsType<StructArray>(result.Column(0));
+            Assert.Equal(12, value.Fields.Count);
+            Assert.Equal(11, ((Int32Array)value.Fields[11]).GetValue(0));
+        }
+
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(false, 3)]
+        [InlineData(true, 0)]
+        [InlineData(true, 3)]
+        public void GroupedMapPreservesRowCountForZeroValueColumns(bool dataFrame, int rows)
+        {
+            using var batch = IntBatch(Enumerable.Repeat<int?>(1, rows).ToArray());
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(dataFrame);
+            command.ArgOffsets = System.Array.Empty<int>();
+            command.GroupingKeyOffsets = new[] { 0 };
+            command.WorkerFunction = dataFrame ?
+                new Sql.DataFrameGroupedMapWorkerFunction(projected =>
+                {
+                    Assert.Empty(projected.Columns);
+                    Assert.Equal(rows, projected.Rows.Count);
+                    return new FxDataFrame(new Int32DataFrameColumn(
+                        "count", new[] { (int)projected.Rows.Count * 2 + 1 }));
+                }) :
+                (Sql.WorkerFunction)new Sql.ArrowGroupedMapWorkerFunction(projected =>
+                {
+                    Assert.Equal(0, projected.ColumnCount);
+                    Assert.Equal(rows, projected.Length);
+                    return IntBatch(new int?[] { projected.Length * 2 + 1 });
+                });
+            Assert.Equal(1, Execute(input, output, true, command).NumEntriesProcessed);
+            Assert.Equal(Sentinel, SerDe.ReadInt32(input));
+            SerDe.Write(output, Sentinel);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch result = reader.ReadNextRecordBatch();
+            var value = Assert.IsType<StructArray>(result.Column(0));
+            Assert.Equal(1, result.Length);
+            Assert.Equal(rows * 2 + 1, ((Int32Array)value.Fields[0]).GetValue(0));
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(Sentinel, SerDe.ReadInt32(output));
+        }
+
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(false, 3)]
+        [InlineData(true, 0)]
+        [InlineData(true, 3)]
+        public void GroupedMapReportsPinnedArrowEmptyStructLimitation(bool dataFrame, int rows)
+        {
+            using var batch = IntBatch(new int?[] { 1, 2 });
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(dataFrame);
+            command.ReturnSchema = new SqlTypes.StructType(System.Array.Empty<SqlTypes.StructField>());
+            command.WorkerFunction = dataFrame ?
+                new Sql.DataFrameGroupedMapWorkerFunction(_ =>
+                {
+                    var result = new FxDataFrame();
+                    for (int i = 0; i < rows; ++i)
+                    {
+                        result.Append(System.Array.Empty<object>(), inPlace: true);
+                    }
+                    Assert.Equal(rows, result.Rows.Count);
+                    return result;
+                }) :
+                (Sql.WorkerFunction)new Sql.ArrowGroupedMapWorkerFunction(_ => new RecordBatch(
+                    new Schema(System.Array.Empty<Field>(), null),
+                    System.Array.Empty<IArrowArray>(), rows));
+            // Arrow 14.0.2 NestedType rejects empty fields. Keep this existing dependency
+            // boundary explicit; do not fabricate a field or start a malformed output stream.
+            ArgumentNullException error = Assert.Throws<ArgumentNullException>(
+                () => Execute(input, output, true, command));
+            Assert.Equal("fields", error.ParamName);
+            Assert.Equal(0, output.Length);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedMapAcceptsZeroRowResults(bool dataFrame)
+        {
+            using var batch = IntBatch(new int?[] { 1, 2 });
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(dataFrame);
+            command.WorkerFunction = dataFrame ?
+                new Sql.DataFrameGroupedMapWorkerFunction(_ => new FxDataFrame(new Int32DataFrameColumn("renamed", 0))) :
+                (Sql.WorkerFunction)new Sql.ArrowGroupedMapWorkerFunction(_ => IntBatch(System.Array.Empty<int?>()));
+            Execute(input, output, true, command);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            using RecordBatch result = reader.ReadNextRecordBatch();
+            Assert.Equal(0, result.Length);
+            Assert.Null(reader.ReadNextRecordBatch());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataFrameGroupedNullabilityIsStableAcrossGroups(bool nullFirst)
+        {
+            int? firstValue = nullFirst ? null : (int?)19;
+            int? secondValue = nullFirst ? (int?)19 : null;
+            using var first = IntBatch(new[] { firstValue });
+            using var second = IntBatch(new[] { secondValue });
+
+            // Microsoft.Data.Analysis derives Arrow field nullability from actual NullCount,
+            // not the Apply declaration. Establish that the two input groups trigger this.
+            using RecordBatch firstConverted = FxDataFrame.FromArrowRecordBatch(first)
+                .ToArrowRecordBatches().Single();
+            using RecordBatch secondConverted = FxDataFrame.FromArrowRecordBatch(second)
+                .ToArrowRecordBatches().Single();
+            Assert.NotEqual(firstConverted.Schema.GetFieldByIndex(0).IsNullable,
+                secondConverted.Schema.GetFieldByIndex(0).IsNullable);
+
+            using var input = Input(first, second);
+            using var output = new MemoryStream();
+            Execute(input, output, true, Group(dataFrame: true));
+            SerDe.Write(output, Sentinel);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            foreach (int? expected in new[] { firstValue, secondValue })
+            {
+                using RecordBatch result = reader.ReadNextRecordBatch();
+                var values = Assert.IsType<StructArray>(result.Column(0));
+                Assert.True(((StructType)values.Data.DataType).Fields[0].IsNullable);
+                Assert.Equal(expected, ((Int32Array)values.Fields[0]).GetValue(0));
+            }
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(Sentinel, SerDe.ReadInt32(output));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataFrameGroupedNullabilityStillEnforcesTheDeclaration(bool nullFirst)
+        {
+            using var first = IntBatch(new int?[] { nullFirst ? null : (int?)19 });
+            using var second = IntBatch(new int?[] { nullFirst ? (int?)19 : null });
+            using var input = Input(first, second);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(dataFrame: true);
+            command.ReturnSchema = new SqlTypes.StructType(new[]
+            {
+                new SqlTypes.StructField("declared", new SqlTypes.IntegerType(), isNullable: false)
+            });
+            InvalidDataException error = Assert.Throws<InvalidDataException>(
+                () => Execute(input, output, true, command));
+            Assert.Contains("non-nullable", error.Message);
+            if (nullFirst)
+            {
+                Assert.Equal(0, output.Length);
+            }
+            else
+            {
+                SerDe.Write(output, Sentinel);
+                output.Position = 0;
+                Assert.Equal(-6, SerDe.ReadInt32(output));
+                using var reader = new ArrowStreamReader(output, leaveOpen: true);
+                Assert.NotNull(reader.ReadNextRecordBatch());
+                Assert.Null(reader.ReadNextRecordBatch());
+                Assert.Equal(Sentinel, SerDe.ReadInt32(output));
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedOffsetsAreValidatedBeforeDelegate(bool keyOffset)
+        {
+            using var batch = IntBatch(new int?[] { 1 });
+            using var input = Input(batch);
+            using var output = new MemoryStream();
+            SqlCommand command = Group(false);
+            if (keyOffset)
+            {
+                command.GroupingKeyOffsets = new[] { 1 };
+            }
+            else
+            {
+                command.ArgOffsets = new[] { -1 };
+            }
+            command.WorkerFunction = new Sql.ArrowGroupedMapWorkerFunction(_ => throw new Exception("must not run"));
+            Assert.Throws<InvalidDataException>(() => Execute(input, output, true, command));
+            Assert.Equal(0, output.Length);
+        }
+
+        [Fact]
+        public void SchemaChangeEndsIpcBeforeRethrowing()
+        {
+            using var batch = IntBatch(new int?[] { 1 });
+            using var input = Input(batch, batch);
+            using var output = new MemoryStream();
+            int calls = 0;
+            SqlCommand command = Scalar(false);
+            command.WorkerFunction = new Sql.ArrowWorkerFunction((_, __) => ++calls == 1 ?
+                new Int32Array.Builder().Append(1).Build() :
+                (IArrowArray)new Int64Array.Builder().Append(2).Build());
+            Assert.Throws<InvalidDataException>(() => Execute(input, output, false, command));
+            SerDe.Write(output, Sentinel);
+            output.Position = 0;
+            Assert.Equal(-6, SerDe.ReadInt32(output));
+            using var reader = new ArrowStreamReader(output, leaveOpen: true);
+            Assert.NotNull(reader.ReadNextRecordBatch());
+            Assert.Null(reader.ReadNextRecordBatch());
+            Assert.Equal(Sentinel, SerDe.ReadInt32(output));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TaskRunnerWritesExceptionAtTheCorrectIpcBoundary(bool laterBatch)
+        {
+            using var input = TaskInput(laterBatch ? new[] { 1, -1 } : new[] { -1 });
+            using var output = new MemoryStream();
+            var socket = new Mock<ISocketWrapper>();
+            socket.SetupGet(s => s.InputStream).Returns(input);
+            socket.SetupGet(s => s.OutputStream).Returns(output);
+            new TaskRunner(0, socket.Object, reuseSocket: true, s_version).Run();
+            socket.Verify(s => s.Dispose(), Times.Once);
+            output.Position = 0;
+            if (laterBatch)
+            {
+                Assert.Equal(-6, SerDe.ReadInt32(output));
+                using var reader = new ArrowStreamReader(output, leaveOpen: true);
+                using RecordBatch result = reader.ReadNextRecordBatch();
+                Assert.Equal(1, ((Int32Array)result.Column(0)).GetValue(0));
+                Assert.Null(reader.ReadNextRecordBatch());
+            }
+            Assert.Equal(-2, SerDe.ReadInt32(output));
+            Assert.Contains("test udf failed", SerDe.ReadString(output));
+            Assert.Equal(output.Length, output.Position);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TaskRunnerDoesNotAppendControlFramesAfterWriteOrFlushFailure(bool flushFailure)
+        {
+            using var input = TaskInput(new[] { 1 });
+            using var output = new FaultStream(flushFailure);
+            var socket = new Mock<ISocketWrapper>();
+            socket.SetupGet(s => s.InputStream).Returns(input);
+            socket.SetupGet(s => s.OutputStream).Returns(output);
+            new TaskRunner(0, socket.Object, reuseSocket: true, s_version).Run();
+            socket.Verify(s => s.Dispose(), Times.Once);
+            Assert.True(output.Failed);
+            Assert.Equal(0, output.WritesAfterFailure);
+            Assert.True(input.Position < input.Length);
+        }
+
+        [Fact]
+        public void EosFailureDoesNotMaskTheUserException()
+        {
+            using var batch = IntBatch(new int?[] { 1 });
+            using var input = Input(batch, batch);
+            using var output = new FaultStream(flushFailure: true);
+            var primary = new InvalidOperationException("original user failure");
+            int calls = 0;
+            SqlCommand command = Scalar(false);
+            command.WorkerFunction = new Sql.ArrowWorkerFunction((columns, offsets) =>
+                ++calls == 1 ? columns.Span[offsets[0]] : throw primary);
+            ArrowStreamWriteException error = Assert.Throws<ArrowStreamWriteException>(
+                () => Execute(input, output, false, command));
+            Assert.Same(primary, error.InnerException);
+            Assert.Equal(0, output.WritesAfterFailure);
+        }
+
+        private static SqlCommand Scalar(bool dataFrame) => new SqlCommand
+        {
+            SerializerMode = CommandSerDe.SerializedMode.Row,
+            DeserializerMode = CommandSerDe.SerializedMode.Row,
+            ArgOffsets = new[] { 0 },
+            WorkerFunction = dataFrame ?
+                new Sql.DataFrameWorkerFunction((columns, offsets) => columns.Span[offsets[0]]) :
+                (Sql.WorkerFunction)new Sql.ArrowWorkerFunction((columns, offsets) => columns.Span[offsets[0]])
+        };
+
+        private static SqlCommand Group(bool dataFrame, int columns = 1) => new SqlCommand
+        {
+            SerializerMode = CommandSerDe.SerializedMode.Row,
+            DeserializerMode = CommandSerDe.SerializedMode.Row,
+            ArgOffsets = Enumerable.Range(0, columns).ToArray(),
+            GroupingKeyOffsets = System.Array.Empty<int>(),
+            ReturnSchema = new SqlTypes.StructType(Enumerable.Range(0, columns)
+                .Select(i => new SqlTypes.StructField("declared" + i, new SqlTypes.IntegerType())).ToArray()),
+            WorkerFunction = dataFrame ?
+                new Sql.DataFrameGroupedMapWorkerFunction(input => input) :
+                (Sql.WorkerFunction)new Sql.ArrowGroupedMapWorkerFunction(input => input)
+        };
+
+        private static CommandExecutorStat Execute(
+            Stream input, Stream output, bool grouped, params SqlCommand[] commands) =>
+            SqlCommandExecutor.Execute(s_version, input, output, grouped ?
+                UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF :
+                UdfUtils.PythonEvalType.SQL_SCALAR_PANDAS_UDF, commands);
+
+        private static RecordBatch IntBatch(params int?[][] columns)
+        {
+            var arrays = columns.Select(values =>
+            {
+                var builder = new Int32Array.Builder();
+                foreach (int? value in values)
+                {
+                    if (value.HasValue)
+                    {
+                        builder.Append(value.Value);
+                    }
+                    else
+                    {
+                        builder.AppendNull();
+                    }
+                }
+                return (IArrowArray)builder.Build();
+            }).ToArray();
+            var fields = columns.Select((_, i) => new Field("input" + i, Int32Type.Default, true));
+            return new RecordBatch(new Schema(fields, null), arrays, columns[0].Length);
+        }
+
+        private static MemoryStream Input(params RecordBatch[] batches)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batches[0].Schema, leaveOpen: true))
+            {
+                foreach (RecordBatch batch in batches)
+                {
+                    writer.WriteRecordBatch(batch);
+                }
+                writer.WriteEnd();
+            }
+            SerDe.Write(stream, Sentinel);
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static MemoryStream TaskInput(int[] values)
+        {
+            var stream = new MemoryStream();
+            SerDe.Write(stream, 0);
+            SerDe.Write(stream, AssemblyInfoProvider.MicrosoftSparkAssemblyInfo().AssemblyVersion);
+            new TaskContextWriterV3_3_X().Write(stream, new TaskContext { Secret = string.Empty });
+            SerDe.Write(stream, Path.GetTempPath());
+            SerDe.Write(stream, 0); // Includes.
+            SerDe.Write(stream, false); // No encrypted broadcasts.
+            SerDe.Write(stream, 0);
+            SerDe.Write(stream, 200);
+            SerDe.Write(stream, 0); // Arrow configuration.
+            SerDe.Write(stream, false); // Profiling.
+            SerDe.Write(stream, 1); // UDF count.
+            SerDe.Write(stream, 1); // Argument count.
+            SerDe.Write(stream, 0); // Offset.
+            SerDe.Write(stream, false); // No named argument.
+            SerDe.Write(stream, 1); // Chain count.
+            var wrapper = new Sql.ArrowUdfWrapper<Int32Array, Int32Array>(IdentityOrThrow);
+            byte[] command = CommandSerDe.Serialize(
+                (Sql.ArrowWorkerFunction.ExecuteDelegate)wrapper.Execute,
+                CommandSerDe.SerializedMode.Row, CommandSerDe.SerializedMode.Row);
+            SerDe.Write(stream, command.Length);
+            SerDe.Write(stream, command);
+            using var first = IntBatch(new int?[] { values[0] });
+            using (var writer = new ArrowStreamWriter(stream, first.Schema, leaveOpen: true))
+            {
+                foreach (int value in values)
+                {
+                    using var batch = IntBatch(new int?[] { value });
+                    writer.WriteRecordBatch(batch);
+                }
+                writer.WriteEnd();
+            }
+            SerDe.Write(stream, -4);
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static Int32Array IdentityOrThrow(Int32Array input) =>
+            input.GetValue(0) < 0 ? throw new InvalidOperationException("test udf failed") : input;
+
+        private sealed class FaultStream : MemoryStream
+        {
+            private readonly bool _flushFailure;
+
+            internal FaultStream(bool flushFailure)
+            {
+                _flushFailure = flushFailure;
+            }
+
+            internal bool Failed { get; private set; }
+
+            internal int WritesAfterFailure { get; private set; }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (Failed)
+                {
+                    ++WritesAfterFailure;
+                    throw new IOException("write after failure");
+                }
+                if (!_flushFailure && Length + count > 24)
+                {
+                    base.Write(buffer, offset, (int)(24 - Length));
+                    Failed = true;
+                    throw new IOException("partial write");
+                }
+                base.Write(buffer, offset, count);
+            }
+
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                Write(buffer.ToArray(), 0, buffer.Length);
+            }
+
+            public override void Flush()
+            {
+                if (_flushFailure)
+                {
+                    Failed = true;
+                    throw new IOException("flush failure");
+                }
+                base.Flush();
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker.UnitTest/Spark40ArrowCommandProcessorTests.cs
+++ b/src/csharp/Microsoft.Spark.Worker.UnitTest/Spark40ArrowCommandProcessorTests.cs
@@ -1,0 +1,344 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Apache.Arrow;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
+using Microsoft.Spark.Utils;
+using Microsoft.Spark.Worker.Processor;
+using Xunit;
+using Array = System.Array;
+
+namespace Microsoft.Spark.Worker.UnitTest
+{
+    [Collection("Spark Unit Tests")]
+    public class Spark40ArrowCommandProcessorTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ScalarConsumesConfigurationAndNameFlagsBeforeArrow(bool dataFrame)
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { Scalar(dataFrame) },
+                configuration: new[] { Pair("spark.sql.session.timeZone", "America/Los_Angeles") });
+            long frameEnd = stream.Length;
+            AppendSentinel(stream);
+
+            SqlCommand command = ReadSingle(stream);
+            Assert.Equal(new[] { 0 }, command.ArgOffsets);
+            Assert.Null(command.ReturnSchema);
+            Assert.Equal("America/Los_Angeles",
+                command.ArrowConfiguration["spark.sql.session.timeZone"]);
+            Assert.Equal(dataFrame ? typeof(DataFrameWorkerFunction) : typeof(ArrowWorkerFunction),
+                command.WorkerFunction.GetType());
+            Assert.Equal(frameEnd, stream.Position);
+            Assert.Equal(123456, SerDe.ReadInt32(stream));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GroupedMapDecodesComputedKeyWithoutNameFlags(bool dataFrame)
+        {
+            using MemoryStream stream = Frame(201, new[] { 4, 1, 0, 1, 2 },
+                new[] { Grouped(dataFrame) });
+            long frameEnd = stream.Length;
+            AppendSentinel(stream);
+
+            SqlCommand command = ReadSingle(stream);
+            Assert.Equal(new[] { 0 }, command.GroupingKeyOffsets);
+            Assert.Equal(new[] { 1, 2 }, command.ArgOffsets);
+            Assert.Equal(Schema().Json, command.ReturnSchema.Json);
+            Assert.Equal(dataFrame ? typeof(DataFrameGroupedMapWorkerFunction) :
+                typeof(ArrowGroupedMapWorkerFunction), command.WorkerFunction.GetType());
+            Assert.Equal(frameEnd, stream.Position);
+            Assert.Equal(123456, SerDe.ReadInt32(stream));
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 20)]
+        [InlineData(2, 20)]
+        public void GroupedMetadataAllowsZeroKeysEmptyValuesWideTablesAndRepeatedKeys(
+            int keyCount, int valueCount)
+        {
+            int[] metadata = new[] { 1 + keyCount + valueCount, keyCount }
+                .Concat(Enumerable.Repeat(0, keyCount))
+                .Concat(Enumerable.Range(0, valueCount)).ToArray();
+            using MemoryStream stream = Frame(201, metadata, new[] { Grouped(false) });
+            SqlCommand command = ReadSingle(stream);
+            Assert.Equal(Enumerable.Repeat(0, keyCount), command.GroupingKeyOffsets);
+            Assert.Equal(Enumerable.Range(0, valueCount), command.ArgOffsets);
+        }
+
+        [Theory]
+        [InlineData(new[] { 3, 1, 0, 0, 1 })]
+        [InlineData(new[] { 4, 4, 0, 0, 1 })]
+        [InlineData(new[] { 4, -1, 0, 0, 1 })]
+        [InlineData(new[] { 2, 0, -1 })]
+        [InlineData(new[] { 0 })]
+        public void MalformedGroupedOffsetsAreRejected(int[] offsets)
+        {
+            using MemoryStream stream = Frame(201, offsets, new[] { Grouped(false) });
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Fact]
+        public void GroupedMapCannotChainFunctions()
+        {
+            using MemoryStream stream = Frame(201, new[] { 1, 0 },
+                new[] { Grouped(false), Grouped(false) });
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ScalarSameRepresentationChainIsAccepted(bool dataFrame)
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 },
+                new[] { Scalar(dataFrame), Scalar(dataFrame) });
+            Assert.Equal(2, ReadSingle(stream).NumChainedFunctions);
+        }
+
+        [Fact]
+        public void MixedRepresentationChainIsRejected()
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 },
+                new[] { Scalar(false), Scalar(true) });
+            Assert.Contains("mix", Assert.Throws<NotSupportedException>(
+                () => ReadSingle(stream)).Message);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void ValidUnsupportedFeaturesConsumeFrameBeforeRejection(bool profiling, bool named)
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { Scalar(false) },
+                profiling: profiling, named: named);
+            long end = stream.Length;
+            AppendSentinel(stream);
+            Assert.Throws<NotSupportedException>(() => ReadSingle(stream));
+            Assert.Equal(end, stream.Position);
+            Assert.Equal(123456, SerDe.ReadInt32(stream));
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void MalformedCommandWinsOverUnsupportedFeatures(bool profiling, bool named)
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 },
+                new[] { Scalar(false), new byte[] { 0 } }, profiling: profiling, named: named);
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Fact]
+        public void LaterMalformedCommandIsRejectedBeforeFirstUserTypeResolution()
+        {
+            byte[] first = Scalar(false);
+            byte[] className = Encoding.UTF8.GetBytes(nameof(Spark40ArrowCommandProcessorTests));
+            bool poisoned = false;
+            for (int i = 0; i <= first.Length - className.Length; ++i)
+            {
+                if (first.Skip(i).Take(className.Length).SequenceEqual(className))
+                {
+                    first[i] = (byte)'X';
+                    poisoned = true;
+                }
+            }
+
+            Assert.True(poisoned);
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { first, new byte[] { 0 } });
+            Assert.Contains("envelope", Assert.Throws<InvalidDataException>(
+                () => ReadSingle(stream)).Message);
+        }
+
+        [Fact]
+        public void ArrowLargeVariableTypesAreExplicitlyUnsupported()
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { Scalar(false) },
+                configuration: new[] { Pair("spark.sql.execution.arrow.useLargeVarTypes", "true") });
+            long end = stream.Length;
+            Assert.Contains("large", Assert.Throws<NotSupportedException>(
+                () => ReadSingle(stream)).Message);
+            Assert.Equal(end, stream.Position);
+        }
+
+        [Fact]
+        public void ConfigurationIsTaskLocal()
+        {
+            var processor = new CommandProcessor(new Version("4.0.4"));
+            using MemoryStream first = Frame(200, new[] { 0 }, new[] { Scalar(false) },
+                configuration: new[] { Pair("spark.sql.session.timeZone", "UTC") });
+            using MemoryStream second = Frame(200, new[] { 0 }, new[] { Scalar(false) });
+            var firstCommand = (SqlCommand)processor.Process(first).Commands[0];
+            var secondCommand = (SqlCommand)processor.Process(second).Commands[0];
+            Assert.Single(firstCommand.ArrowConfiguration);
+            Assert.Empty(secondCommand.ArrowConfiguration);
+        }
+
+        [Theory]
+        [InlineData("spark.sql.execution.arrow.useLargeVarTypes")]
+        [InlineData("spark.sql.execution.pandas.convertToArrowArraySafely")]
+        [InlineData("spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName")]
+        public void InvalidBooleanConfigurationIsRejected(string key)
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { Scalar(false) },
+                configuration: new[] { Pair(key, "not-a-boolean") });
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Fact]
+        public void DuplicateConfigurationIsRejected()
+        {
+            using MemoryStream stream = Frame(200, new[] { 0 }, new[] { Scalar(false) },
+                configuration: new[] { Pair("key", "one"), Pair("key", "two") });
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(65)]
+        public void ConfigurationCountIsBoundedBeforeAllocation(int count)
+        {
+            using var stream = new MemoryStream();
+            SerDe.Write(stream, 200);
+            SerDe.Write(stream, count);
+            stream.Position = 0;
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        [Fact]
+        public void FragmentedReadsAndTruncatedCommandAreHandledExactly()
+        {
+            using MemoryStream frame = Frame(201, new[] { 2, 0, 0 }, new[] { Grouped(false) });
+            using var fragmented = new FragmentedStream(frame.ToArray());
+            Assert.Single(ReadSingle(fragmented).ArgOffsets);
+            byte[] bytes = frame.ToArray();
+            foreach (int length in new[] { 0, 3, 6, 8, 12, bytes.Length - 1 })
+            {
+                using var truncated = new FragmentedStream(bytes.Take(length).ToArray());
+                Assert.Throws<EndOfStreamException>(() => ReadSingle(truncated));
+            }
+        }
+
+        [Fact]
+        public void InvalidUtf8ConfigurationIsRejected()
+        {
+            using var stream = new MemoryStream();
+            SerDe.Write(stream, 200);
+            SerDe.Write(stream, 1);
+            SerDe.Write(stream, 1);
+            stream.WriteByte(0xff);
+            stream.Position = 0;
+            Assert.Throws<InvalidDataException>(() => ReadSingle(stream));
+        }
+
+        private static SqlCommand ReadSingle(Stream stream) => (SqlCommand)Assert.Single(
+            new CommandProcessor(new Version("4.0.4")).Process(stream).Commands);
+
+        private static StructType Schema() => new StructType(new[]
+        {
+            new StructField("value", new IntegerType())
+        });
+
+        private static KeyValuePair<string, string> Pair(string key, string value) =>
+            new KeyValuePair<string, string>(key, value);
+
+        private static byte[] Scalar(bool dataFrame)
+        {
+            Delegate wrapper = dataFrame ?
+                (Delegate)(DataFrameWorkerFunction.ExecuteDelegate)new DataFrameUdfWrapper<Int32DataFrameColumn,
+                    Int32DataFrameColumn>(value => value).Execute :
+                (ArrowWorkerFunction.ExecuteDelegate)new ArrowUdfWrapper<Int32Array, Int32Array>(
+                    value => value).Execute;
+            return CommandSerDe.Serialize(wrapper, CommandSerDe.SerializedMode.Row,
+                CommandSerDe.SerializedMode.Row);
+        }
+
+        private static byte[] Grouped(bool dataFrame)
+        {
+            Delegate wrapper = dataFrame ?
+                (Delegate)(DataFrameGroupedMapWorkerFunction.ExecuteDelegate)
+                    new DataFrameGroupedMapUdfWrapper(value => value).Execute :
+                (ArrowGroupedMapWorkerFunction.ExecuteDelegate)
+                    new ArrowGroupedMapUdfWrapper(value => value).Execute;
+            return CommandSerDe.SerializeSpark40GroupedMap(wrapper, Schema());
+        }
+
+        private static MemoryStream Frame(int eval, int[] offsets, byte[][] commands,
+            KeyValuePair<string, string>[] configuration = null, bool profiling = false, bool named = false)
+        {
+            var stream = new MemoryStream();
+            SerDe.Write(stream, eval);
+            configuration ??= Array.Empty<KeyValuePair<string, string>>();
+            SerDe.Write(stream, configuration.Length);
+            foreach (KeyValuePair<string, string> pair in configuration)
+            {
+                SerDe.Write(stream, pair.Key);
+                SerDe.Write(stream, pair.Value);
+            }
+
+            SerDe.Write(stream, profiling);
+            if (profiling)
+            {
+                SerDe.Write(stream, "perf");
+            }
+
+            SerDe.Write(stream, 1);
+            SerDe.Write(stream, offsets.Length);
+            foreach (int offset in offsets)
+            {
+                SerDe.Write(stream, offset);
+                if (eval == 200)
+                {
+                    SerDe.Write(stream, named);
+                    if (named)
+                    {
+                        SerDe.Write(stream, "value");
+                    }
+                }
+            }
+
+            SerDe.Write(stream, commands.Length);
+            foreach (byte[] command in commands)
+            {
+                SerDe.Write(stream, command.Length);
+                stream.Write(command, 0, command.Length);
+            }
+
+            if (profiling)
+            {
+                SerDe.Write(stream, 42L);
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static void AppendSentinel(MemoryStream stream)
+        {
+            stream.Position = stream.Length;
+            SerDe.Write(stream, 123456);
+            stream.Position = 0;
+        }
+
+        private sealed class FragmentedStream : MemoryStream
+        {
+            internal FragmentedStream(byte[] bytes) : base(bytes) { }
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                base.Read(buffer, offset, Math.Min(1, count));
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputValidator.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/ArrowOutputValidator.cs
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using SparkTypes = Microsoft.Spark.Sql.Types;
+
+namespace Microsoft.Spark.Worker.Command
+{
+    /// <summary>
+    /// Checks Spark 4 grouped-map results before they enter the Arrow output stream.
+    /// Spark's grouped-map reader does not check the complete declared return schema.
+    /// </summary>
+    internal static class ArrowOutputValidator
+    {
+        internal static void Validate(RecordBatch batch, SparkTypes.StructType schema)
+        {
+            if (batch == null || schema == null || batch.Length < 0 ||
+                batch.ColumnCount != schema.Fields.Count ||
+                batch.Schema.FieldsList.Count != schema.Fields.Count)
+            {
+                throw new InvalidDataException("Grouped-map result must match the declared column count.");
+            }
+
+            for (int i = 0; i < schema.Fields.Count; ++i)
+            {
+                IArrowArray column = batch.Column(i);
+                if (column == null || column.Length != batch.Length)
+                {
+                    throw new InvalidDataException("Grouped-map result columns must match the result row count.");
+                }
+
+                // The public Apply API is positional, including nested structs.
+                SparkTypes.StructField field = schema.Fields[i];
+                ValidateType(batch.Schema.GetFieldByIndex(i).DataType, field.DataType);
+                ValidateLayout(column, batch.Schema.GetFieldByIndex(i).DataType);
+                ValidateNulls(column, field.DataType, field.IsNullable, 0, batch.Length);
+            }
+        }
+
+        internal static void ValidateSchema(Schema expected, Schema actual)
+        {
+            ValidateFields(expected.FieldsList, actual.FieldsList);
+        }
+
+        private static void ValidateFields(IReadOnlyList<Field> expected, IReadOnlyList<Field> actual)
+        {
+            if (expected.Count != actual.Count)
+            {
+                throw new InvalidDataException("Arrow result schema changed between batches.");
+            }
+
+            for (int i = 0; i < expected.Count; ++i)
+            {
+                if (expected[i].Name != actual[i].Name ||
+                    expected[i].IsNullable != actual[i].IsNullable)
+                {
+                    throw new InvalidDataException("Arrow result schema changed between batches.");
+                }
+
+                ValidateSameType(expected[i].DataType, actual[i].DataType);
+            }
+        }
+
+        private static void ValidateSameType(IArrowType expected, IArrowType actual)
+        {
+            if (expected.TypeId != actual.TypeId || expected.GetType() != actual.GetType())
+            {
+                throw new InvalidDataException("Arrow result has an inconsistent physical type.");
+            }
+
+            if (expected is Decimal128Type decimalType &&
+                (decimalType.Precision != ((Decimal128Type)actual).Precision ||
+                 decimalType.Scale != ((Decimal128Type)actual).Scale))
+            {
+                throw new InvalidDataException("Arrow decimal precision or scale changed.");
+            }
+
+            if (expected is TimestampType timestamp &&
+                (timestamp.Unit != ((TimestampType)actual).Unit ||
+                 timestamp.Timezone != ((TimestampType)actual).Timezone))
+            {
+                throw new InvalidDataException("Arrow timestamp unit or timezone changed.");
+            }
+
+            if (expected is NestedType nested)
+            {
+                ValidateFields(nested.Fields, ((NestedType)actual).Fields);
+            }
+        }
+
+        private static void ValidateType(IArrowType actual, SparkTypes.DataType expected)
+        {
+            bool matches = expected switch
+            {
+                SparkTypes.BooleanType _ => actual.TypeId == ArrowTypeId.Boolean,
+                SparkTypes.ByteType _ => actual.TypeId == ArrowTypeId.Int8,
+                SparkTypes.ShortType _ => actual.TypeId == ArrowTypeId.Int16,
+                SparkTypes.IntegerType _ => actual.TypeId == ArrowTypeId.Int32,
+                SparkTypes.LongType _ => actual.TypeId == ArrowTypeId.Int64,
+                SparkTypes.FloatType _ => actual.TypeId == ArrowTypeId.Float,
+                SparkTypes.DoubleType _ => actual.TypeId == ArrowTypeId.Double,
+                SparkTypes.StringType _ => actual.TypeId == ArrowTypeId.String,
+                SparkTypes.BinaryType _ => actual.TypeId == ArrowTypeId.Binary,
+                SparkTypes.DateType _ => actual.TypeId == ArrowTypeId.Date32,
+                SparkTypes.NullType _ => actual.TypeId == ArrowTypeId.Null,
+                SparkTypes.DecimalType dec => actual is Decimal128Type arrowDecimal &&
+                    dec.SimpleString == new SparkTypes.DecimalType(
+                        arrowDecimal.Precision, arrowDecimal.Scale).SimpleString,
+                SparkTypes.TimestampType _ => actual is TimestampType timestamp &&
+                    timestamp.Unit == TimeUnit.Microsecond &&
+                    !string.IsNullOrEmpty(timestamp.Timezone),
+                SparkTypes.ArrayType _ => actual is ListType,
+                SparkTypes.MapType _ => actual is MapType,
+                SparkTypes.StructType _ => actual is StructType,
+                _ => false
+            };
+
+            if (!matches)
+            {
+                throw new InvalidDataException("Grouped-map result type does not match the declared Spark type.");
+            }
+
+            if (expected is SparkTypes.ArrayType list)
+            {
+                ValidateType(((ListType)actual).ValueDataType, list.ElementType);
+            }
+            else if (expected is SparkTypes.MapType map)
+            {
+                var arrowMap = (MapType)actual;
+                ValidateType(arrowMap.KeyField.DataType, map.KeyType);
+                ValidateType(arrowMap.ValueField.DataType, map.ValueType);
+            }
+            else if (expected is SparkTypes.StructType structure)
+            {
+                IReadOnlyList<Field> fields = ((StructType)actual).Fields;
+                if (fields.Count != structure.Fields.Count)
+                {
+                    throw new InvalidDataException("Grouped-map struct has an unexpected number of fields.");
+                }
+
+                for (int i = 0; i < fields.Count; ++i)
+                {
+                    ValidateType(fields[i].DataType, structure.Fields[i].DataType);
+                }
+            }
+        }
+
+        private static void ValidateLayout(IArrowArray array, IArrowType fieldType)
+        {
+            if (array == null || array.Length < 0 || array.Offset < 0)
+            {
+                throw new InvalidDataException("Invalid Arrow result array.");
+            }
+
+            ValidateSameType(fieldType, array.Data.DataType);
+            if (array is StructArray structure)
+            {
+                IReadOnlyList<Field> fields = ((StructType)fieldType).Fields;
+                if (fields.Count != structure.Fields.Count)
+                {
+                    throw new InvalidDataException("Arrow struct array does not match its schema.");
+                }
+
+                for (int i = 0; i < fields.Count; ++i)
+                {
+                    CheckRange(structure.Fields[i], structure.Offset, structure.Length);
+                    ValidateLayout(structure.Fields[i], fields[i].DataType);
+                }
+            }
+            else if (array is MapArray map)
+            {
+                ValidateLayout(map.KeyValues, ((MapType)fieldType).KeyValueType);
+            }
+            else if (array is ListArray list)
+            {
+                ValidateLayout(list.Values, ((ListType)fieldType).ValueDataType);
+            }
+        }
+
+        private static void CheckRange(IArrowArray array, int start, int count)
+        {
+            if (array == null || start < 0 || count < 0 || start > array.Length - count)
+            {
+                throw new InvalidDataException("Arrow result contains an invalid child range.");
+            }
+        }
+
+        private static void ValidateNulls(
+            IArrowArray array,
+            SparkTypes.DataType type,
+            bool nullable,
+            int start,
+            int count)
+        {
+            CheckRange(array, start, count);
+            for (int i = start; i < start + count; ++i)
+            {
+                if (array.IsNull(i))
+                {
+                    if (!nullable)
+                    {
+                        throw new InvalidDataException("Grouped-map result contains null in a non-nullable field.");
+                    }
+
+                    // Child validity is irrelevant beneath a null parent.
+                    continue;
+                }
+
+                if (type is SparkTypes.StructType structure)
+                {
+                    var values = (StructArray)array;
+                    for (int fieldIndex = 0; fieldIndex < structure.Fields.Count; ++fieldIndex)
+                    {
+                        SparkTypes.StructField field = structure.Fields[fieldIndex];
+                        ValidateNulls(values.Fields[fieldIndex], field.DataType,
+                            field.IsNullable, values.Offset + i, 1);
+                    }
+                }
+                else if (type is SparkTypes.MapType mapType)
+                {
+                    var map = (MapArray)array;
+                    int first = map.ValueOffsets[i];
+                    int length = map.GetValueLength(i);
+                    CheckRange(map.KeyValues, first, length);
+                    for (int entry = first; entry < first + length; ++entry)
+                    {
+                        if (map.KeyValues.IsNull(entry))
+                        {
+                            throw new InvalidDataException("Arrow map entries cannot be null.");
+                        }
+                    }
+
+                    ValidateNulls(map.Keys, mapType.KeyType, false,
+                        map.KeyValues.Offset + first, length);
+                    ValidateNulls(map.Values, mapType.ValueType, mapType.ValueContainsNull,
+                        map.KeyValues.Offset + first, length);
+                }
+                else if (type is SparkTypes.ArrayType listType)
+                {
+                    var list = (ListArray)array;
+                    ValidateNulls(list.Values, listType.ElementType, listType.ContainsNull,
+                        list.ValueOffsets[i], list.GetValueLength(i));
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/Spark40ArrowCommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/Spark40ArrowCommandExecutor.cs
@@ -1,0 +1,431 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Microsoft.Data.Analysis;
+using Microsoft.Spark.Interop.Ipc;
+using Microsoft.Spark.Services;
+using Microsoft.Spark.Sql;
+using Microsoft.Spark.Utils;
+using FxDataFrame = Microsoft.Data.Analysis.DataFrame;
+
+namespace Microsoft.Spark.Worker.Command
+{
+    /// <summary>
+    /// Spark 4 Arrow execution, including grouped input projection and the boundary between
+    /// Arrow IPC messages and Spark control frames. Legacy executors retain their old behavior.
+    /// </summary>
+    internal sealed class Spark40ArrowCommandExecutor : SqlCommandExecutor
+    {
+        private static readonly ILoggerService s_logger =
+            LoggerServiceFactory.GetLogger(typeof(Spark40ArrowCommandExecutor));
+
+        private readonly bool _groupedMap;
+
+        internal Spark40ArrowCommandExecutor(bool groupedMap)
+        {
+            _groupedMap = groupedMap;
+        }
+
+        protected internal override CommandExecutorStat ExecuteCore(
+            Stream inputStream,
+            Stream outputStream,
+            SqlCommand[] commands)
+        {
+            ValidateCommands(commands);
+            var stat = new CommandExecutorStat();
+            var output = new ArrowOutput(outputStream);
+            ArrowStreamReader reader = null;
+            RecordBatch input = null;
+            try
+            {
+                reader = new ArrowStreamReader(inputStream, leaveOpen: true);
+                // ArrowStreamReader loads its schema lazily on the first read, including
+                // a schema-only stream whose first result is null.
+                input = reader.ReadNextRecordBatch();
+                foreach (SqlCommand command in commands)
+                {
+                    ValidateOffsets(command.ArgOffsets, reader.Schema.FieldsList.Count);
+                    if (_groupedMap)
+                    {
+                        ValidateOffsets(command.GroupingKeyOffsets, reader.Schema.FieldsList.Count);
+                    }
+                }
+
+                while (input != null)
+                {
+                    try
+                    {
+                        if (_groupedMap)
+                        {
+                            ExecuteGroup(input, commands[0], output, stat);
+                        }
+                        else
+                        {
+                            ExecuteScalar(input, commands, output, stat);
+                        }
+                    }
+                    finally
+                    {
+                        // Delegates may return arrays that alias input buffers. Release input
+                        // only after every result for this batch has been synchronously written.
+                        DisposeQuietly(input);
+                        input = null;
+                    }
+                    input = reader.ReadNextRecordBatch();
+                }
+
+                // Schema-only input does not represent a batch or a group.
+                output.End();
+                return stat;
+            }
+            catch (Exception exception)
+            {
+                if (output.HasFailed)
+                {
+                    throw new ArrowStreamWriteException(exception);
+                }
+
+                try
+                {
+                    // A user/validation failure between batches must finish valid IPC before
+                    // TaskRunner writes PYTHON_EXCEPTION_THROWN. Never repair a partial write.
+                    output.End();
+                }
+                catch (Exception cleanupException)
+                {
+                    s_logger.LogWarn($"Ending Arrow output failed: {cleanupException.GetType().Name}.");
+                    throw new ArrowStreamWriteException(exception);
+                }
+
+                throw;
+            }
+            finally
+            {
+                DisposeQuietly(input);
+                DisposeQuietly(output);
+                DisposeQuietly(reader);
+            }
+        }
+
+        private void ValidateCommands(SqlCommand[] commands)
+        {
+            if (_groupedMap &&
+                (commands.Length != 1 || commands[0].ReturnSchema is null))
+            {
+                throw new InvalidDataException("Spark 4 grouped-map requires one command and a return schema.");
+            }
+
+            Type firstType = commands[0].WorkerFunction?.GetType();
+            foreach (SqlCommand command in commands)
+            {
+                WorkerFunction function = command.WorkerFunction;
+                bool supported = _groupedMap ?
+                    function is ArrowGroupedMapWorkerFunction ||
+                        function is DataFrameGroupedMapWorkerFunction :
+                    function is ArrowWorkerFunction || function is DataFrameWorkerFunction;
+                if (!supported || function.GetType() != firstType)
+                {
+                    throw new NotSupportedException(
+                        "Combined Arrow and DataFrame style commands or mismatched evaluation types are not supported.");
+                }
+            }
+        }
+
+        private static void ValidateOffsets(int[] offsets, int columnCount)
+        {
+            if (offsets is null || offsets.Any(offset => offset < 0 || offset >= columnCount))
+            {
+                throw new InvalidDataException("Spark 4 Arrow argument offset is outside the input schema.");
+            }
+        }
+
+        private static void ExecuteScalar(
+            RecordBatch input,
+            SqlCommand[] commands,
+            ArrowOutput output,
+            CommandExecutorStat stat)
+        {
+            if (commands[0].WorkerFunction is ArrowWorkerFunction)
+            {
+                var results = new IArrowArray[commands.Length];
+                try
+                {
+                    IArrowArray[] columns = input.Arrays.ToArray();
+                    for (int i = 0; i < commands.Length; ++i)
+                    {
+                        results[i] = ((ArrowWorkerFunction)commands[i].WorkerFunction).Func(
+                            columns, commands[i].ArgOffsets);
+                        ValidateScalarLength(results[i]?.Length, input.Length);
+                    }
+
+                    var batch = new RecordBatch(ScalarSchema(results), results, input.Length);
+                    output.Write(batch);
+                    stat.NumEntriesProcessed += batch.Length;
+                }
+                finally
+                {
+                    DisposeResultArrays(results, input);
+                }
+            }
+            else
+            {
+                FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(input);
+                DataFrameColumn[] columns = dataFrame.Columns.ToArray();
+                var results = new DataFrameColumn[commands.Length];
+                var names = new HashSet<string>(StringComparer.Ordinal);
+                for (int i = 0; i < commands.Length; ++i)
+                {
+                    DataFrameColumn result = ((DataFrameWorkerFunction)commands[i].WorkerFunction)
+                        .Func(columns, commands[i].ArgOffsets);
+                    ValidateScalarLength(result?.Length, input.Length);
+                    if (!names.Add(result.Name))
+                    {
+                        // Do not rename a user's input/aliased result just to satisfy the
+                        // DataFrame's unique-name restriction for parallel scalar UDFs.
+                        result = result.Clone();
+                        string name = "Result" + i;
+                        while (!names.Add(name))
+                        {
+                            name += "_";
+                        }
+                        result.SetName(name);
+                    }
+                    results[i] = result;
+                }
+
+                foreach (RecordBatch batch in new FxDataFrame(results).ToArrowRecordBatches())
+                {
+                    try
+                    {
+                        IArrowArray[] arrays = batch.Arrays.ToArray();
+                        if (arrays.Length != results.Length || arrays.Any(a => a.Length != batch.Length))
+                        {
+                            throw new InvalidDataException("Invalid Spark 4 DataFrame Arrow conversion.");
+                        }
+                        output.Write(new RecordBatch(ScalarSchema(arrays), arrays, batch.Length));
+                        stat.NumEntriesProcessed += batch.Length;
+                    }
+                    finally
+                    {
+                        DisposeQuietly(batch);
+                    }
+                }
+            }
+        }
+
+        private static void ValidateScalarLength(long? actual, int expected)
+        {
+            if (actual != expected)
+            {
+                throw new InvalidDataException(
+                    $"Spark 4 scalar Arrow UDF returned {actual?.ToString() ?? "null"} rows; expected {expected}.");
+            }
+        }
+
+        private static Schema ScalarSchema(IArrowArray[] arrays)
+        {
+            return new Schema(arrays.Select((array, i) =>
+                new Field("Result" + i, array.Data.DataType, nullable: true)), null);
+        }
+
+        private static void ExecuteGroup(
+            RecordBatch input,
+            SqlCommand command,
+            ArrowOutput output,
+            CommandExecutorStat stat)
+        {
+            // This is a borrowed view. Input owns its buffers until all group results are sent.
+            var projected = new RecordBatch(
+                new Schema(command.ArgOffsets.Select(input.Schema.GetFieldByIndex), input.Schema.Metadata),
+                command.ArgOffsets.Select(input.Column),
+                input.Length);
+
+            if (command.WorkerFunction is ArrowGroupedMapWorkerFunction arrow)
+            {
+                RecordBatch result = null;
+                try
+                {
+                    result = arrow.Func(projected);
+                    WriteGroupResult(result, command, output, stat);
+                }
+                finally
+                {
+                    if (result != null && !ReferenceEquals(result, input) &&
+                        !ReferenceEquals(result, projected))
+                    {
+                        DisposeQuietly(result);
+                    }
+                }
+            }
+            else
+            {
+                FxDataFrame dataFrame = FxDataFrame.FromArrowRecordBatch(projected);
+                if (projected.ColumnCount == 0)
+                {
+                    // FromArrowRecordBatch infers row count from columns. Preserve real
+                    // rows in a zero-value-column group using the public row append API.
+                    for (int i = 0; i < projected.Length; ++i)
+                    {
+                        dataFrame.Append(System.Array.Empty<object>(), inPlace: true);
+                    }
+                }
+                FxDataFrame result = ((DataFrameGroupedMapWorkerFunction)command.WorkerFunction)
+                    .Func(dataFrame);
+                if (result is null)
+                {
+                    throw new InvalidDataException("Spark 4 grouped-map UDF returned null.");
+                }
+                foreach (RecordBatch batch in result.ToArrowRecordBatches())
+                {
+                    try
+                    {
+                        WriteGroupResult(batch, command, output, stat);
+                    }
+                    finally
+                    {
+                        DisposeQuietly(batch);
+                    }
+                }
+            }
+        }
+
+        private static void WriteGroupResult(
+            RecordBatch result,
+            SqlCommand command,
+            ArrowOutput output,
+            CommandExecutorStat stat)
+        {
+            ArrowOutputValidator.Validate(result, command.ReturnSchema);
+            IReadOnlyList<Field> fields = result.Schema.FieldsList;
+            if (command.WorkerFunction is DataFrameGroupedMapWorkerFunction)
+            {
+                // DataFrame derives nullable metadata from each group's actual NullCount.
+                // Emit the stable Apply declaration after validating those actual nulls;
+                // user-provided Arrow schemas still undergo strict stability checks.
+                fields = fields.Select((field, i) => new Field(
+                    field.Name, field.DataType, command.ReturnSchema.Fields[i].IsNullable,
+                    field.Metadata)).ToArray();
+            }
+            var structType = new StructType(fields);
+            var array = new StructArray(
+                structType,
+                result.Length,
+                result.Arrays.Cast<Apache.Arrow.Array>(),
+                ArrowBuffer.Empty);
+            var schema = new Schema(new[] { new Field("Struct", structType, false) }, null);
+            output.Write(new RecordBatch(schema, new[] { array }, result.Length));
+            stat.NumEntriesProcessed += result.Length;
+        }
+
+        private static void DisposeResultArrays(IArrowArray[] results, RecordBatch input)
+        {
+            var seen = new HashSet<IArrowArray>(input.Arrays);
+            foreach (IArrowArray result in results)
+            {
+                if (result != null && seen.Add(result))
+                {
+                    DisposeQuietly(result);
+                }
+            }
+        }
+
+        private static void DisposeQuietly(IDisposable disposable)
+        {
+            try
+            {
+                disposable?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                s_logger.LogWarn($"Arrow cleanup failed: {exception.GetType().Name}.");
+            }
+        }
+
+        private sealed class ArrowOutput : IDisposable
+        {
+            private enum OutputState { NotStarted, Writing, Ended, WriteFailed }
+
+            private readonly Stream _stream;
+            private OutputState _state;
+            private ArrowStreamWriter _writer;
+            private Schema _schema;
+
+            internal ArrowOutput(Stream stream)
+            {
+                _stream = stream;
+            }
+
+            internal bool HasFailed => _state == OutputState.WriteFailed;
+
+            internal void Write(RecordBatch batch)
+            {
+                if (_schema != null)
+                {
+                    ArrowOutputValidator.ValidateSchema(_schema, batch.Schema);
+                }
+                else
+                {
+                    _schema = batch.Schema;
+                    _writer = new ArrowStreamWriter(
+                        _stream, _schema, leaveOpen: true,
+                        new IpcOptions { WriteLegacyIpcFormat = false });
+                }
+
+                try
+                {
+                    if (_state == OutputState.NotStarted)
+                    {
+                        SerDe.Write(_stream, (int)SpecialLengths.START_ARROW_STREAM);
+                        _state = OutputState.Writing;
+                    }
+                    _writer.WriteRecordBatch(batch);
+                }
+                catch
+                {
+                    _state = OutputState.WriteFailed;
+                    throw;
+                }
+            }
+
+            internal void End()
+            {
+                if (_state != OutputState.Writing)
+                {
+                    return;
+                }
+                try
+                {
+                    _writer.WriteEnd();
+                    _stream.Flush();
+                    _state = OutputState.Ended;
+                }
+                catch
+                {
+                    _state = OutputState.WriteFailed;
+                    throw;
+                }
+            }
+
+            public void Dispose() => _writer?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The output may contain a partial Arrow message; only closing the connection is safe.
+    /// </summary>
+    internal sealed class ArrowStreamWriteException : IOException
+    {
+        internal ArrowStreamWriteException(Exception primaryException)
+            : base("Spark 4 Arrow output is incomplete; the worker connection cannot be reused.", primaryException)
+        {
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark.Worker/Command/SqlCommandExecutor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Command/SqlCommandExecutor.cs
@@ -62,11 +62,15 @@ namespace Microsoft.Spark.Worker.Command
             }
             else if (evalType == UdfUtils.PythonEvalType.SQL_SCALAR_PANDAS_UDF)
             {
-                executor = new ArrowOrDataFrameSqlCommandExecutor(version);
+                executor = (version.Major, version.Minor) == (4, 0) ?
+                    new Spark40ArrowCommandExecutor(groupedMap: false) :
+                    (SqlCommandExecutor)new ArrowOrDataFrameSqlCommandExecutor(version);
             }
             else if (evalType == UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
             {
-                executor = new ArrowOrDataFrameGroupedMapCommandExecutor(version);
+                executor = (version.Major, version.Minor) == (4, 0) ?
+                    new Spark40ArrowCommandExecutor(groupedMap: true) :
+                    (SqlCommandExecutor)new ArrowOrDataFrameGroupedMapCommandExecutor(version);
             }
             else
             {

--- a/src/csharp/Microsoft.Spark.Worker/Payload.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Payload.cs
@@ -58,6 +58,12 @@ namespace Microsoft.Spark.Worker
     {
         internal int[] ArgOffsets { get; set; }
 
+        internal int[] GroupingKeyOffsets { get; set; }
+
+        internal Sql.Types.StructType ReturnSchema { get; set; }
+
+        internal IReadOnlyDictionary<string, string> ArrowConfiguration { get; set; }
+
         // Note that WorkerFunction will be chained, and this will
         // be used only for the logging purpose.
         internal int NumChainedFunctions { get; set; }

--- a/src/csharp/Microsoft.Spark.Worker/Processor/CommandProcessor.cs
+++ b/src/csharp/Microsoft.Spark.Worker/Processor/CommandProcessor.cs
@@ -4,9 +4,12 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 using Microsoft.Spark.Utils;
 using static Microsoft.Spark.Utils.UdfUtils;
 
@@ -82,7 +85,9 @@ namespace Microsoft.Spark.Worker.Processor
 
             int rawEvalType = BinaryPrimitives.ReadInt32BigEndian(buffer);
             if (rawEvalType == (int)PythonEvalType.NON_UDF ||
-                rawEvalType == (int)PythonEvalType.SQL_BATCHED_UDF)
+                rawEvalType == (int)PythonEvalType.SQL_BATCHED_UDF ||
+                rawEvalType == (int)PythonEvalType.SQL_SCALAR_PANDAS_UDF ||
+                rawEvalType == (int)PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
             {
                 return (PythonEvalType)rawEvalType;
             }
@@ -179,13 +184,11 @@ namespace Microsoft.Spark.Worker.Processor
             PythonEvalType evalType,
             Stream stream)
         {
-            if (evalType != PythonEvalType.SQL_BATCHED_UDF)
-            {
-                throw new NotSupportedException(
-                    $"Spark 4 evaluation type {evalType} is not supported.");
-            }
-
             var reader = new ProtocolReader(stream);
+            bool isArrow = evalType != PythonEvalType.SQL_BATCHED_UDF;
+            bool grouped = evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF;
+            IReadOnlyDictionary<string, string> configuration = isArrow ?
+                ReadSpark40ArrowConfiguration(reader) : null;
             bool isProfiling = reader.ReadBoolean("Spark 4 profiling flag");
             if (isProfiling)
             {
@@ -200,7 +203,7 @@ namespace Microsoft.Spark.Worker.Processor
             }
 
             int numUdfs = reader.ReadInt32("Spark 4 UDF count");
-            ValidateRange(numUdfs, 1, MaxSpark40Udfs, "Spark 4 UDF count");
+            ValidateRange(numUdfs, 1, grouped ? 1 : MaxSpark40Udfs, "Spark 4 UDF count");
 
             var frames = new Spark40UdfFrame[numUdfs];
             bool hasNamedArguments = false;
@@ -214,8 +217,8 @@ namespace Microsoft.Spark.Worker.Processor
                 int numArguments = reader.ReadInt32("Spark 4 UDF argument count");
                 ValidateRange(
                     numArguments,
-                    0,
-                    MaxSpark40ArgumentsPerUdf,
+                    grouped ? 2 : (isArrow ? 1 : 0),
+                    grouped ? MaxSpark40Arguments : MaxSpark40ArgumentsPerUdf,
                     "Spark 4 UDF argument count");
                 totalArguments = AddWithLimit(
                     totalArguments,
@@ -227,18 +230,23 @@ namespace Microsoft.Spark.Worker.Processor
                 for (int argIndex = 0; argIndex < numArguments; ++argIndex)
                 {
                     int offset = reader.ReadInt32("Spark 4 UDF argument offset");
-                    if (offset < 0 || offset > nextOffset)
+                    if (offset < 0 || (!grouped && offset > nextOffset))
                     {
                         throw new InvalidDataException(
                             "Invalid Spark 4 UDF argument offset.");
                     }
 
-                    if (offset == nextOffset)
+                    if (!grouped && offset == nextOffset)
                     {
                         ++nextOffset;
                     }
 
                     argOffsets[argIndex] = offset;
+
+                    if (grouped)
+                    {
+                        continue;
+                    }
 
                     bool hasName = reader.ReadBoolean(
                         "Spark 4 named argument flag");
@@ -252,12 +260,29 @@ namespace Microsoft.Spark.Worker.Processor
                     }
                 }
 
+                int[] groupingKeyOffsets = null;
+                if (grouped)
+                {
+                    int metadataLength = argOffsets[0];
+                    int keyCount = argOffsets[1];
+                    if (metadataLength != numArguments - 1 || keyCount > numArguments - 2)
+                    {
+                        throw new InvalidDataException("Invalid Spark 4 grouped-map offsets.");
+                    }
+
+                    groupingKeyOffsets = new int[keyCount];
+                    Array.Copy(argOffsets, 2, groupingKeyOffsets, 0, keyCount);
+                    var values = new int[numArguments - 2 - keyCount];
+                    Array.Copy(argOffsets, 2 + keyCount, values, 0, values.Length);
+                    argOffsets = values;
+                }
+
                 int numChainedFunctions = reader.ReadInt32(
                     "Spark 4 chained function count");
                 ValidateRange(
                     numChainedFunctions,
                     1,
-                    MaxSpark40ChainedFunctionsPerUdf,
+                    grouped ? 1 : MaxSpark40ChainedFunctionsPerUdf,
                     "Spark 4 chained function count");
                 totalChainedFunctions = AddWithLimit(
                     totalChainedFunctions,
@@ -293,7 +318,35 @@ namespace Microsoft.Spark.Worker.Processor
 
                 frames[udfIndex] = new Spark40UdfFrame(
                     argOffsets,
-                    commandBytes);
+                    commandBytes)
+                {
+                    GroupingKeyOffsets = groupingKeyOffsets
+                };
+            }
+
+            bool hasRepl = false;
+            bool mixedRepresentations = false;
+            bool? usesDataFrame = null;
+            if (isArrow)
+            {
+                // Validate every bounded command before resolving even the first
+                // user type. Malformed commands take precedence over unsupported
+                // profiling, named arguments, REPL, or Arrow configurations.
+                foreach (Spark40UdfFrame frame in frames)
+                {
+                    for (int i = 0; i < frame.CommandBytes.Length; ++i)
+                    {
+                        bool isDataFrame = CommandSerDe.PreflightSpark40Arrow(
+                            frame.CommandBytes[i], i == 0 ? frame.ArgOffsets.Length : 1,
+                            grouped, out StructType returnSchema, out bool isRepl);
+                        hasRepl |= isRepl;
+                        mixedRepresentations |= usesDataFrame.HasValue &&
+                            usesDataFrame.Value != isDataFrame;
+                        usesDataFrame = isDataFrame;
+                        frame.IsDataFrame = isDataFrame;
+                        frame.ReturnSchema = returnSchema;
+                    }
+                }
             }
 
             if (isProfiling)
@@ -308,7 +361,18 @@ namespace Microsoft.Spark.Worker.Processor
                     "Spark 4 named UDF arguments are not supported.");
             }
 
-            foreach (Spark40UdfFrame frame in frames)
+            if (hasRepl || mixedRepresentations ||
+                (configuration != null && configuration.TryGetValue(
+                    "spark.sql.execution.arrow.useLargeVarTypes", out string largeTypes) &&
+                    bool.Parse(largeTypes)))
+            {
+                throw new NotSupportedException(hasRepl ?
+                    "Spark 4 REPL commands are not supported." : mixedRepresentations ?
+                    "Spark 4 cannot mix Arrow and DataFrame UDF representations." :
+                    "Spark 4 Arrow large variable-width types are not supported.");
+            }
+
+            foreach (Spark40UdfFrame frame in isArrow ? Array.Empty<Spark40UdfFrame>() : frames)
             {
                 for (int functionIndex = 0;
                     functionIndex < frame.CommandBytes.Length;
@@ -330,6 +394,9 @@ namespace Microsoft.Spark.Worker.Processor
                 var command = new SqlCommand
                 {
                     ArgOffsets = frame.ArgOffsets,
+                    GroupingKeyOffsets = frame.GroupingKeyOffsets,
+                    ReturnSchema = frame.ReturnSchema,
+                    ArrowConfiguration = configuration,
                     NumChainedFunctions = frame.CommandBytes.Length
                 };
 
@@ -340,6 +407,25 @@ namespace Microsoft.Spark.Worker.Processor
                     int expectedArity = functionIndex == 0 ?
                         frame.ArgOffsets.Length :
                         1;
+                    if (isArrow)
+                    {
+                        WorkerFunction function = DeserializeSpark40ArrowFunction(
+                            frame.CommandBytes[functionIndex], expectedArity, grouped,
+                            frame.IsDataFrame, out CommandSerDe.SerializedMode arrowSerializer,
+                            out CommandSerDe.SerializedMode arrowDeserializer);
+                        command.WorkerFunction = command.WorkerFunction == null ? function :
+                            frame.IsDataFrame ?
+                            DataFrameWorkerFunction.Chain(
+                                (DataFrameWorkerFunction)command.WorkerFunction,
+                                (DataFrameWorkerFunction)function) :
+                            ArrowWorkerFunction.Chain(
+                                (ArrowWorkerFunction)command.WorkerFunction,
+                                (ArrowWorkerFunction)function);
+                        command.SerializerMode = arrowSerializer;
+                        command.DeserializerMode = arrowDeserializer;
+                        continue;
+                    }
+
                     var currentWorkerFunction = new PicklingWorkerFunction(
                         CommandSerDe.DeserializeSpark40<
                             PicklingWorkerFunction.ExecuteDelegate>(
@@ -361,6 +447,64 @@ namespace Microsoft.Spark.Worker.Processor
             }
 
             return commands;
+        }
+
+        private static IReadOnlyDictionary<string, string> ReadSpark40ArrowConfiguration(
+            ProtocolReader reader)
+        {
+            int count = reader.ReadInt32("Spark 4 Arrow configuration count");
+            ValidateRange(count, 0, 64, "Spark 4 Arrow configuration count");
+            var configuration = new Dictionary<string, string>(StringComparer.Ordinal);
+            int totalBytes = 0;
+            for (int i = 0; i < count; ++i)
+            {
+                string key = reader.ReadUtf8("Spark 4 Arrow configuration key", 1, 256);
+                string value = reader.ReadUtf8("Spark 4 Arrow configuration value", 0, 4096);
+                totalBytes = AddWithLimit(totalBytes,
+                    Encoding.UTF8.GetByteCount(key) + Encoding.UTF8.GetByteCount(value),
+                    256 * 1024, "Spark 4 Arrow configuration bytes");
+                if (configuration.ContainsKey(key))
+                {
+                    throw new InvalidDataException("Duplicate Spark 4 Arrow configuration key.");
+                }
+
+                if ((key == "spark.sql.execution.arrow.useLargeVarTypes" ||
+                    key == "spark.sql.execution.pandas.convertToArrowArraySafely" ||
+                    key == "spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName") &&
+                    !bool.TryParse(value, out _))
+                {
+                    throw new InvalidDataException("Invalid Spark 4 Arrow boolean configuration.");
+                }
+
+                configuration.Add(key, value);
+            }
+
+            return configuration;
+        }
+
+        private static WorkerFunction DeserializeSpark40ArrowFunction(
+            byte[] bytes, int arity, bool grouped, bool dataFrame,
+            out CommandSerDe.SerializedMode serializer,
+            out CommandSerDe.SerializedMode deserializer)
+        {
+            if (grouped)
+            {
+                return dataFrame ?
+                    new DataFrameGroupedMapWorkerFunction(
+                        CommandSerDe.DeserializeSpark40Arrow<DataFrameGroupedMapWorkerFunction.ExecuteDelegate>(
+                            bytes, arity, true, out serializer, out deserializer)) :
+                    new ArrowGroupedMapWorkerFunction(
+                        CommandSerDe.DeserializeSpark40Arrow<ArrowGroupedMapWorkerFunction.ExecuteDelegate>(
+                            bytes, arity, true, out serializer, out deserializer));
+            }
+
+            return dataFrame ?
+                new DataFrameWorkerFunction(
+                    CommandSerDe.DeserializeSpark40Arrow<DataFrameWorkerFunction.ExecuteDelegate>(
+                        bytes, arity, false, out serializer, out deserializer)) :
+                new ArrowWorkerFunction(
+                    CommandSerDe.DeserializeSpark40Arrow<ArrowWorkerFunction.ExecuteDelegate>(
+                        bytes, arity, false, out serializer, out deserializer));
         }
 
         private static void ValidateRange(
@@ -410,6 +554,12 @@ namespace Microsoft.Spark.Worker.Processor
             internal int[] ArgOffsets { get; }
 
             internal byte[][] CommandBytes { get; }
+
+            internal int[] GroupingKeyOffsets { get; set; }
+
+            internal StructType ReturnSchema { get; set; }
+
+            internal bool IsDataFrame { get; set; }
         }
 
         /// <summary>

--- a/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
+++ b/src/csharp/Microsoft.Spark.Worker/TaskRunner.cs
@@ -195,6 +195,13 @@ namespace Microsoft.Spark.Worker
             {
                 s_logger.LogError($"[{TaskId}] ProcessStream() failed with exception: {e}");
 
+                if (e is ArrowStreamWriteException)
+                {
+                    // A partially written IPC message cannot be followed by a Spark control
+                    // frame. Run() closes this socket and never reuses the failed attempt.
+                    throw;
+                }
+
                 try
                 {
                     SerDe.Write(outputStream, (int)SpecialLengths.PYTHON_EXCEPTION_THROWN);

--- a/src/csharp/Microsoft.Spark/Sql/RelationalGroupedDataset.cs
+++ b/src/csharp/Microsoft.Spark/Sql/RelationalGroupedDataset.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Apache.Arrow;
+using Microsoft.Spark.Interop;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql.Expressions;
 using Microsoft.Spark.Sql.Types;
@@ -143,18 +144,22 @@ namespace Microsoft.Spark.Sql
         /// <returns>New DataFrame object with the UDF applied.</returns>
         public DataFrame Apply(StructType returnType, Func<FxDataFrame, FxDataFrame> func)
         {
+            Version version = SparkEnvironment.SparkVersion;
+            bool isSpark40 = (version.Major, version.Minor) == (4, 0);
+            string returnTypeJson = returnType.Json;
             DataFrameGroupedMapWorkerFunction.ExecuteDelegate wrapper =
                 new DataFrameGroupedMapUdfWrapper(func).Execute;
 
             var udf = UserDefinedFunction.Create(
                 Reference.Jvm,
                 func.Method.ToString(),
+                isSpark40 ? CommandSerDe.SerializeSpark40GroupedMap(wrapper, returnTypeJson) :
                 CommandSerDe.Serialize(
                     wrapper,
                     CommandSerDe.SerializedMode.Row,
                     CommandSerDe.SerializedMode.Row),
                 UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
-                returnType.Json);
+                returnTypeJson);
 
             IReadOnlyList<string> columnNames = _dataFrame.Columns();
             var columns = new Column[columnNames.Count];
@@ -165,9 +170,7 @@ namespace Microsoft.Spark.Sql
 
             Column udfColumn = udf.Apply(columns);
 
-            return new DataFrame((JvmObjectReference)Reference.Invoke(
-                "flatMapGroupsInPandas",
-                udfColumn.Expr()));
+            return ApplyGroupedMap(udfColumn, version);
         }
 
         /// <summary>
@@ -189,18 +192,22 @@ namespace Microsoft.Spark.Sql
         /// <returns>New DataFrame object with the UDF applied.</returns>
         public DataFrame Apply(StructType returnType, Func<RecordBatch, RecordBatch> func)
         {
+            Version version = SparkEnvironment.SparkVersion;
+            bool isSpark40 = (version.Major, version.Minor) == (4, 0);
+            string returnTypeJson = returnType.Json;
             ArrowGroupedMapWorkerFunction.ExecuteDelegate wrapper =
                 new ArrowGroupedMapUdfWrapper(func).Execute;
 
             UserDefinedFunction udf = UserDefinedFunction.Create(
                 Reference.Jvm,
                 func.Method.ToString(),
+                isSpark40 ? CommandSerDe.SerializeSpark40GroupedMap(wrapper, returnTypeJson) :
                 CommandSerDe.Serialize(
                     wrapper,
                     CommandSerDe.SerializedMode.Row,
                     CommandSerDe.SerializedMode.Row),
                 UdfUtils.PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
-                returnType.Json);
+                returnTypeJson);
 
             IReadOnlyList<string> columnNames = _dataFrame.Columns();
             var columns = new Column[columnNames.Count];
@@ -211,9 +218,14 @@ namespace Microsoft.Spark.Sql
 
             Column udfColumn = udf.Apply(columns);
 
+            return ApplyGroupedMap(udfColumn, version);
+        }
+
+        internal DataFrame ApplyGroupedMap(Column udfColumn, Version version)
+        {
             return new DataFrame((JvmObjectReference)Reference.Invoke(
                 "flatMapGroupsInPandas",
-                udfColumn.Expr()));
+                (version.Major, version.Minor) == (4, 0) ? (object)udfColumn : udfColumn.Expr()));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
+++ b/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs
@@ -14,6 +14,9 @@ using System.Text;
 using MessagePack;
 using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Spark.Utils
 {
@@ -41,6 +44,7 @@ namespace Microsoft.Spark.Utils
         private const sbyte TypelessExtensionCode = 100;
         private const int MaxSpark40TypeNameBytes = 4096;
         private const int MaxSpark40MessagePackDepth = 500;
+        private const int MaxSpark40SchemaBytes = 1024 * 1024;
 
         private static readonly UTF8Encoding s_strictUtf8 =
             new UTF8Encoding(false, true);
@@ -185,6 +189,54 @@ namespace Microsoft.Spark.Utils
         internal static void PreflightSpark40(byte[] command, int expectedArity)
         {
             ArraySegment<byte> serializedUdf = ParseSpark40Envelope(command);
+            ValidateSpark40WrapperArityName(
+                ReadSpark40WrapperName(serializedUdf), expectedArity);
+        }
+
+        // Only the new Spark 4 grouped-map format carries this private tail. The
+        // inner serialized-UDF length still describes MessagePack bytes alone.
+        internal static byte[] SerializeSpark40GroupedMap(Delegate func, StructType returnType)
+        {
+            if (returnType == null)
+            {
+                throw new ArgumentNullException(nameof(returnType));
+            }
+
+            return SerializeSpark40GroupedMap(func, returnType.Json);
+        }
+
+        internal static byte[] SerializeSpark40GroupedMap(Delegate func, string returnTypeJson)
+        {
+            byte[] command = Serialize(func, SerializedMode.Row, SerializedMode.Row);
+            byte[] schema = s_strictUtf8.GetBytes(returnTypeJson);
+            if (schema.Length == 0 || schema.Length > MaxSpark40SchemaBytes)
+            {
+                throw new InvalidDataException("Invalid Spark 4 grouped-map schema length.");
+            }
+
+            using var stream = new MemoryStream();
+            stream.Write(command, 0, command.Length);
+            SerDe.Write(stream, schema.Length);
+            stream.Write(schema, 0, schema.Length);
+            return stream.ToArray();
+        }
+
+        internal static bool PreflightSpark40Arrow(
+            byte[] command,
+            int expectedArity,
+            bool grouped,
+            out StructType returnSchema,
+            out bool isRepl)
+        {
+            ArraySegment<byte> serializedUdf = ParseSpark40ArrowEnvelope(
+                command, grouped, out returnSchema, out isRepl);
+            return ValidateSpark40ArrowWrapperName(
+                ReadSpark40WrapperName(serializedUdf, singleUdf: true), expectedArity, grouped);
+        }
+
+        private static string ReadSpark40WrapperName(
+            ArraySegment<byte> serializedUdf, bool singleUdf = false)
+        {
             try
             {
                 var reader = new MessagePackReader(
@@ -194,16 +246,15 @@ namespace Microsoft.Spark.Utils
                         serializedUdf.Count));
                 string rootTypeName = ReadSpark40RootTypelessExtension(
                     ref reader,
-                    out string wrapperTypeName);
+                    out string wrapperTypeName,
+                    singleUdf);
                 if (!reader.End || !IsExpectedSpark40RootTypeName(rootTypeName))
                 {
                     throw new InvalidDataException(
                         "Invalid Spark 4 serialized UDF root.");
                 }
 
-                ValidateSpark40WrapperArityName(
-                    wrapperTypeName,
-                    expectedArity);
+                return wrapperTypeName;
             }
             catch (InvalidDataException)
             {
@@ -228,6 +279,38 @@ namespace Microsoft.Spark.Utils
             out SerializedMode deserializerMode) where T : Delegate
         {
             ArraySegment<byte> serializedUdf = ParseSpark40Envelope(command);
+            return DeserializeSpark40Udf<T>(
+                serializedUdf, expectedArity, false, false,
+                out serializerMode, out deserializerMode);
+        }
+
+        internal static T DeserializeSpark40Arrow<T>(
+            byte[] command,
+            int expectedArity,
+            bool grouped,
+            out SerializedMode serializerMode,
+            out SerializedMode deserializerMode) where T : Delegate
+        {
+            ArraySegment<byte> serializedUdf = ParseSpark40ArrowEnvelope(
+                command, grouped, out _, out bool isRepl);
+            if (isRepl)
+            {
+                throw new NotSupportedException("Spark 4 REPL commands are not supported.");
+            }
+
+            return DeserializeSpark40Udf<T>(
+                serializedUdf, expectedArity, true, grouped,
+                out serializerMode, out deserializerMode);
+        }
+
+        private static T DeserializeSpark40Udf<T>(
+            ArraySegment<byte> serializedUdf,
+            int expectedArity,
+            bool arrow,
+            bool grouped,
+            out SerializedMode serializerMode,
+            out SerializedMode deserializerMode) where T : Delegate
+        {
             UdfWrapperData udfWrapperData;
             try
             {
@@ -257,7 +340,23 @@ namespace Microsoft.Spark.Utils
                     ex);
             }
 
-            ValidateSpark40WrapperArity(udfWrapperData, expectedArity);
+            if (arrow)
+            {
+                if (udfWrapperData?.UdfWrapperNodes?.Length != 1 ||
+                    udfWrapperData.Udfs?.Length != 1 ||
+                    udfWrapperData.UdfWrapperNodes[0].NumChildren != 1 ||
+                    !udfWrapperData.UdfWrapperNodes[0].HasUdf)
+                {
+                    throw new InvalidDataException("Invalid Spark 4 Arrow UDF wrapper data.");
+                }
+
+                ValidateSpark40ArrowWrapperName(
+                    udfWrapperData.UdfWrapperNodes[0].TypeName, expectedArity, grouped);
+            }
+            else
+            {
+                ValidateSpark40WrapperArity(udfWrapperData, expectedArity);
+            }
 
             int nodeIndex = 0;
             int udfIndex = 0;
@@ -275,6 +374,133 @@ namespace Microsoft.Spark.Utils
             serializerMode = SerializedMode.Row;
             deserializerMode = SerializedMode.Row;
             return udf;
+        }
+
+        private static ArraySegment<byte> ParseSpark40ArrowEnvelope(
+            byte[] command,
+            bool grouped,
+            out StructType returnSchema,
+            out bool isRepl)
+        {
+            if (command == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            int offset = 0;
+            ReadExpectedAscii(command, ref offset, "Row", "serializer");
+            ReadExpectedAscii(command, ref offset, "Row", "deserializer");
+            string runMode = ReadSpark40Utf8(command, ref offset, 1, 1, "run mode");
+            isRepl = runMode == "R";
+            if (isRepl)
+            {
+                _ = ReadSpark40Utf8(command, ref offset, 1, 4096, "REPL directory");
+            }
+            else if (runMode != "N")
+            {
+                throw new InvalidDataException("Invalid Spark 4 run mode.");
+            }
+
+            int length = ReadSpark40Int32(command, ref offset);
+            if (length <= 0 || length > command.Length - offset)
+            {
+                throw new InvalidDataException("Invalid Spark 4 serialized UDF length.");
+            }
+
+            var serializedUdf = new ArraySegment<byte>(command, offset, length);
+            offset += length;
+            returnSchema = null;
+            if (grouped)
+            {
+                string json = ReadSpark40Utf8(
+                    command, ref offset, 1, MaxSpark40SchemaBytes, "grouped-map schema");
+                try
+                {
+                    using var jsonReader = new JsonTextReader(new StringReader(json))
+                    {
+                        MaxDepth = 64,
+                        DateParseHandling = DateParseHandling.None
+                    };
+                    JToken token = JToken.ReadFrom(jsonReader, new JsonLoadSettings
+                    {
+                        DuplicatePropertyNameHandling = DuplicatePropertyNameHandling.Error
+                    });
+                    if (jsonReader.Read() || token.Type != JTokenType.Object ||
+                        (string)token["type"] != "struct")
+                    {
+                        throw new InvalidDataException("Invalid Spark 4 grouped-map schema.");
+                    }
+
+                    // The general DataType parser supports UDT aliases; this new
+                    // Arrow contract deliberately does not enable those aliases.
+                    RejectSpark40UdtSchema(token);
+                    returnSchema = (StructType)DataType.ParseDataType(token);
+                }
+                catch (Exception ex) when (ex is JsonException || ex is ArgumentException ||
+                    ex is TargetInvocationException || ex is InvalidCastException ||
+                    ex is FormatException || ex is OverflowException)
+                {
+                    throw new InvalidDataException("Invalid Spark 4 grouped-map schema.", ex);
+                }
+            }
+
+            if (offset != command.Length)
+            {
+                throw new InvalidDataException("Trailing Spark 4 command data.");
+            }
+
+            return serializedUdf;
+        }
+
+        private static void RejectSpark40UdtSchema(JToken type)
+        {
+            if (!(type is JObject schema))
+            {
+                return;
+            }
+
+            switch ((string)schema["type"])
+            {
+                case "udt":
+                    throw new InvalidDataException("Spark 4 Arrow UDT schemas are not supported.");
+                case "struct":
+                    if (schema["fields"] is JArray fields)
+                    {
+                        foreach (JObject field in fields.OfType<JObject>())
+                        {
+                            RejectSpark40UdtSchema(field["type"]);
+                        }
+                    }
+                    break;
+                case "array":
+                    RejectSpark40UdtSchema(schema["elementType"]);
+                    break;
+                case "map":
+                    RejectSpark40UdtSchema(schema["keyType"]);
+                    RejectSpark40UdtSchema(schema["valueType"]);
+                    break;
+            }
+        }
+
+        private static string ReadSpark40Utf8(
+            byte[] command, ref int offset, int minimum, int maximum, string fieldName)
+        {
+            int length = ReadSpark40Int32(command, ref offset);
+            if (length < minimum || length > maximum || length > command.Length - offset)
+            {
+                throw new InvalidDataException($"Invalid Spark 4 {fieldName} length.");
+            }
+
+            try
+            {
+                string value = s_strictUtf8.GetString(command, offset, length);
+                offset += length;
+                return value;
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new InvalidDataException($"Invalid Spark 4 {fieldName} encoding.", ex);
+            }
         }
 
         private static ArraySegment<byte> ParseSpark40Envelope(byte[] command)
@@ -388,7 +614,8 @@ namespace Microsoft.Spark.Utils
 
         private static string ReadSpark40RootTypelessExtension(
             ref MessagePackReader reader,
-            out string wrapperTypeName)
+            out string wrapperTypeName,
+            bool singleUdf = false)
         {
             if (reader.NextMessagePackType != MessagePackType.Extension)
             {
@@ -407,7 +634,8 @@ namespace Microsoft.Spark.Utils
             string typeName = ReadStrictTypeName(ref extensionReader);
             wrapperTypeName = ReadSpark40RootWrapperTypeName(
                 ref extensionReader,
-                depth: 1);
+                depth: 1,
+                singleUdf);
             if (!extensionReader.End)
             {
                 throw new InvalidDataException(
@@ -419,7 +647,8 @@ namespace Microsoft.Spark.Utils
 
         private static string ReadSpark40RootWrapperTypeName(
             ref MessagePackReader reader,
-            int depth)
+            int depth,
+            bool singleUdf)
         {
             if (depth > MaxSpark40MessagePackDepth)
             {
@@ -431,6 +660,7 @@ namespace Microsoft.Spark.Utils
             {
                 int count = reader.ReadMapHeader();
                 string wrapperTypeName = null;
+                bool hasUdf = false;
                 for (int i = 0; i < count; ++i)
                 {
                     string key = ReadStrictMessagePackString(
@@ -447,12 +677,28 @@ namespace Microsoft.Spark.Utils
 
                         wrapperTypeName = ReadFirstSpark40WrapperTypeName(
                             ref reader,
-                            depth + 1);
+                            depth + 1,
+                            singleUdf);
+                    }
+                    else if (singleUdf && key == "Udfs")
+                    {
+                        if (hasUdf)
+                        {
+                            throw new InvalidDataException("Duplicate Spark 4 Arrow UDF data.");
+                        }
+
+                        ReadSingleSpark40Udf(ref reader, depth + 1);
+                        hasUdf = true;
                     }
                     else
                     {
                         ScanMessagePackValue(ref reader, depth + 1);
                     }
+                }
+
+                if (singleUdf && !hasUdf)
+                {
+                    throw new InvalidDataException("Missing Spark 4 Arrow UDF data.");
                 }
 
                 return wrapperTypeName ?? throw new InvalidDataException(
@@ -462,7 +708,7 @@ namespace Microsoft.Spark.Utils
             if (reader.NextMessagePackType == MessagePackType.Array)
             {
                 int count = reader.ReadArrayHeader();
-                if (count < 1)
+                if (count < 1 || (singleUdf && count != 2))
                 {
                     throw new InvalidDataException(
                         "Missing Spark 4 UDF wrapper data.");
@@ -470,10 +716,18 @@ namespace Microsoft.Spark.Utils
 
                 string wrapperTypeName = ReadFirstSpark40WrapperTypeName(
                     ref reader,
-                    depth + 1);
+                    depth + 1,
+                    singleUdf);
                 for (int i = 1; i < count; ++i)
                 {
-                    ScanMessagePackValue(ref reader, depth + 1);
+                    if (singleUdf)
+                    {
+                        ReadSingleSpark40Udf(ref reader, depth + 1);
+                    }
+                    else
+                    {
+                        ScanMessagePackValue(ref reader, depth + 1);
+                    }
                 }
 
                 return wrapperTypeName;
@@ -485,7 +739,8 @@ namespace Microsoft.Spark.Utils
 
         private static string ReadFirstSpark40WrapperTypeName(
             ref MessagePackReader reader,
-            int depth)
+            int depth,
+            bool singleUdf)
         {
             if (depth > MaxSpark40MessagePackDepth ||
                 reader.NextMessagePackType != MessagePackType.Array)
@@ -495,7 +750,7 @@ namespace Microsoft.Spark.Utils
             }
 
             int count = reader.ReadArrayHeader();
-            if (count < 1)
+            if (count < 1 || (singleUdf && count != 1))
             {
                 throw new InvalidDataException(
                     "Missing Spark 4 UDF wrapper.");
@@ -503,7 +758,8 @@ namespace Microsoft.Spark.Utils
 
             string wrapperTypeName = ReadSpark40WrapperNodeTypeName(
                 ref reader,
-                depth + 1);
+                depth + 1,
+                singleUdf);
             for (int i = 1; i < count; ++i)
             {
                 ScanMessagePackValue(ref reader, depth + 1);
@@ -514,7 +770,8 @@ namespace Microsoft.Spark.Utils
 
         private static string ReadSpark40WrapperNodeTypeName(
             ref MessagePackReader reader,
-            int depth)
+            int depth,
+            bool singleUdf)
         {
             if (depth > MaxSpark40MessagePackDepth ||
                 reader.NextMessagePackType != MessagePackType.Map)
@@ -525,6 +782,8 @@ namespace Microsoft.Spark.Utils
 
             int count = reader.ReadMapHeader();
             string typeName = null;
+            bool hasChildCount = false;
+            bool hasUdf = false;
             for (int i = 0; i < count; ++i)
             {
                 string key = ReadStrictMessagePackString(
@@ -544,14 +803,50 @@ namespace Microsoft.Spark.Utils
                         MaxSpark40TypeNameBytes,
                         "Spark 4 UDF wrapper type");
                 }
+                else if (singleUdf && key == "NumChildren")
+                {
+                    if (hasChildCount || reader.NextMessagePackType != MessagePackType.Integer ||
+                        reader.ReadInt32() != 1)
+                    {
+                        throw new InvalidDataException("Invalid Spark 4 Arrow wrapper children.");
+                    }
+
+                    hasChildCount = true;
+                }
+                else if (singleUdf && key == "HasUdf")
+                {
+                    if (hasUdf || reader.NextMessagePackType != MessagePackType.Boolean ||
+                        !reader.ReadBoolean())
+                    {
+                        throw new InvalidDataException("Invalid Spark 4 Arrow wrapper delegate.");
+                    }
+
+                    hasUdf = true;
+                }
                 else
                 {
                     ScanMessagePackValue(ref reader, depth + 1);
                 }
             }
 
+            if (singleUdf && (!hasChildCount || !hasUdf))
+            {
+                throw new InvalidDataException("Missing Spark 4 Arrow wrapper metadata.");
+            }
+
             return typeName ?? throw new InvalidDataException(
                 "Missing Spark 4 UDF wrapper type.");
+        }
+
+        private static void ReadSingleSpark40Udf(ref MessagePackReader reader, int depth)
+        {
+            if (reader.NextMessagePackType != MessagePackType.Array ||
+                reader.ReadArrayHeader() != 1)
+            {
+                throw new InvalidDataException("Invalid Spark 4 Arrow UDF count.");
+            }
+
+            ScanMessagePackValue(ref reader, depth + 1);
         }
 
         private static void ScanMessagePackValue(
@@ -648,18 +943,19 @@ namespace Microsoft.Spark.Utils
 
         private static void ValidateSpark40WrapperArityName(
             string wrapperTypeName,
-            int expectedArity)
+            int expectedArity,
+            string prefix = "Microsoft.Spark.Sql.PicklingUdfWrapper`",
+            int minimumArity = 0)
         {
-            const string Prefix = "Microsoft.Spark.Sql.PicklingUdfWrapper`";
-            if (expectedArity < 0 || expectedArity > 10 ||
+            if (expectedArity < minimumArity || expectedArity > 10 ||
                 wrapperTypeName == null ||
-                !wrapperTypeName.StartsWith(Prefix, StringComparison.Ordinal))
+                !wrapperTypeName.StartsWith(prefix, StringComparison.Ordinal))
             {
                 throw new InvalidDataException(
                     "Invalid Spark 4 UDF wrapper arity.");
             }
 
-            int position = Prefix.Length;
+            int position = prefix.Length;
             int genericArity = 0;
             int genericArityDigits = 0;
             while (position < wrapperTypeName.Length &&
@@ -737,6 +1033,37 @@ namespace Microsoft.Spark.Utils
                 throw new InvalidDataException(
                     "Invalid Spark 4 UDF wrapper type.");
             }
+        }
+
+        private static bool ValidateSpark40ArrowWrapperName(
+            string wrapperTypeName, int expectedArity, bool grouped)
+        {
+            if (grouped)
+            {
+                foreach (Type type in new[]
+                {
+                    typeof(ArrowGroupedMapUdfWrapper), typeof(DataFrameGroupedMapUdfWrapper)
+                })
+                {
+                    if (wrapperTypeName == type.FullName ||
+                        wrapperTypeName == type.AssemblyQualifiedName ||
+                        wrapperTypeName == $"{type.FullName}, {type.Assembly.GetName().Name}")
+                    {
+                        return type == typeof(DataFrameGroupedMapUdfWrapper);
+                    }
+                }
+
+                throw new InvalidDataException("Invalid Spark 4 grouped-map UDF wrapper.");
+            }
+
+            const string ArrowPrefix = "Microsoft.Spark.Sql.ArrowUdfWrapper`";
+            const string DataFramePrefix = "Microsoft.Spark.Sql.DataFrameUdfWrapper`";
+            bool isDataFrame = wrapperTypeName != null &&
+                wrapperTypeName.StartsWith(DataFramePrefix, StringComparison.Ordinal);
+            ValidateSpark40WrapperArityName(
+                wrapperTypeName, expectedArity,
+                isDataFrame ? DataFramePrefix : ArrowPrefix, minimumArity: 1);
+            return isDataFrame;
         }
 
         private static bool IsExpectedSpark40RootTypeName(string typeName)


### PR DESCRIPTION
## Summary

Add Spark 4.0.x support for scalar Arrow UDFs (eval type 200) and grouped-map UDFs (eval type 201), using both Apache Arrow and Microsoft.Data.Analysis representations.

## Changes

- Add Spark 4-specific command parsing and execution for the two supported eval types.
- Pass the declared grouped-map schema consistently to the JVM and .NET Worker.
- Validate output shape, schema, types, and nullability before returning results.
- Handle Arrow stream completion and failures without appending protocol frames to partially written output.
- Preserve existing Spark 2.x/3.x routing and command formats.
- Add unit and E2E coverage, and include the ArrowUdf category in Spark 4.0.0–4.0.4 CI lanes on Windows and Linux.

## Validation

- Managed unit tests: 225 passed.
- Worker unit tests: 243 passed; one Linux-only test skipped on Windows.
- Worker builds: net472, net48, and net8.0 succeeded with no warnings or errors.
- Local Spark 4.0.4 E2E on Windows and Linux: 23 passed per platform, covering Arrow UDFs and existing compatibility cases.
- Local official Apache Spark 3.5.3 Arrow regression tests on Windows and Linux: 6 passed per platform; 8 Spark 4-only tests skipped.

