### PR TITLE
Add Spark 4.0 Avro support

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -226,7 +226,7 @@ extends:
             - ${{ each pool in parameters.listOfE2ETestsPoolTypes }}:
               - pool: ${{ pool }}
                 ${{ if startsWith(version, '4.0.') }}:
-                  testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf"'
+                  testOptions: '--filter "Category=Spark40Compatibility|Category=DataFrameRowRetrieval|Category=Broadcast|Category=ArrowUdf|Category=Avro"'
                 ${{ else }}:
                   testOptions: ""
                 backwardCompatibleTestOptions: $(backwardCompatibleTestOptions_${{ pool }}_${{ split(version, '.')[0] }}_${{ split(version, '.')[1] }})

--- a/src/csharp/Microsoft.Spark.E2ETest/IpcTests/AvroFunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.E2ETest/IpcTests/AvroFunctionsTests.cs
@@ -2,15 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Spark.E2ETest.Utils;
 using Microsoft.Spark.Sql;
+using Microsoft.Spark.Sql.Types;
 using Xunit;
 using static Microsoft.Spark.Sql.Avro.Functions;
 
 namespace Microsoft.Spark.E2ETest.IpcTests
 {
     [Collection("Spark E2E Tests")]
+    [Trait("Category", "Avro")]
     public class AvroFunctionsTests
     {
         private readonly SparkSession _spark;
@@ -47,6 +51,172 @@ namespace Microsoft.Spark.E2ETest.IpcTests
             Column inputCol = df.Col("id");
             Column avroCol = ToAvro(inputCol, jsonSchema);
             Assert.IsType<Column>(FromAvro(avroCol, jsonSchema, options));
+        }
+
+        [Fact]
+        public void RoundTripPreservesValuesAndSchema()
+        {
+            const string schema = "\"long\"";
+            DataFrame input = _spark.Range(4);
+            DataFrame encoded = input.Select(
+                ToAvro(input["id"]).Alias("inferred"),
+                ToAvro(input["id"], schema).Alias("explicit"));
+
+            Assert.All(encoded.Schema().Fields,
+                field => Assert.IsType<BinaryType>(field.DataType));
+            Row[] encodedRows = encoded.Collect().ToArray();
+            Assert.Equal(4, encodedRows.Length);
+            for (int i = 0; i < encodedRows.Length; ++i)
+            {
+                // Avro long uses zigzag varints: 0, 1, 2, 3 encode as 00, 02, 04, 06.
+                var expected = new byte[] { (byte)(i * 2) };
+                Assert.Equal(expected, encodedRows[i].GetAs<byte[]>(0));
+                Assert.Equal(expected, encodedRows[i].GetAs<byte[]>(1));
+            }
+
+            var options = new Dictionary<string, string> { { "mode", "FAILFAST" } };
+            DataFrame decoded = encoded.Select(
+                FromAvro(encoded["inferred"], schema).Alias("inferred"),
+                FromAvro(encoded["explicit"], schema, options).Alias("explicit"));
+
+            Assert.Equal(new[] { "inferred", "explicit" },
+                decoded.Schema().Fields.Select(field => field.Name));
+            Assert.All(decoded.Schema().Fields,
+                field => Assert.IsType<LongType>(field.DataType));
+            Row[] decodedRows = decoded.Collect().ToArray();
+            Assert.Equal(new long[] { 0, 1, 2, 3 },
+                decodedRows.Select(row => row.GetAs<long>(0)));
+            Assert.Equal(new long[] { 0, 1, 2, 3 },
+                decodedRows.Select(row => row.GetAs<long>(1)));
+        }
+
+        [Fact]
+        public void NullableValuesRespectExplicitSchema()
+        {
+            const string inferredSchema = "[\"long\",\"null\"]";
+            const string explicitSchema = "\"long\"";
+            DataFrame input = _spark.Range(3).SelectExpr(
+                "case when id = 1 then cast(null as bigint) else id end as value");
+            DataFrame encoded = input.Select(
+                ToAvro(input["value"]).Alias("inferred"),
+                ToAvro(input["value"], explicitSchema).Alias("explicit"));
+
+            Row[] encodedRows = encoded.Collect().ToArray();
+            Assert.Equal(3, encodedRows.Length);
+            Assert.Equal(new byte[] { 0, 0 }, encodedRows[0].GetAs<byte[]>(0));
+            Assert.Equal(new byte[] { 0 }, encodedRows[0].GetAs<byte[]>(1));
+            Assert.Null(encodedRows[1].Get(0));
+            Assert.Null(encodedRows[1].Get(1));
+            Assert.Equal(new byte[] { 0, 4 }, encodedRows[2].GetAs<byte[]>(0));
+            Assert.Equal(new byte[] { 4 }, encodedRows[2].GetAs<byte[]>(1));
+
+            DataFrame decoded = encoded.Select(
+                FromAvro(encoded["inferred"], inferredSchema),
+                FromAvro(encoded["explicit"], explicitSchema,
+                    new Dictionary<string, string>()));
+            Assert.All(decoded.Schema().Fields,
+                field => Assert.IsType<LongType>(field.DataType));
+            Row[] decodedRows = decoded.Collect().ToArray();
+            Assert.Equal(3, decodedRows.Length);
+            for (int column = 0; column < 2; ++column)
+            {
+                Assert.Equal(0L, decodedRows[0].GetAs<long>(column));
+                Assert.Null(decodedRows[1].Get(column));
+                Assert.Equal(2L, decodedRows[2].GetAs<long>(column));
+            }
+        }
+
+        [Fact]
+        public void EmptyInputRetainsAvroSchema()
+        {
+            DataFrame input = _spark.Range(0);
+            DataFrame encoded = input.Select(ToAvro(input["id"]).Alias("value"));
+            Assert.IsType<BinaryType>(encoded.Schema().Fields[0].DataType);
+            Assert.Empty(encoded.Collect());
+
+            DataFrame decoded = encoded.Select(FromAvro(encoded["value"], "\"long\""));
+            Assert.IsType<LongType>(decoded.Schema().Fields[0].DataType);
+            Assert.Empty(decoded.Collect());
+        }
+
+        [Fact]
+        public void ReaderSchemaAddsDefaultField()
+        {
+            const string writerSchema = "{\"type\":\"record\",\"name\":\"Order\"," +
+                "\"fields\":[{\"name\":\"id\",\"type\":\"long\"}]}";
+            const string readerSchema = "{\"type\":\"record\",\"name\":\"Order\"," +
+                "\"fields\":[{\"name\":\"id\",\"type\":\"long\"}," +
+                "{\"name\":\"label\",\"type\":\"string\",\"default\":\"new\"}]}";
+            var options = new Dictionary<string, string> { { "avroSchema", readerSchema } };
+            DataFrame input = _spark.Range(2).SelectExpr("named_struct('id', id) as value");
+            DataFrame encoded = input.Select(
+                ToAvro(input["value"], writerSchema).Alias("value"));
+            DataFrame decoded = encoded.Select(
+                FromAvro(encoded["value"], writerSchema).Alias("original"),
+                FromAvro(encoded["value"], writerSchema, options).Alias("evolved"));
+
+            StructType originalSchema = Assert.IsType<StructType>(
+                decoded.Schema().Fields[0].DataType);
+            StructType evolvedSchema = Assert.IsType<StructType>(
+                decoded.Schema().Fields[1].DataType);
+            Assert.Equal("id", Assert.Single(originalSchema.Fields).Name);
+            Assert.Equal(new[] { "id", "label" },
+                evolvedSchema.Fields.Select(field => field.Name));
+            Assert.IsType<LongType>(evolvedSchema.Fields[0].DataType);
+            Assert.IsType<StringType>(evolvedSchema.Fields[1].DataType);
+
+            Row[] rows = decoded.Collect().ToArray();
+            Assert.Equal(2, rows.Length);
+            for (int i = 0; i < rows.Length; ++i)
+            {
+                Assert.Equal((long)i, rows[i].GetAs<Row>(0).GetAs<long>("id"));
+                Row evolved = rows[i].GetAs<Row>(1);
+                Assert.Equal((long)i, evolved.GetAs<long>("id"));
+                Assert.Equal("new", evolved.GetAs<string>("label"));
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void InvalidSchemaPropagatesJvmError(bool encode)
+        {
+            const string invalidSchema = "{not valid avro json";
+            DataFrame input = _spark.Range(1);
+            Exception error = Assert.ThrowsAny<Exception>(() =>
+            {
+                Column value = encode ?
+                    ToAvro(input["id"], invalidSchema) :
+                    FromAvro(ToAvro(input["id"]), invalidSchema);
+                input.Select(value).Collect().ToArray();
+            });
+
+            JvmException jvmError = Assert.IsType<JvmException>(error.InnerException);
+            Assert.Contains("SchemaParseException", jvmError.Message);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("80")]
+        public void MalformedDataHonorsDecodeMode(string hex)
+        {
+            DataFrame input = _spark.Range(1).SelectExpr($"unhex('{hex}') as value");
+            Exception error = Assert.ThrowsAny<Exception>(() =>
+                input.Select(FromAvro(input["value"], "\"int\"")).Collect().ToArray());
+            JvmException jvmError = Assert.IsType<JvmException>(error.InnerException);
+            Assert.Contains("AvroDataToCatalyst", jvmError.Message);
+            Assert.Contains("EOFException", jvmError.Message);
+            Assert.Contains("FAILFAST", jvmError.Message);
+
+            var options = new Dictionary<string, string> { { "mode", "PERMISSIVE" } };
+            DataFrame permissive = input.Select(FromAvro(input["value"], "\"int\"", options));
+            Assert.IsType<IntegerType>(permissive.Schema().Fields[0].DataType);
+            Assert.Null(Assert.Single(permissive.Collect()).Get(0));
+
+            DataFrame healthy = _spark.Range(1);
+            Row recovered = Assert.Single(healthy.Select(
+                FromAvro(ToAvro(healthy["id"]), "\"long\"")).Collect());
+            Assert.Equal(0L, recovered.GetAs<long>(0));
         }
     }
 }

--- a/src/csharp/Microsoft.Spark.UnitTest/Sql/AvroFunctionsTests.cs
+++ b/src/csharp/Microsoft.Spark.UnitTest/Sql/AvroFunctionsTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Spark.Sql.Avro;
+using Xunit;
+
+namespace Microsoft.Spark.UnitTest
+{
+    [Collection("Spark Unit Tests")]
+    public class AvroFunctionsTests
+    {
+        [Theory]
+        [InlineData("3.0.0")]
+        [InlineData("3.1.1")]
+        [InlineData("3.2.0")]
+        [InlineData("3.3.0")]
+        [InlineData("3.4.0")]
+        [InlineData("3.5.3")]
+        [InlineData("4.0.0")]
+        [InlineData("4.0.1")]
+        [InlineData("4.0.2")]
+        [InlineData("4.0.3")]
+        [InlineData("4.0.4")]
+        public void SupportedVersionsUseExistingAvroFunctions(string version)
+        {
+            Assert.Equal("org.apache.spark.sql.avro.functions",
+                Functions.GetAvroClassName(new Version(version)));
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.4.8")]
+        [InlineData("4.1.0")]
+        [InlineData("5.0.0")]
+        public void UnsupportedVersionsAreRejected(string version)
+        {
+            NotSupportedException error = Assert.Throws<NotSupportedException>(() =>
+                Functions.GetAvroClassName(new Version(version)));
+            Assert.Contains(version, error.Message);
+        }
+    }
+}

--- a/src/csharp/Microsoft.Spark/Sql/Avro/Functions.cs
+++ b/src/csharp/Microsoft.Spark/Sql/Avro/Functions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Spark.Sql.Avro
     {
         private static IJvmBridge Jvm { get; } = SparkEnvironment.JvmBridge;
         private static readonly Lazy<string> s_avroClassName =
-            new Lazy<string>(() =>
+            new Lazy<string>(() => GetAvroClassName(SparkEnvironment.SparkVersion));
+
+        internal static string GetAvroClassName(Version sparkVersion) =>
+            (sparkVersion.Major, sparkVersion.Minor) switch
             {
-                Version sparkVersion = SparkEnvironment.SparkVersion;
-                return sparkVersion.Major switch
-                {
-                    3 => "org.apache.spark.sql.avro.functions",
-                    _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
-                };
-            });
+                (3, _) => "org.apache.spark.sql.avro.functions",
+                (4, 0) => "org.apache.spark.sql.avro.functions",
+                _ => throw new NotSupportedException($"Spark {sparkVersion} not supported.")
+            };
 
         /// <summary>
         /// Converts a binary column of avro format into its corresponding catalyst value. The specified


### PR DESCRIPTION
## Summary

Enable the four existing `FromAvro` and `ToAvro` overloads on Spark 4.0.x while preserving Spark 3 behavior.

## Changes

- Add explicit Spark 4.0 version routing, reusing the existing JVM Avro functions and bridge.
- Retain unsupported-version checks without changing public APIs, Scala code, or worker protocols.
- Add version-routing unit tests and real Avro E2E coverage for:
  - Round-trip values, schemas, and independently verified encoded bytes.
  - Null values, empty input, and explicit output schemas.
  - Schema evolution through the `avroSchema` option.
  - Invalid schemas, malformed data, and FAILFAST/PERMISSIVE behavior.
- Include Avro tests in the existing Spark 4.0.0–4.0.4 Windows/Linux CI lanes. Spark 3 test coverage remains enabled.

## Validation

Local Windows validation:
- Core unit tests: 254 passed.
- Fixture tests: 30 passed.
- Avro E2E: 10 passed on Spark 3.5.3 and 10 passed on Spark 4.0.4.
- Expanded Spark 4.0.4 focused E2E suite: 48 passed, including the Avro tests.

